### PR TITLE
infra: gate db/redis/worker behind hosted profile, document functiona…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,46 @@ Run the full Wake -> Dream -> Nightmare -> Compress cycle on SST-2 in under 10 m
 > Dev hardware target is a 4 GB VRAM laptop GPU (RTX 3050 Ti). DistilBERT and DistilGPT-2 fit comfortably; GPT-2 (124M) requires gradient checkpointing + FP16.
 
 ---
+## Running the API + Dashboard Locally (Docker)
+
+The open-source version of NightmareNet currently supports running the **API** and **Frontend** locally. The `db`, `redis`, and `worker` services are included for future hosted functionality and are disabled by default.
+
+### Default (functional) setup
+
+Start the currently supported services:
+
+```bash
+docker compose up
+```
+
+or explicitly:
+
+```bash
+docker compose up api frontend
+```
+
+This starts only:
+
+- ✅ `api`
+- ✅ `frontend`
+
+### Hosted profile (planned infrastructure)
+
+To include the optional infrastructure services, enable the `hosted` profile:
+
+```bash
+docker compose --profile hosted up
+```
+
+This starts:
+
+- `api`
+- `frontend`
+- `db`
+- `redis`
+- `worker`
+
+> **Note:** The `db`, `redis`, and `worker` services are intended for the future hosted platform and are not required by the current open-source API. Running `docker compose up` without a profile starts only the functional services.
 
 ## What's Inside — 20 Panels of Capability
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,30 @@
 # NightmareNet — local development orchestration
 #
-# Boots the full hosted stack: API + worker + Postgres + Redis + Next.js
-# frontend. Use `docker compose up` for a fresh stack, or target a single
-# service with `docker compose up api`.
+# By default (`docker compose up`), this starts only the services that are
+# actually functional today: `api` and `frontend`. The `db`, `redis`, and
+# `worker` services are part of the planned hosted-platform architecture
+# (see CONTRIBUTING.md — `nightmarenet_server/` is future work) and are
+# gated behind the `hosted` profile since nothing in the OSS core currently
+# connects to them:
+#   - `worker` has no Celery tasks defined yet.
+#   - `api` (nightmarenet/api/app.py) never connects to Postgres or Redis;
+#     rate limiting uses slowapi's in-memory backend.
+#
+# Run the functional stack:
+#   docker compose up api frontend
+#
+# Run the full (currently non-functional) hosted stack, once
+# nightmarenet_server/ exists:
+#   docker compose --profile hosted up
 #
 # All services share the `nightmarenet` network and mount the repo .env
 # file when present. See docker/Dockerfile.api and docker/Dockerfile.worker.
-
 name: nightmarenet
-
 services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
+    profiles: ["hosted"]
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-nightmarenet}
       POSTGRES_USER: ${POSTGRES_USER:-nightmare}
@@ -34,6 +46,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    profiles: ["hosted"]
     command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
     volumes:
       - redis_data:/data
@@ -56,15 +69,14 @@ services:
       - path: ./.env
         required: false
     environment:
-      NIGHTMARENET_DATABASE_URL: ${NIGHTMARENET_DATABASE_URL:-postgresql+psycopg://nightmare:nightmare@db:5432/nightmarenet}
-      NIGHTMARENET_REDIS_URL: ${NIGHTMARENET_REDIS_URL:-redis://redis:6379/0}
+      # NIGHTMARENET_DATABASE_URL / NIGHTMARENET_REDIS_URL are reserved for
+      # the future hosted platform (nightmarenet_server/) and are not read
+      # by the OSS API today. Left here (commented) for forward reference;
+      # uncomment once nightmarenet_server/ lands and actually consumes them.
+      # NIGHTMARENET_DATABASE_URL: ${NIGHTMARENET_DATABASE_URL:-postgresql+psycopg://nightmare:nightmare@db:5432/nightmarenet}
+      # NIGHTMARENET_REDIS_URL: ${NIGHTMARENET_REDIS_URL:-redis://redis:6379/0}
       NIGHTMARENET_CORS_ORIGINS: ${NIGHTMARENET_CORS_ORIGINS:-*}
       NIGHTMARENET_LOG_LEVEL: ${NIGHTMARENET_LOG_LEVEL:-info}
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     ports:
       - "${API_PORT:-8000}:8000"
     volumes:
@@ -85,6 +97,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.worker
     restart: unless-stopped
+    profiles: ["hosted"]
     env_file:
       - path: ./.env
         required: false


### PR DESCRIPTION
## Summary
Gates the non-functional `db`, `redis`, and `worker` services in `docker-compose.yml` behind a `hosted` Compose profile, so `docker compose up` only starts the services that actually work today (`api`, `frontend`).

Closes #72

## Changes
- Added `profiles: ["hosted"]` to `db`, `redis`, `worker` in `docker-compose.yml`.
- Removed `api`'s `depends_on: { db, redis }` — without this, gating the profile alone would still block `api` from starting on a plain `docker compose up` (Compose refuses to start a service that depends on a profile-gated service outside the active profile).
- Commented out the unused `NIGHTMARENET_DATABASE_URL` / `NIGHTMARENET_REDIS_URL` env vars on `api`, since the OSS API doesn't read them (confirmed — no Postgres/Redis client code in `nightmarenet/api/app.py`).
- Updated the `docker-compose.yml` header comment to explain the functional/planned split and both invocation modes.
- Added a new README section ("Running the API + Dashboard Locally (Docker)") documenting `docker compose up api frontend` as the default path and `--profile hosted` as the future/non-functional path.

## Verification
```bash
docker compose config --services
# api
# frontend

docker compose --profile hosted config --services
# api
# frontend
# redis
# db
# worker
```

## Acceptance Criteria (from #72)
- [x] `docker compose up api frontend` works without needing Postgres/Redis
- [x] Worker/db/redis services gated behind a Docker Compose profile
- [x] README/docs updated to reflect which services are functional vs planned
- [x] `docker compose up` without profile runs only functional services

## AI Disclosure
This PR includes AI-assisted code generation. I reviewed and validated all generated content before submitting this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined local Docker setup that starts the API and dashboard by default.
  * Added an optional hosted profile for running database, Redis, and worker services.

* **Documentation**
  * Added instructions for launching the API and dashboard locally with Docker Compose.
  * Documented the optional hosted services and clarified that they are not required for the open-source API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->