### PR TITLE
Wire certification into evaluator, add config + budget controls (#161)

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -84,11 +84,23 @@ evaluation:
     - "robustness"
     - "hallucination"
     # - "glue"                  # Uncomment for GLUE benchmark (requires seq_classification model)
+    # - "certification"         # Opt-in: certified robustness via randomized smoothing
   robustness_strengths: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
   # significance_alpha: 0.05    # Statistical significance threshold for baseline vs trained comparisons
   eval_split_ratio: 0.2         # Fraction of ingested data held out for evaluation; 0.0 disables splitting
   # glue_tasks: null            # null = all tasks; or list: ["sst2", "mrpc"]
   # glue_max_samples: null      # Limit per-task samples for quick runs
+  # Certified robustness (randomized smoothing) — only used if "certification" is
+  # uncommented above. Compute-expensive (n forward passes per certified sample), so it
+  # is opt-in and budget-capped rather than running by default.
+  certification:
+    n: 1000                # Number of noisy forward passes per sample (estimation stage)
+    sigma: 0.1             # Gaussian noise standard deviation in embedding space
+    alpha: 0.001           # Significance level for Clopper-Pearson bound (99.9% confidence)
+    batch_size: 100        # Batch size for noisy copies per forward pass
+    subset_size: 50        # Number of samples to certify (controls total compute)
+    budget: 100000          # Max total forward passes (n * subset_size); n is reduced
+                             # proportionally (with a warning) if this would be exceeded
 
 # Experiment tracking
 tracking:

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -95,6 +95,7 @@ evaluation:
   # is opt-in and budget-capped rather than running by default.
   certification:
     n: 1000                # Number of noisy forward passes per sample (estimation stage)
+    n0: 100                # Number of selection-stage samples (picks the candidate class)
     sigma: 0.1             # Gaussian noise standard deviation in embedding space
     alpha: 0.001           # Significance level for Clopper-Pearson bound (99.9% confidence)
     batch_size: 100        # Batch size for noisy copies per forward pass

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -299,6 +299,7 @@ class Evaluator:
         """
         cert_config = self.eval_config.get("certification", {})
         n = cert_config.get("n", 1000)
+        n0 = cert_config.get("n0", 100)
         subset_size = cert_config.get("subset_size", 50)
         budget = cert_config.get("budget")
 
@@ -324,6 +325,7 @@ class Evaluator:
             label_column=cert_config.get("label_column", "label"),
             sigma=cert_config.get("sigma", 0.1),
             n=n,
+            n0=n0,
             alpha=cert_config.get("alpha", 0.001),
             subset_size=subset_size,
             batch_size=cert_config.get("batch_size", 100),
@@ -369,13 +371,20 @@ class Evaluator:
                 "trained": trained,
             }
 
-            # Compute deltas for key numeric fields
+            # Compute deltas for key numeric fields. bool is a subtype of int in Python,
+            # so it's explicitly excluded here -- otherwise flags like budget_exceeded
+            # would silently get a meaningless numeric delta (e.g. True - False == 1).
             deltas = {}
             for key in baseline:
-                if isinstance(baseline.get(key), (int, float)) and isinstance(
-                    trained.get(key), (int, float)
+                baseline_val = baseline.get(key)
+                trained_val = trained.get(key)
+                if (
+                    isinstance(baseline_val, (int, float))
+                    and not isinstance(baseline_val, bool)
+                    and isinstance(trained_val, (int, float))
+                    and not isinstance(trained_val, bool)
                 ):
-                    deltas[key] = trained[key] - baseline[key]
+                    deltas[key] = trained_val - baseline_val
             metric_comparison["deltas"] = deltas
 
             # Add statistical significance testing for robustness (per-strength scores)

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -16,6 +16,7 @@ import numpy as np
 from scipy import stats
 from torch.utils.data import DataLoader
 
+from nightmarenet.evaluation.certification import certify_dataset
 from nightmarenet.evaluation.glue import evaluate_glue
 from nightmarenet.evaluation.metrics import (
     classification_metrics,
@@ -262,7 +263,82 @@ class Evaluator:
                 logger.error("Failed to compute GLUE: %s", e)
                 results["glue"] = {"error": str(e)}
 
+        if "certification" in self.enabled_metrics and base_dataset is not None:
+            logger.info("Evaluating: certification")
+            try:
+                results["certification"] = self._run_certification(base_dataset)
+                if self.tracker:
+                    self._log_eval("certification", results["certification"])
+            except Exception as e:
+                logger.error("Failed to compute certification: %s", e)
+                results["certification"] = {"error": str(e)}
+
         return results
+
+    def _run_certification(self, base_dataset) -> dict:
+        """Run certified-robustness verification (randomized smoothing) on a dataset.
+
+        Opt-in metric: only invoked from evaluate() when "certification" is explicitly
+        listed in evaluation.metrics. Config is read from the evaluation.certification
+        namespace (see configs/default.yaml).
+
+        Budget control: `budget` caps the total forward passes for the *estimation*
+        stage across the whole run (n * subset_size). If the configured n and
+        subset_size would exceed it, n is reduced proportionally (subset_size is left
+        alone, since it controls how many samples get any signal at all) and a warning
+        is logged. This is a coarse, evaluator-level cap on top of certify_dataset's own
+        finer-grained per-sample budget splitting.
+
+        Args:
+            base_dataset: Dataset to certify (same dataset used for robustness testing).
+
+        Returns:
+            Dict with certified_radius_mean, certified_radius_median,
+            certification_abstain_rate, certified_accuracy, samples_certified, and
+            budget_exceeded -- the shape expected in compare()'s comparison dict.
+        """
+        cert_config = self.eval_config.get("certification", {})
+        n = cert_config.get("n", 1000)
+        subset_size = cert_config.get("subset_size", 50)
+        budget = cert_config.get("budget")
+
+        effective_size = subset_size if subset_size is not None else len(base_dataset)
+        budget_exceeded = False
+        if budget is not None and effective_size > 0 and n * effective_size > budget:
+            reduced_n = max(1, budget // effective_size)
+            logger.warning(
+                "Certification budget exceeded: n=%d * subset_size=%d = %d > budget=%d; "
+                "reducing n to %d",
+                n, effective_size, n * effective_size, budget, reduced_n,
+            )
+            n = reduced_n
+            budget_exceeded = True
+
+        dataset_config = self.config.get("dataset", {})
+        model_config = self.config.get("model", {})
+        cert_result = certify_dataset(
+            self.model,
+            self.tokenizer,
+            base_dataset,
+            text_column=dataset_config.get("text_column", "text"),
+            label_column=cert_config.get("label_column", "label"),
+            sigma=cert_config.get("sigma", 0.1),
+            n=n,
+            alpha=cert_config.get("alpha", 0.001),
+            subset_size=subset_size,
+            batch_size=cert_config.get("batch_size", 100),
+            max_length=model_config.get("max_length", 128),
+            device=self.device,
+        )
+
+        return {
+            "certified_radius_mean": cert_result["certified_radius_mean"],
+            "certified_radius_median": cert_result["certified_radius_median"],
+            "certification_abstain_rate": cert_result["certification_abstain_rate"],
+            "certified_accuracy": cert_result["certified_accuracy"],
+            "samples_certified": cert_result["n_samples"],
+            "budget_exceeded": budget_exceeded,
+        }
 
     def compare(self, baseline_results: dict, trained_results: dict) -> dict:
         """Produce a comparison between baseline and trained model results.

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -248,7 +248,13 @@ class TestCertificationIntegration:
         )
         dataset = _CertListDataset([{"text": "a", "label": 0} for _ in range(10)])
 
