### PR TITLE
docs: separate measured and projected benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,13 @@ Measured on RTX 3050 Ti (4 GB VRAM), DistilBERT-base-uncased, 500 train / 200 ev
 
 > **Key finding:** NightmareNet delivers robustness gains *without* the typical clean-accuracy tradeoff. The +13.64% relative robustness improvement comes with a +4.0 absolute point clean accuracy gain (0.745 → 0.785).
 
-| Model | Method | Clean Acc | TextFooler Acc | BertAttack Acc | Robustness Score | Params |
-|-------|--------|-----------|----------------|----------------|------------------|--------|
 
 ### Measured Benchmarks (v1)
-
+| Model | Method | Clean Acc | TextFooler Acc | BertAttack Acc | Robustness Score | Params |
+|-------|--------|-----------|----------------|----------------|------------------|--------|
 | DistilBERT | Standard FT (baseline) | 90.5% | 23.1% | 17.6% | 0.412 | 66.0M |
 | DistilBERT | Adversarial Training (PGD) | 88.2% | 41.7% | 38.4% | 0.598 | 66.0M |
 | DistilBERT | TRADES | 87.6% | 44.9% | 42.1% | 0.621 | 66.0M |
-| DistilBERT | **NightmareNet (1 cycle)** | 89.1% | 51.3%* | 48.2%* | 0.683* | 66.0M |
 
 
 ### Projected Benchmarks (Pending v2 Evaluation)
@@ -195,8 +193,8 @@ Measured on RTX 3050 Ti (4 GB VRAM), DistilBERT-base-uncased, 500 train / 200 ev
 
 | Model | Method | Clean Acc | TextFooler Acc | BertAttack Acc | Robustness Score | Params |
 |-------|--------|-----------|----------------|----------------|------------------|--------|
-
-| DistilBERT | **NightmareNet (3 cycles)** | **89.7%** | **58.4%*** | **55.7%** | **0.741** | **42.6M** |
+| DistilBERT | **NightmareNet (1 cycle)** | 89.1% | 51.3% | 48.2% | 0.683 | 66.0M |
+| DistilBERT | **NightmareNet (3 cycles)** | **89.7%** | **58.4%** | **55.7%** | **0.741** | **42.6M** |
 
 
 

--- a/README.md
+++ b/README.md
@@ -179,13 +179,26 @@ Measured on RTX 3050 Ti (4 GB VRAM), DistilBERT-base-uncased, 500 train / 200 ev
 
 | Model | Method | Clean Acc | TextFooler Acc | BertAttack Acc | Robustness Score | Params |
 |-------|--------|-----------|----------------|----------------|------------------|--------|
+
+### Measured Benchmarks (v1)
+
 | DistilBERT | Standard FT (baseline) | 90.5% | 23.1% | 17.6% | 0.412 | 66.0M |
 | DistilBERT | Adversarial Training (PGD) | 88.2% | 41.7% | 38.4% | 0.598 | 66.0M |
 | DistilBERT | TRADES | 87.6% | 44.9% | 42.1% | 0.621 | 66.0M |
 | DistilBERT | **NightmareNet (1 cycle)** | 89.1% | 51.3%* | 48.2%* | 0.683* | 66.0M |
-| DistilBERT | **NightmareNet (3 cycles)** | **89.7%** | **58.4%*** | **55.7%*** | **0.741*** | **42.6M** |
 
-\* Multi-cycle TextFooler/BertAttack numbers are projected from the v1 distortion-sweep trend; full adversarial-attack benchmark pending GPU time.
+
+### Projected Benchmarks (Pending v2 Evaluation)
+
+> [!NOTE]
+> The following benchmark values are projected estimates based on the v1 distortion-sweep trend. They have not yet been experimentally measured and are pending full adversarial benchmark evaluation.
+
+| Model | Method | Clean Acc | TextFooler Acc | BertAttack Acc | Robustness Score | Params |
+|-------|--------|-----------|----------------|----------------|------------------|--------|
+
+| DistilBERT | **NightmareNet (3 cycles)** | **89.7%** | **58.4%*** | **55.7%** | **0.741** | **42.6M** |
+
+
 
 > [!NOTE]
 > The 3-cycle compressed model achieves higher robustness *and* lower parameter count than the 1-cycle full model. Compression is not a tradeoff — it is part of the robustness mechanism (lottery-ticket-style removal of non-robust features).


### PR DESCRIPTION
## Summary

Separate measured and projected benchmark results in the README for better clarity.

## Motivation

The benchmark table mixed measured and projected values, making it easy for readers to mistake projected estimates for measured results. This change separates them into distinct sections and adds a clear note explaining the projected results.

Closes #119 

## Changes

- Split benchmark results into "Measured Benchmarks (v1)" and "Projected Benchmarks (Pending v2 Evaluation)"
- Added a GitHub NOTE callout explaining that projected results are estimates
- Moved the NightmareNet (3 cycles) benchmark into its own projected section
- Improved README readability without changing any benchmark values

-

## Acceptance Criteria

- [x] Casual reader can immediately distinguish measured vs projected numbers
- [x] Projected numbers clearly labeled as estimates pending full evaluation
- [x] README remains visually appealing (not cluttered with disclaimers)
- [x] No factual claims change (numbers stay the same, just presentation improves)


## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [ ] No `from __future__ import annotations` added under `nightmarenet/api/`
- [ ] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [ ] No documentation needed (test-only or internal refactor)
- [x] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

<!-- Required by CONTRIBUTING.md. Check one. -->

- [x] This PR is entirely human-written
- [ ] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [ ] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

<!-- Required by CONTRIBUTING.md for any frontend change. All three are needed. -->

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | |
| Desktop (light mode) | |
| Mobile (375px) | |

## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured the benchmark results section to clearly separate baseline measured results from projected results awaiting v2 evaluation.
  * Added a dedicated **Measured Benchmarks (v1)** subsection with baseline results.
  * Added a **Projected Benchmarks (Pending v2 Evaluation)** subsection, including one-cycle and three-cycle projections, with a note that multi-cycle figures are pending further evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->