### PR TITLE
docs: add Code of Conduct with cross-references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Code of Conduct
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+### Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+### Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or email address, without  their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional     setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [@Adit-Jain-srm](https://github.com/Adit-Jain-srm/NightmareNet/issues). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. Warning
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A **warning** with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a **temporary or permanent ban**.
+
+3. Temporary Ban
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A **temporary ban** from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a **permanent ban**.
+
+4. Permanent Ban
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A **permanent ban** from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by **Mozilla’s code of conduct enforcement ladder**.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Community leaders will follow these Community Impact Guidelines in determining t
 1. Correction
 Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+Consequence: A **private, written warning** from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 2. Warning
 Community Impact: A violation through a single incident or series of actions.
@@ -59,8 +59,8 @@ Community Impact: Demonstrating a pattern of violation of community standards, i
 Consequence: A **permanent ban** from any sort of public interaction within the community.
 
 ## Attribution
-This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the [**Contributor Covenant**](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by **Mozilla’s code of conduct enforcement ladder**.
+Community Impact Guidelines were inspired by [**Mozilla’s code of conduct enforcement ladder**](https://github.com/mozilla/inclusion).
 
 For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for helping improve NightmareNet. This project uses a **research-first
 1. **Star this repository** — It helps us gauge community interest and prioritize features.
 2. **Follow [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)** — Stay updated on releases, related projects, and research.
 3. **Read this entire guide** — PRs that don't follow the coding standards or skip tests will be asked to revise.
-4. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing to help maintain a welcoming and respectful community.
+4.  **Please read our [Code of Conduct](CODE_OF_CONDUCT.md)** before contributing to help maintain a welcoming and respectful community.
 > Maintainers verify star/follow status before merging. PRs from accounts that haven't completed steps 1-2 will be asked to do so before review begins.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for helping improve NightmareNet. This project uses a **research-first
 1. **Star this repository** — It helps us gauge community interest and prioritize features.
 2. **Follow [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)** — Stay updated on releases, related projects, and research.
 3. **Read this entire guide** — PRs that don't follow the coding standards or skip tests will be asked to revise.
-
+4. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing to help maintain a welcoming and respectful community.
 > Maintainers verify star/follow status before merging. PRs from accounts that haven't completed steps 1-2 will be asked to do so before review begins.
 
 ---

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ If you use NightmareNet in academic work, please cite:
 - **Sponsors** — GitHub Sponsors and OpenCollective links go here once the project moves out of pre-release
 
 > [!IMPORTANT]
+>Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 > Research-first contributions are especially welcome. If you have measured results extending the 4-phase cycle to a new domain (vision, multimodal, code generation), open a Discussion thread. We aim to credit external research in the paper's acknowledgements.
 
 ---


### PR DESCRIPTION
## Summary
No Code of Conduct exists in the repository. This is a baseline requirement for any professional open-source project, especially one with active community contributors (ECSoC'26)

## Motivation

This change improves the project's contributor documentation by making the Code of Conduct easier to discover. Adding cross-references to the README and CONTRIBUTING guide helps contributors understand community expectations before participating and ensures that important documentation is easy to access.

Closes #142 

## Changes

- Added CODE_OF_CONDUCT.md file.
- Added enforcement contact as the maintainer's GitHub ID, in the form of a hyperlink, which links to the GitHub issues page.
- Added a one-line cross-reference in CONTRIBUTING.md under "Before You Start".
- Added a link in README.md.

## Acceptance Criteria
- [x] CODE_OF_CONDUCT.md exists at repo root with full Contributor Covenant v2.1 text

- [x] Enforcement contact is filled in (not placeholder [INSERT CONTACT METHOD])

- [x] CONTRIBUTING.md links to the Code of Conduct

- [x] GitHub "Community Standards" page shows Code of Conduct as present

- [x] File renders correctly with proper Markdown formatting



## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behaviour)
- [ ] Refactor (no functional change)
- [x] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [ ] No documentation needed (test-only or internal refactor)
- [x] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

<!-- Required by CONTRIBUTING.md. Check one. -->

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched





## Breaking Changes
N/A

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Code of Conduct covering expected/unacceptable behavior, reporting, enforcement steps, and project scope.
  * Updated contribution guidance with a “Before You Start” reminder to review the Code of Conduct prior to contributing.
  * Added a Code of Conduct reference in the README’s community section to reinforce the requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->