-        with caplog.at_level("WARNING"):
+        # Target the evaluator's logger by name (not just the root/default level).
+        # nightmarenet/utils/logging_config.setup_logging() sets propagate=False on the
+        # "nightmarenet" logger the first time it's called anywhere in the test session --
+        # after that, records from child loggers like this one never reach the root
+        # logger, so caplog.at_level("WARNING") alone would silently miss them depending
+        # on test execution order. Attaching directly to the named logger sidesteps that.
+        with caplog.at_level("WARNING", logger="nightmarenet.evaluation.evaluator"):
             results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
 
         cert = results["certification"]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,8 +1,86 @@
 """Tests for evaluation metrics and comparison."""
 
 import pytest
+import torch
+import torch.nn as nn
 
-from nightmarenet.evaluation.evaluator import _bootstrap_ci
+from nightmarenet.evaluation.evaluator import Evaluator, _bootstrap_ci
+
+# ---------------------------------------------------------------------------------------
+# Minimal fakes for certification integration tests (issue #161).
+#
+# Mirrors the fakes in tests/test_certification.py, kept self-contained here so this
+# module doesn't depend on another test module's internals.
+# ---------------------------------------------------------------------------------------
+
+
+class _FakeModelConfig:
+    num_labels = 2
+
+
+class _CertNoiseSignClassifier(nn.Module):
+    """Deterministic (given a seed) stand-in for a PreTrainedModel classifier."""
+
+    def __init__(self, vocab_size: int = 20, hidden_dim: int = 8):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_dim)
+        nn.init.zeros_(self.embedding.weight)
+        self.config = _FakeModelConfig()
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def forward(self, input_ids=None, attention_mask=None):
+        embeds = self.embedding(input_ids)
+        means = embeds.mean(dim=(1, 2))
+        logits = torch.stack([-means, means], dim=1)
+        return type("Output", (), {"logits": logits})()
+
+
+class _CertFakeTokenizer:
+    """Minimal HF-tokenizer-shaped callable: maps any text to a fixed token sequence."""
+
+    def __call__(self, text, truncation=True, max_length=128, return_tensors="pt"):
+        ids = torch.tensor([[1, 2, 3, 4, 5]])
+        mask = torch.ones_like(ids)
+        return {"input_ids": ids, "attention_mask": mask}
+
+
+class _CertListDataset:
+    """Minimal HF-Dataset-shaped wrapper around a list of dicts."""
+
+    def __init__(self, examples):
+        self._examples = examples
+
+    def __len__(self):
+        return len(self._examples)
+
+    def __iter__(self):
+        return iter(self._examples)
+
+    def shuffle(self, seed=42):
+        return self
+
+    def select(self, indices):
+        return _CertListDataset([self._examples[i] for i in indices])
+
+
+def _make_cert_evaluator(tmp_path, metrics, certification_config=None):
+    config = {
+        "evaluation": {
+            "metrics": metrics,
+            "output_dir": str(tmp_path),
+        },
+        "dataset": {"text_column": "text"},
+        "model": {"max_length": 32},
+    }
+    if certification_config is not None:
+        config["evaluation"]["certification"] = certification_config
+    return Evaluator(
+        model=_CertNoiseSignClassifier(),
+        tokenizer=_CertFakeTokenizer(),
+        config=config,
+    )
 
 
 def test_bootstrap_ci_identical():
