### PR TITLE
fix: add missing test coverage for DataIngestor (#40)

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -195,6 +195,15 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="produced only 5 usable samples"):
             ingestor.from_text_content(content)
 
+    def test_minimum_samples_threshold_exact(self, ingestor):
+        """_finalise should NOT raise ValueError if resulting dataset has exactly _MIN_SAMPLES."""
+        content = "\n\n".join([
+            f"Paragraph {i}: This is valid and exactly enough samples to pass the threshold."
+            for i in range(10)
+        ])
+        ds = ingestor.from_text_content(content)
+        assert len(ds) == 10
+
 
 # ── URL ingestion ──
 
@@ -215,6 +224,18 @@ class TestUrlIngestion:
         mock_scraper_instance.scrape.assert_called_once_with(urls, chunk_size=256)
         assert len(ds) == 15
         assert "text" in ds.column_names
+
+    @patch("nightmarenet.data.ingest.WebScraper")
+    def test_from_urls_below_threshold_raises(self, mock_scraper_class, ingestor):
+        """from_urls should raise ValueError if scraper returns < 10 samples."""
+        mock_scraper_instance = mock_scraper_class.return_value
+        from datasets import Dataset
+        mock_ds = Dataset.from_dict({"text": [f"Valid sample {i} content" for i in range(5)]})
+        mock_scraper_instance.scrape.return_value = mock_ds
+
+        urls = ["http://example.com/1"]
+        with pytest.raises(ValueError, match="produced only 5 usable samples"):
+            ingestor.from_urls(urls)
 
 
 # ── HuggingFace Hub ingestion ──

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 
@@ -183,3 +184,62 @@ class TestEdgeCases:
         ])
         ds = ingestor.from_text_content(content)
         assert len(ds) <= 15
+
+    def test_minimum_samples_threshold_raises(self, ingestor):
+        """_finalise should raise ValueError if resulting dataset has fewer than _MIN_SAMPLES."""
+        # We provide only 5 samples (less than 10)
+        content = "\n\n".join([
+            f"Paragraph {i}: This is valid but not enough samples."
+            for i in range(5)
+        ])
+        with pytest.raises(ValueError, match="produced only 5 usable samples"):
+            ingestor.from_text_content(content)
+
+
+# ── URL ingestion ──
+
+
+class TestUrlIngestion:
+    @patch("nightmarenet.data.ingest.WebScraper")
+    def test_from_urls(self, mock_scraper_class, ingestor):
+        """WebScraper should be instantiated and used to process URLs."""
+        mock_scraper_instance = mock_scraper_class.return_value
+        from datasets import Dataset
+        mock_ds = Dataset.from_dict({"text": [f"Valid sample {i} content" for i in range(15)]})
+        mock_scraper_instance.scrape.return_value = mock_ds
+
+        urls = ["http://example.com/1", "http://example.com/2"]
+        ds = ingestor.from_urls(urls, delay=0.5, chunk_size=256)
+
+        mock_scraper_class.assert_called_once_with(delay=0.5)
+        mock_scraper_instance.scrape.assert_called_once_with(urls, chunk_size=256)
+        assert len(ds) == 15
+        assert "text" in ds.column_names
+
+
+# ── HuggingFace Hub ingestion ──
+
+
+class TestHuggingFaceIngestion:
+    @patch("nightmarenet.data.ingest.DatasetWrapper")
+    def test_from_huggingface(self, mock_wrapper_class, ingestor):
+        """DatasetWrapper should be used to load HuggingFace datasets."""
+        mock_wrapper_instance = mock_wrapper_class.return_value
+        from datasets import Dataset
+        mock_ds = Dataset.from_dict({"text": [f"HF sample {i} content" for i in range(15)]})
+        mock_wrapper_instance.train_data = mock_ds
+        mock_wrapper_instance.load.return_value = mock_wrapper_instance
+
+        ds = ingestor.from_huggingface("glue", subset="sst2", streaming=True)
+
+        mock_wrapper_class.assert_called_once_with(
+            dataset_name="glue",
+            subset="sst2",
+            text_column="text",
+            max_samples=None,
+            seed=42,
+            streaming=True,
+        )
+        mock_wrapper_instance.load.assert_called_once()
+        assert ds == mock_ds
+


### PR DESCRIPTION
## Summary

This PR addresses issue #40 by adding missing unit test coverage for `DataIngestor` methods in `tests/test_ingest.py`.

## Changes
- **URL Ingestion**: Added a mock test for `DataIngestor.from_urls` verifying that `WebScraper` is properly instantiated and called.
- **HuggingFace Hub Ingestion**: Added a mock test for `DataIngestor.from_huggingface` verifying that `DatasetWrapper` is properly utilized.
- **Minimum Threshold Validation**: Added a test explicitly verifying the `ValueError` raised in `_finalise` when the ingested sample count is below `_MIN_SAMPLES` (10).

Closes #40

## Type
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests

## Quality Checklist
- [x] `ruff check nightmarenet/ tests/` passes with 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` passes
- [x] `pytest tests/` — all tests pass
- [x] Added tests for new functionality (if applicable)
- [x] Updated documentation (if applicable)
- [x] Commit messages follow Conventional Commits
