### PR TITLE
docs: update stale test count badge and testing section (434/502 -> 556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![CI](https://img.shields.io/badge/CI-passing-brightgreen)](.github/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-434%2B%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-556%2B%20passing-brightgreen)](#testing)
 [![Python](https://img.shields.io/badge/python-3.9%E2%80%933.12-blue)](#installation)
 
 *Wake. Dream. Nightmare. Compress. Repeat.*
@@ -366,7 +366,7 @@ If you use NightmareNet in academic work, please cite:
 ## Testing
 
 ```bash
-pytest --cov=nightmarenet --cov-report=term-missing tests/ -v --tb=short   # 502+ tests
+pytest --cov=nightmarenet --cov-report=term-missing tests/ -v --tb=short   # 556+ tests
 ruff check .                         # zero lint errors
 mypy nightmarenet/                   # type check
 cd frontend && npm run build         # production build


### PR DESCRIPTION
## Summary
Fixes stale test count references in README.md — both the badge and the testing section comment were out of date.

Closes #68

## Changes
- Badge: `434+` → `556+`
- Testing section comment: `502+` → `556+`

## Note on test count
The issue's acceptance criteria reference **502+** (the count as of PR #56's merge). Since then, the suite has grown to **556 tests**, confirmed via:

```bash
pytest tests/ --collect-only -q
```

Using 502 now would make the badge stale again immediately, so I've used the current accurate count instead. Happy to change to 502 if you'd prefer to match the issue exactly — let me know.

## Acceptance Criteria (from #68)
- [x] Badge reflects current test count (**556+**, not 502+ — see note above)
- [x] Testing section comment matches
- [x] No other changes in the PR

## Testing
- `git diff README.md` confirms only these two lines changed — no other content touched.
- No code changes; count verified via `pytest tests/ --collect-only -q` (no tests executed, collection only).

## AI Disclosure
This PR includes AI-assisted code generation. I reviewed and validated all generated content before submitting this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect the latest test coverage numbers in the badge and testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->