@@ -52,3 +130,184 @@ def test_bootstrap_ci_custom_alpha():
 
     assert result["alpha"] == 0.01
     assert result["significant"] is True
+
+
+# ---------------------------------------------------------------------------------------
+# Certification integration (issue #161)
+# ---------------------------------------------------------------------------------------
+
+
+class TestCertificationIntegration:
+    def test_certification_not_run_when_not_enabled(self, tmp_path):
+        """Existing behavior is unchanged when certification isn't opted into: no
+        regression, and the key is simply absent rather than erroring."""
+        evaluator = _make_cert_evaluator(tmp_path, metrics=["recall"])
+        dataset = _CertListDataset([{"text": "a", "label": 0}])
+
+        results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+
+        assert "certification" not in results
+
+    def test_certification_skipped_without_base_dataset(self, tmp_path):
+        """Even when enabled, certification needs a dataset to certify -- it should be
+        skipped (not error) if base_dataset isn't provided, same as robustness."""
+        evaluator = _make_cert_evaluator(tmp_path, metrics=["certification"])
+
+        results = evaluator.evaluate(clean_dataloader=None, base_dataset=None)
+
+        assert "certification" not in results
+
+    def test_certification_produces_expected_output_keys(self, tmp_path):
+        """Integration test: evaluate() with certification in metrics list produces the
+        expected output keys (issue #161 acceptance criteria)."""
+        evaluator = _make_cert_evaluator(
+            tmp_path,
+            metrics=["certification"],
+            certification_config={
+                "n": 20,
+                "n0": 10,
+                "sigma": 0.1,
+                "alpha": 0.05,
+                "batch_size": 10,
+                "subset_size": 2,
+                "budget": None,
+            },
+        )
+        dataset = _CertListDataset(
+            [
+                {"text": "example one", "label": 0},
+                {"text": "example two", "label": 1},
+            ]
+        )
+
+        results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+
+        assert "certification" in results
+        cert = results["certification"]
+        assert set(cert.keys()) == {
+            "certified_radius_mean",
+            "certified_radius_median",
+            "certification_abstain_rate",
+            "certified_accuracy",
+            "samples_certified",
+            "budget_exceeded",
+        }
+        assert cert["samples_certified"] == 2
+        assert 0.0 <= cert["certification_abstain_rate"] <= 1.0
+        assert cert["budget_exceeded"] is False
+
+    def test_certification_config_read_from_namespace(self, tmp_path, monkeypatch):
+        """Config values must be read from evaluation.certification, not hardcoded
+        defaults -- verified by checking certify_dataset receives them."""
+        captured = {}
+        real_certify_dataset = __import__(
+            "nightmarenet.evaluation.evaluator", fromlist=["certify_dataset"]
+        ).certify_dataset
+
+        def spy(*args, **kwargs):
+            captured.update(kwargs)
+            return real_certify_dataset(*args, **kwargs)
+
+        monkeypatch.setattr("nightmarenet.evaluation.evaluator.certify_dataset", spy)
+
+        evaluator = _make_cert_evaluator(
+            tmp_path,
+            metrics=["certification"],
+            certification_config={
+                "n": 15,
+                "sigma": 0.33,
+                "alpha": 0.02,
+                "batch_size": 5,
+                "subset_size": 1,
+                "budget": None,
+            },
+        )
+        dataset = _CertListDataset([{"text": "a", "label": 0}])
+
+        evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+
+        assert captured["sigma"] == 0.33
+        assert captured["alpha"] == 0.02
+        assert captured["batch_size"] == 5
+        assert captured["subset_size"] == 1
+
+    def test_certification_budget_reduces_n_and_flags_exceeded(self, tmp_path, caplog):
+        """Budget control: when n * subset_size exceeds budget, n is reduced
+        proportionally, budget_exceeded is flagged, and a warning is logged."""
+        evaluator = _make_cert_evaluator(
+            tmp_path,
+            metrics=["certification"],
+            certification_config={
+                "n": 1000,
+                "subset_size": 10,
+                "budget": 50,  # 1000 * 10 = 10000 >> 50
+                "sigma": 0.1,
+                "alpha": 0.05,
+                "batch_size": 10,
+            },
+        )
+        dataset = _CertListDataset([{"text": "a", "label": 0} for _ in range(10)])
+
+        with caplog.at_level("WARNING"):
+            results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+
+        cert = results["certification"]
+        assert cert["budget_exceeded"] is True
+        assert any("budget" in record.message.lower() for record in caplog.records)
+
+    def test_certification_within_budget_not_flagged(self, tmp_path):
+        """When n * subset_size is within budget, no reduction happens."""
+        evaluator = _make_cert_evaluator(
+            tmp_path,
+            metrics=["certification"],
+            certification_config={
+                "n": 10,
+                "subset_size": 2,
+                "budget": 1000,  # comfortably above 10 * 2 = 20
+                "sigma": 0.1,
+                "alpha": 0.05,
+                "batch_size": 10,
+            },
+        )
+        dataset = _CertListDataset([{"text": "a", "label": 0}, {"text": "b", "label": 1}])
+
+        results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+
+        assert results["certification"]["budget_exceeded"] is False
+
+    def test_compare_includes_certification_results(self, tmp_path):
+        """compare() folds certification into the comparison dict alongside other
+        metrics, using the same generic baseline/trained/deltas shape."""
+        evaluator = _make_cert_evaluator(tmp_path, metrics=["certification"])
+
+        baseline_results = {
+            "label": "baseline",
+            "certification": {
+                "certified_radius_mean": 0.1,
+                "certified_radius_median": 0.1,
+                "certification_abstain_rate": 0.5,
+                "certified_accuracy": 0.6,
+                "samples_certified": 10,
+                "budget_exceeded": False,
+            },
+        }
+        trained_results = {
+            "label": "trained",
+            "certification": {
+                "certified_radius_mean": 0.2,
+                "certified_radius_median": 0.2,
+                "certification_abstain_rate": 0.3,
+                "certified_accuracy": 0.8,
+                "samples_certified": 10,
+                "budget_exceeded": False,
+            },
+        }
+
+        comparison = evaluator.compare(baseline_results, trained_results)
+
+        assert "certification" in comparison["metrics"]
+        cert_comparison = comparison["metrics"]["certification"]
+        assert cert_comparison["baseline"]["certified_radius_mean"] == 0.1
+        assert cert_comparison["trained"]["certified_radius_mean"] == 0.2
+        assert cert_comparison["deltas"]["certified_radius_mean"] == pytest.approx(0.1)
+        assert cert_comparison["deltas"]["certification_abstain_rate"] == pytest.approx(-0.2)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,6 @@
 """Tests for evaluation metrics and comparison."""
 
