### PR TITLE
Add Appendix A: full hyperparameter tables for all experiments 

### DIFF
--- a/docs/research/paper-draft.md
+++ b/docs/research/paper-draft.md
@@ -539,26 +539,45 @@ robustness distillation: Robust soft labels make student better (RSLAD).
 
 ---
 
-## Appendix A — Hyperparameters
+## Appendix A — Full Hyperparameter Tables for All Experiments
 
-Reproduced exactly as committed in `scripts/run_gpu_benchmark.py` (commit
-`80f0e8f`):
+All values below are extracted directly from the YAML configs in `configs/`
+and are the source of truth for reproduction.
 
-| Hyperparameter | Value |
-|----------------|-------|
-| Optimizer | AdamW |
-| Wake learning rate | 3e-5 |
-| Nightmare learning rate | 1.5e-5 (= wake_lr × 0.5) |
-| Batch size | 8 |
-| Max sequence length | 128 |
-| AMP dtype | float16 (`torch.amp.GradScaler("cuda")`) |
-| Gradient clipping | none |
-| Weight decay | 0 (AdamW default) |
-| Warmup steps | 0 |
-| LR schedule | constant |
-| Random seed | 42 (`random`, `numpy`, `torch`, `torch.cuda`) |
-| Tokenizer truncation | left, `max_length=128` |
-| Distortion seed | 42 (fixed for all eval distortions) |
+### A.1 Training configurations
+
+| Experiment | Model | Batch Size | Learning Rate | Warmup Steps | Dream Strength | Nightmare Strength | Pruning Ratio | num\_cycles | Max Length | Seed |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `default.yaml` (base config) | `gpt2` | 8 | 5.0e-5 | 100 | 0.25 | 0.80 | 0.20 | 3 | 128 | 42 |
+| `benchmark_sst2.yaml` (v1 benchmark) | `distilbert-base-uncased` | 8 | 3.0e-5 | — $^{a}$ | 0.25 | 0.75 | 0.15 | 1 | 128 | 42 |
+
+$^{a}$ `warmup_steps` is not overridden in `benchmark_sst2.yaml`; inherits `default.yaml`'s value of 100 unless the run explicitly disables it.
+
+**Additional `default.yaml` fields not in the table above:** `nightmare_lr_multiplier: 2.0`, `weight_decay: 0.01`, `gradient_accumulation_steps: 4`, `wake_epochs: 3` / `dream_epochs: 2` / `nightmare_epochs: 1`.
+
+**Additional `benchmark_sst2.yaml` fields not in the table above:** `wake_epochs: 2` / `dream_epochs: 1` / `nightmare_epochs: 1` / `compress_epochs: 1`, `distill_temperature: 2.0`, `device: cpu`.
+
+### A.2 Ensemble evaluation configuration (`ensemble_benchmark.yaml`)
+
+This config is **evaluation-only** — it does not train a model, so it has no
+batch size, learning rate, warmup, pruning ratio, or `num_cycles` fields. It
+evaluates 3 pretrained/checkpointed models against a distortion sweep on
+SST-2 (validation split, 100 samples):
+
+| Field | Value |
+|---|---|
+| Models evaluated | `distilbert-base-uncased`, `roberta-base`, `bert-base-uncased` |
+| Dataset | SST-2 (`sentence` / `label` columns), validation split, 100 samples |
+| Dream distortion strengths | 0.1, 0.3, 0.5, 0.7, 0.9 |
+| Nightmare distortion strengths | 0.1, 0.3, 0.5, 0.7, 0.9 |
+| Output formats | json, csv, latex |
+| Output directory | `./results/ensemble-v1` |
+
+### A.3 Hardware
+
+All experiments reported in this paper were run on a single consumer laptop
+GPU: **NVIDIA RTX 3050 Ti Laptop GPU, 4 GB VRAM** (see §4.1, §6.2 for
+context on the compute constraints this implies).
 
 ## Appendix B — Distortion taxonomy
 

--- a/docs/research/paper-draft.md
+++ b/docs/research/paper-draft.md
@@ -541,23 +541,50 @@ robustness distillation: Robust soft labels make student better (RSLAD).
 
 ## Appendix A — Full Hyperparameter Tables for All Experiments
 
-All values below are extracted directly from the YAML configs in `configs/`
-and are the source of truth for reproduction.
+### A.1 Reported GPU experiment (§4 results)
 
-### A.1 Training configurations
+Reproduced exactly as committed in `scripts/run_gpu_benchmark.py` (commit
+`80f0e8f`) — these are the settings that produced the headline numbers in §5:
+
+| Hyperparameter | Value |
+|----------------|-------|
+| Optimizer | AdamW |
+| Wake learning rate | 3e-5 |
+| Nightmare learning rate | 1.5e-5 (= wake_lr × 0.5) |
+| Batch size | 8 |
+| Max sequence length | 128 |
+| AMP dtype | float16 (`torch.amp.GradScaler("cuda")`) |
+| Gradient clipping | none |
+| Weight decay | 0 (AdamW default) |
+| Warmup steps | 0 |
+| LR schedule | constant |
+| Random seed | 42 (`random`, `numpy`, `torch`, `torch.cuda`) |
+| Tokenizer truncation | left, `max_length=128` |
+| Distortion seed | 42 (fixed for all eval distortions) |
+
+### A.2 Config-file training defaults
 
 | Experiment | Model | Batch Size | Learning Rate | Warmup Steps | Dream Strength | Nightmare Strength | Pruning Ratio | num\_cycles | Max Length | Seed |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | `default.yaml` (base config) | `gpt2` | 8 | 5.0e-5 | 100 | 0.25 | 0.80 | 0.20 | 3 | 128 | 42 |