+import logging
 
 import pytest
 import torch
@@ -235,7 +236,7 @@ class TestCertificationIntegration:
         assert captured["batch_size"] == 5
         assert captured["subset_size"] == 1
 
-    def test_certification_budget_reduces_n_and_flags_exceeded(self, tmp_path, caplog):
+    def test_certification_budget_reduces_n_and_flags_exceeded(self, tmp_path):
         """Budget control: when n * subset_size exceeds budget, n is reduced
         proportionally, budget_exceeded is flagged, and a warning is logged."""
         evaluator = _make_cert_evaluator(
@@ -252,18 +253,36 @@ class TestCertificationIntegration:
         )
         dataset = _CertListDataset([{"text": "a", "label": 0} for _ in range(10)])
 
-        # Target the evaluator's logger by name (not just the root/default level).
-        # nightmarenet/utils/logging_config.setup_logging() sets propagate=False on the
-        # "nightmarenet" logger the first time it's called anywhere in the test session --
-        # after that, records from child loggers like this one never reach the root
-        # logger, so caplog.at_level("WARNING") alone would silently miss them depending
-        # on test execution order. Attaching directly to the named logger sidesteps that.
-        with caplog.at_level("WARNING", logger="nightmarenet.evaluation.evaluator"):
+        # caplog.at_level(..., logger=name) is *not* used here: whether it attaches its
+        # capture handler directly to the named logger or only adjusts that logger's
+        # level (leaving the handler on the root logger) differs across pytest versions,
+        # and nightmarenet/utils/logging_config.setup_logging() sets propagate=False on
+        # the "nightmarenet" logger the first time it's called anywhere in the test
+        # session -- so whether this test passes can depend on both the pytest version
+        # resolved for a given Python version and on test execution order elsewhere in
+        # the suite. Attaching a plain logging.Handler directly to the evaluator's own
+        # logger sidesteps both: a logger's own handlers always fire regardless of its
+        # (or an ancestor's) propagate setting, independent of caplog/pytest internals.
+        target_logger = logging.getLogger("nightmarenet.evaluation.evaluator")
+        records: list[logging.LogRecord] = []
+
+        class _ListHandler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _ListHandler(level=logging.WARNING)
+        original_level = target_logger.level
+        target_logger.addHandler(handler)
+        target_logger.setLevel(logging.WARNING)
+        try:
             results = evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
+        finally:
+            target_logger.removeHandler(handler)
+            target_logger.setLevel(original_level)
 
         cert = results["certification"]
         assert cert["budget_exceeded"] is True
-        assert any("budget" in record.message.lower() for record in caplog.records)
+        assert any("budget" in record.getMessage().lower() for record in records)
 
     def test_certification_within_budget_not_flagged(self, tmp_path):
         """When n * subset_size is within budget, no reduction happens."""

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,6 @@
 """Tests for evaluation metrics and comparison."""
 
+
 import pytest
 import torch
 import torch.nn as nn
@@ -215,6 +216,7 @@ class TestCertificationIntegration:
             metrics=["certification"],
             certification_config={
                 "n": 15,
+                "n0": 7,
                 "sigma": 0.33,
                 "alpha": 0.02,
                 "batch_size": 5,
@@ -226,6 +228,8 @@ class TestCertificationIntegration:
 
         evaluator.evaluate(clean_dataloader=None, base_dataset=dataset)
 
+        assert captured["n"] == 15
+        assert captured["n0"] == 7
         assert captured["sigma"] == 0.33
         assert captured["alpha"] == 0.02
         assert captured["batch_size"] == 5
@@ -305,7 +309,7 @@ class TestCertificationIntegration:
                 "certification_abstain_rate": 0.3,
                 "certified_accuracy": 0.8,
                 "samples_certified": 10,
-                "budget_exceeded": False,
+                "budget_exceeded": True,
             },
         }
 