-| `benchmark_sst2.yaml` (v1 benchmark) | `distilbert-base-uncased` | 8 | 3.0e-5 | — $^{a}$ | 0.25 | 0.75 | 0.15 | 1 | 128 | 42 |
+| `benchmark_sst2.yaml` (v1 benchmark) | `distilbert-base-uncased` | 8 | 3.0e-5 | 100 $^{a}$ | 0.25 | 0.75 | 0.15 | 1 | 128 | 42 |
 
-$^{a}$ `warmup_steps` is not overridden in `benchmark_sst2.yaml`; inherits `default.yaml`'s value of 100 unless the run explicitly disables it.
+$^{a}$ `benchmark_sst2.yaml` does not set `warmup_steps`, so it resolves to
+`100` via `load_config()`'s merge with `DEFAULT_CONFIG` in
+`nightmarenet/utils/config.py`.
 
-**Additional `default.yaml` fields not in the table above:** `nightmare_lr_multiplier: 2.0`, `weight_decay: 0.01`, `gradient_accumulation_steps: 4`, `wake_epochs: 3` / `dream_epochs: 2` / `nightmare_epochs: 1`.
+**Additional `default.yaml` fields:** `nightmare_lr_multiplier: 2.0`, `weight_decay: 0.01`, `gradient_accumulation_steps: 4`, `wake_epochs: 3` / `dream_epochs: 2` / `nightmare_epochs: 1`.
 
-**Additional `benchmark_sst2.yaml` fields not in the table above:** `wake_epochs: 2` / `dream_epochs: 1` / `nightmare_epochs: 1` / `compress_epochs: 1`, `distill_temperature: 2.0`, `device: cpu`.
+**Additional `benchmark_sst2.yaml` fields:** `wake_epochs: 2` / `dream_epochs: 1` / `nightmare_epochs: 1` / `compress_epochs: 1`, `distill_temperature: 2.0`, `device: cpu`.
 
-### A.2 Ensemble evaluation configuration (`ensemble_benchmark.yaml`)
+> **Note on A.1 vs A.2:** A.1 reflects the actual script-level overrides used
+> for the reported GPU experiment (0 warmup steps, constant LR schedule) and
+> is the source of truth for reproducing §4/§5. A.2 reflects the checked-in
+> YAML config defaults, which differ from A.1 in several fields (e.g. warmup
+> steps, LR schedule) and represent the general-purpose training defaults
+> rather than the exact experimental run.
+
+### A.3 Ensemble evaluation configuration (`ensemble_benchmark.yaml`)
 
 This config is **evaluation-only** — it does not train a model, so it has no
 batch size, learning rate, warmup, pruning ratio, or `num_cycles` fields. It
@@ -573,11 +600,10 @@ SST-2 (validation split, 100 samples):
 | Output formats | json, csv, latex |
 | Output directory | `./results/ensemble-v1` |
 
-### A.3 Hardware
+### A.4 Hardware
 
 All experiments reported in this paper were run on a single consumer laptop
-GPU: **NVIDIA RTX 3050 Ti Laptop GPU, 4 GB VRAM** (see §4.1, §6.2 for
-context on the compute constraints this implies).
+GPU: **NVIDIA RTX 3050 Ti Laptop GPU, 4 GB VRAM** (see §4.1, §6.2).
 
 ## Appendix B — Distortion taxonomy
 


### PR DESCRIPTION
## Summary

Adds Appendix A: full hyperparameter tables extracted from all training/eval
configs (configs/default.yaml, configs/benchmark_sst2.yaml,
configs/ensemble_benchmark.yaml), replacing the previous single-experiment
Appendix A with a more complete set that also preserves the original
reported-GPU-experiment settings for §4/§5 reproducibility.

Closes #117

## Before / After

**Before:** Appendix A only listed hyperparameters for the single reported
GPU run (from scripts/run_gpu_benchmark.py), with no coverage of the
checked-in YAML configs or the ensemble evaluation setup.

**After:** Appendix A now has four subsections: (A.1) the original
reported-experiment table [preserved, unchanged], (A.2) a new table of
training hyperparameters from default.yaml and benchmark_sst2.yaml,
(A.3) the ensemble_benchmark.yaml evaluation setup [documented as
evaluation-only], and (A.4) the hardware note (RTX 3050 Ti, 4GB VRAM).

## Acceptance Criteria (copied from issue #117)

- [x] Appendix A section exists in paper-draft.md
- [x] Table includes all training hyperparameters from configs/
- [x] Values match the actual YAML files (no copy errors)
- [x] Table is formatted for academic readability (LaTeX-compatible markdown)
- [x] Includes a note on hardware used (RTX 3050 Ti, 4GB VRAM)

## Notes

- configs/ensemble_benchmark.yaml has no training hyperparameters (it's an
  evaluation-only sweep across 3 pretrained models) — documented explicitly
  in A.3 rather than leaving blank/invented fields.
- benchmark_sst2.yaml's warmup_steps resolves to 100 via DEFAULT_CONFIG
  merge in nightmarenet/utils/config.py — footnoted rather than stated as
  a direct override.
- Original A.1 (reported GPU experiment settings) is preserved unchanged
  since it's the source of truth for reproducing §4/§5.

## AI Disclosure

This PR includes AI-assisted content generation (Claude). All hyperparameter
values were manually cross-checked against the source YAML files and
nightmarenet/utils/config.py before inclusion.

## Checklist

- [x] I have starred the repo and followed @Adit-Jain-srm
- [x] `ruff check .` — zero errors
- [x] `pytest --cov=nightmarenet tests/ -v --tb=short` — green
- [x] `mypy nightmarenet/` — no new errors
- [x] Documentation updated (this PR *is* the doc update)
- [x] Acceptance criteria checklist included above