@@ -317,3 +321,6 @@ class TestCertificationIntegration:
         assert cert_comparison["trained"]["certified_radius_mean"] == 0.2
         assert cert_comparison["deltas"]["certified_radius_mean"] == pytest.approx(0.1)
         assert cert_comparison["deltas"]["certification_abstain_rate"] == pytest.approx(-0.2)
+        # bool is a subtype of int in Python -- budget_exceeded must not sneak into the
+        # numeric deltas (True - False == 1 would be a meaningless "delta").
+        assert "budget_exceeded" not in cert_comparison["deltas"]


### PR DESCRIPTION
## Summary

Sub-issue 2/3 of #153 — wires the certified-robustness module (`certification.py`, sub-issue #160/1) into the existing evaluation pipeline via config, per #161.

Closes #161

## Changes

**`nightmarenet/evaluation/evaluator.py`**
- Added `"certification"` to the `enabled_metrics` pattern in `Evaluator.evaluate()`. Opt-in only — runs only when explicitly listed in `evaluation.metrics` **and** a `base_dataset` is provided; never runs by default.
- New `_run_certification()` helper: reads config from the `evaluation.certification` namespace (`n`, `sigma`, `alpha`, `batch_size`, `subset_size`, `budget`) and calls `certify_dataset()`.
- **Budget control**: if `n * subset_size > budget`, `n` is reduced proportionally (`budget // subset_size`, floor 1) and a warning is logged. Returns a `budget_exceeded` flag.
- No changes needed to `compare()` — it already handles any metric in `enabled_metrics` generically (baseline/trained/deltas), so certification results flow through automatically once enabled.

**`configs/default.yaml`**
- Added commented `# - "certification"` to `evaluation.metrics` (opt-in).
- Added `evaluation.certification:` block with a comment on every parameter.

**`tests/test_evaluation.py`**
- 7 new tests covering: metric not run when disabled, skipped without `base_dataset`, expected output keys present, config values correctly passed through to `certify_dataset`, budget-exceeded case (n reduced + warning logged + flag set), within-budget case (no reduction), and `compare()` including certification alongside other metrics.

## Acceptance criteria (from #161)

- [x] `"certification"` recognized as a valid metric in `evaluator.py`
- [x] Certification only runs when explicitly enabled (never by default)
- [x] Config values read from `evaluation.certification` namespace
- [x] Budget control prevents `n * subset_size` from exceeding `budget`
- [x] Warning logged when budget forces `n` reduction
- [x] `abstain_rate` correctly reported (from `certify_dataset`, samples where `pA <= 0.5`)
- [x] Comparison dict includes certification results alongside existing metrics
- [x] Existing evaluation behavior unchanged when certification not enabled (no regression)
- [x] Integration test: `evaluate()` with certification in metrics list produces expected output keys
- [x] Config comments in `configs/default.yaml` explain each parameter

## Testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional certified-robustness evaluation using randomized smoothing.
  * Extended configuration with opt-in certification settings (noise level, confidence, sample counts, subset size, batch size, and compute budget).
  * Certification outputs now include certified radius stats, abstain rate, certified accuracy, certified sample count, and budget status.
  * Included certification metrics in evaluation comparisons.
* **Bug Fixes**
  * Improved comparison delta handling to avoid treating boolean fields as numeric deltas.
  * Certification now skips cleanly when the required base dataset isn’t provided.
* **Tests**
  * Added end-to-end integration tests covering enablement, skipping behavior, configuration plumbing, and budget handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->