### PR TITLE
feat(training): implement per-cycle distortion strength scheduling #111

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -46,7 +46,8 @@ distortion:
   dream_strength: 0.25   # Mild distortions for dream phase
   nightmare_strength: 0.8 # Extreme perturbations for nightmare phase (ignored for non-uniform schedules)
   strength_schedule: uniform # uniform|linear|cosine|step (within-epoch scheduling for nightmare phase)
-  strength_min: 0.3 # Min strength for non-uniform schedules
+  schedule_across_cycles: false # Enable/disable per-cycle strength scheduling (paper formula)
+  strength_min: 0.2 # Min strength for non-uniform schedules
   strength_max: 0.9 # Max strength for non-uniform schedules
   # Per-distortion type weights (probability of applying each)
   text:

--- a/nightmarenet/pipeline.py
+++ b/nightmarenet/pipeline.py
@@ -545,6 +545,11 @@ class Pipeline:
                     self._nightmare_base if self._nightmare_base is not None else self._dataset
                 )
 
+                self._dream_generator = dream_gen
+                self._nightmare_generator = nightmare_gen
+                self._dream_base_dataset = dream_base
+                self._nightmare_base_dataset = nightmare_base
+
                 dream_data = dream_gen.generate(dream_base)
                 nightmare_data = nightmare_gen.generate(nightmare_base)
 
@@ -657,6 +662,10 @@ class Pipeline:
                     nightmare_dataloader=self._nightmare_dl,
                     val_dataloader=self._val_dl,
                     on_progress=_on_train_progress,
+                    dream_generator=getattr(self, "_dream_generator", None),
+                    nightmare_generator=getattr(self, "_nightmare_generator", None),
+                    dream_base_dataset=getattr(self, "_dream_base_dataset", None),
+                    nightmare_base_dataset=getattr(self, "_nightmare_base_dataset", None),
                 )
 
                 # Update metrics from history

--- a/nightmarenet/training/trainer.py
+++ b/nightmarenet/training/trainer.py
@@ -395,6 +395,10 @@ class Trainer:
         nightmare_dataloader: DataLoader,
         val_dataloader: Optional[DataLoader] = None,
         on_progress: Optional[Callable[[dict], None]] = None,
+        dream_generator: Optional[Any] = None,
+        nightmare_generator: Optional[Any] = None,
+        dream_base_dataset: Optional[Any] = None,
+        nightmare_base_dataset: Optional[Any] = None,
     ) -> list[dict]:
         """Run the full sleep-cycle training pipeline.
 
@@ -403,6 +407,11 @@ class Trainer:
             dream_dataloader: DataLoader for dream phase (mildly distorted).
             nightmare_dataloader: DataLoader for nightmare phase (extreme perturbations).
             val_dataloader: Optional DataLoader for validation.
+            on_progress: Optional progress callback.
+            dream_generator: Optional generator for dream dataset.
+            nightmare_generator: Optional generator for nightmare dataset.
+            dream_base_dataset: Optional base dataset for dream.
+            nightmare_base_dataset: Optional base dataset for nightmare.
 
         Returns:
             List of phase result dicts (training history).
@@ -533,11 +542,69 @@ class Trainer:
                     state_path,
                 )
 
+        last_cycle_for_strength = -1
         try:
             for cycle, phase, num_epochs in self.scheduler:
                 if cycle < getattr(self, "_start_cycle", 0):
                     logger.info(f"Skipping cycle {cycle} (resuming from {self._start_cycle})")
                     continue
+
+                if cycle != last_cycle_for_strength:
+                    last_cycle_for_strength = cycle
+                    if self.config.get("distortion", {}).get("schedule_across_cycles", False):
+                        num_cycles = self.training_config.get("num_cycles", 3)
+                        distortion_config = self.config.get("distortion", {})
+                        strength_min = distortion_config.get("strength_min", 0.2)
+                        strength_max = distortion_config.get("strength_max", 0.9)
+
+                        if num_cycles > 1:
+                            diff = strength_max - strength_min
+                            cycle_strength = strength_min + diff * cycle / (num_cycles - 1)
+                        else:
+                            cycle_strength = strength_max
+
+                        logger.info(
+                            "Cycle %d: Scheduled distortion strength = %.4f",
+                            cycle + 1,
+                            cycle_strength,
+                        )
+
+                        if dream_generator is not None:
+                            dream_generator.strength = cycle_strength
+                        if nightmare_generator is not None:
+                            nightmare_generator.strength = cycle_strength
+
+                        text_column = self.config.get("dataset", {}).get("text_column", "text")
+                        max_length = self.config.get("model", {}).get("max_length", 128)
+                        batch_size = self.training_config.get("batch_size", 8)
+
+                        if dream_generator is not None and dream_base_dataset is not None:
+                            logger.info(
+                                "Regenerating dream dataset with strength %.4f",
+                                cycle_strength,
+                            )
+                            dream_data = dream_generator.generate(dream_base_dataset)
+                            dream_dataloader = _tokenize_dataset(
+                                dream_data,
+                                self.tokenizer,
+                                text_column,
+                                max_length,
+                                batch_size,
+                            )
+
+                        if nightmare_generator is not None and nightmare_base_dataset is not None:
+                            logger.info(
+                                "Regenerating nightmare dataset with strength %.4f",
+                                cycle_strength,
+                            )
+                            nightmare_data = nightmare_generator.generate(nightmare_base_dataset)
+                            nightmare_dataloader = _tokenize_dataset(
+                                nightmare_data,
+                                self.tokenizer,
+                                text_column,
+                                max_length,
+                                batch_size,
+                            )
 
                 if cycle == getattr(self, "_start_cycle", 0):
                     start_phase = getattr(self, "_start_phase", None)

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -58,7 +58,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "dream_strength": 0.25,
         "nightmare_strength": 0.8,
         "strength_schedule": "uniform",
-        "strength_min": 0.3,
+        "schedule_across_cycles": False,
+        "strength_min": 0.2,
         "strength_max": 0.9,
         "text": {
             "char_swap": 0.3,
@@ -140,6 +141,7 @@ _SCHEMA: dict[str, tuple] = {
     "distortion.dream_strength": (float, 0.0, 1.0, True),
     "distortion.nightmare_strength": (float, 0.0, 1.0, True),
     "distortion.strength_schedule": (str, None, None, False),
+    "distortion.schedule_across_cycles": (bool, None, None, False),
     "distortion.strength_min": (float, 0.0, 1.0, False),
     "distortion.strength_max": (float, 0.0, 1.0, False),
     "compression.pruning_ratio": (float, 0.0, _MAX_PRUNING_RATIO, True),

--- a/tests/test_strength_scheduler.py
+++ b/tests/test_strength_scheduler.py
@@ -1,0 +1,205 @@
+import os
+
+import torch
+from datasets import Dataset
+from torch.utils.data import DataLoader
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Configure offline mode globally to prevent HF hub connection timeouts
+os.environ["TRANSFORMERS_OFFLINE"] = "1"
+os.environ["HF_HUB_OFFLINE"] = "1"
+os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+
+from nightmarenet.data.generator import DreamDatasetGenerator, NightmareDatasetGenerator
+from nightmarenet.training.trainer import Trainer
+
+
+def _make_tiny_dataset(n: int = 10) -> Dataset:
+    texts = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Paris is the capital of France and a major city.",
+    ]
+    return Dataset.from_dict({"text": [texts[i % len(texts)] for i in range(n)]})
+
+def _tokenize_dataset(dataset: Dataset, tokenizer, max_length: int = 16):
+    def tok_fn(examples):
+        return tokenizer(
+            examples["text"],
+            truncation=True,
+            max_length=max_length,
+            padding="max_length",
+        )
+    ds = dataset.map(tok_fn, batched=True, remove_columns=["text"])
+    ds.set_format("torch")
+    return ds
+
+def _make_dataloader(dataset: Dataset, tokenizer, batch_size: int = 2):
+    tokenized = _tokenize_dataset(dataset, tokenizer)
+    return DataLoader(tokenized, batch_size=batch_size, shuffle=False)
+
+def _get_mock_model_and_tokenizer():
+    tokenizer = AutoTokenizer.from_pretrained("gpt2", local_files_only=True)
+    tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained("gpt2", local_files_only=True)
+
+    # Mock save_pretrained to write a tiny dummy file to prevent disk space issues
+    def mock_save_pretrained(save_directory, *args, **kwargs):
+        os.makedirs(save_directory, exist_ok=True)
+        with open(os.path.join(save_directory, "config.json"), "w") as f:
+            f.write("{}")
+        torch.save({}, os.path.join(save_directory, "model.pt"))
+
+    model.save_pretrained = mock_save_pretrained
+    if hasattr(model, "config") and model.config is not None:
+        model.config.save_pretrained = lambda *args, **kwargs: None
+
+    return model, tokenizer
+
+class TestStrengthScheduler:
+    """Test suite for per-cycle distortion strength scheduling."""
+
+    def test_strength_scheduling_enabled(self, tmp_path):
+        """Test that distortion strengths follow the schedule when enabled."""
+        model, tokenizer = _get_mock_model_and_tokenizer()
+        base_ds = _make_tiny_dataset(4)
+        train_loader = _make_dataloader(base_ds, tokenizer, batch_size=2)
+
+        config = {
+            "seed": 42,
+            "training": {
+                "num_cycles": 3,
+                "wake_epochs": 1,
+                "dream_epochs": 1,
+                "nightmare_epochs": 1,
+                "batch_size": 2,
+                "learning_rate": 5e-5,
+                "warmup_steps": 0,
+                "lr_schedule": "none",
+                "gradient_accumulation_steps": 1,
+                "save_every_phase": False,
+                "checkpoint_dir": str(tmp_path / "ckpt"),
+                "log_dir": str(tmp_path / "logs"),
+            },
+            "distortion": {
+                "schedule_across_cycles": True,
+                "strength_min": 0.2,
+                "strength_max": 0.9,
+                "dream_strength": 0.25,
+                "nightmare_strength": 0.8,
+            },
+            "compression": {
+                "finetune_after_prune": False,
+            }
+        }
+
+        # Track the strength values set on generators across cycles
+        dream_strengths = []
+        nightmare_strengths = []
+
+        # Create generators and hook into their strength property setters
+        dream_gen = DreamDatasetGenerator(strength=0.25)
+        nightmare_gen = NightmareDatasetGenerator(strength=0.8)
+
+        # Mock the generate methods to record strength and return a dummy dataset
+        original_dream_generate = dream_gen.generate
+        original_nightmare_generate = nightmare_gen.generate
+
+        def mock_dream_generate(dataset):
+            dream_strengths.append(dream_gen.strength)
+            return original_dream_generate(dataset)
+
+        def mock_nightmare_generate(dataset):
+            nightmare_strengths.append(nightmare_gen.strength)
+            return original_nightmare_generate(dataset)
+
+        dream_gen.generate = mock_dream_generate
+        nightmare_gen.generate = mock_nightmare_generate
+
+        trainer = Trainer(
+            model=model,
+            config=config,
+            tokenizer=tokenizer,
+        )
+
+        trainer.train(
+            train_dataloader=train_loader,
+            dream_dataloader=train_loader,
+            nightmare_dataloader=train_loader,
+            dream_generator=dream_gen,
+            nightmare_generator=nightmare_gen,
+            dream_base_dataset=base_ds,
+            nightmare_base_dataset=base_ds,
+        )
+
+        # Formula: 0.2 + (0.9 - 0.2) * cycle / (3 - 1)
+        # Cycle 0: 0.2
+        # Cycle 1: 0.55
+        # Cycle 2: 0.9
+        assert len(dream_strengths) == 3
+        assert len(nightmare_strengths) == 3
+
+        # Test values are close to formula computed values
+        assert abs(dream_strengths[0] - 0.2) < 1e-5
+        assert abs(dream_strengths[1] - 0.55) < 1e-5
+        assert abs(dream_strengths[2] - 0.9) < 1e-5
+
+        assert abs(nightmare_strengths[0] - 0.2) < 1e-5
+        assert abs(nightmare_strengths[1] - 0.55) < 1e-5
+        assert abs(nightmare_strengths[2] - 0.9) < 1e-5
+
+    def test_strength_scheduling_disabled(self, tmp_path):
+        """Test that distortion strengths remain static when disabled."""
+        model, tokenizer = _get_mock_model_and_tokenizer()
+        base_ds = _make_tiny_dataset(4)
+        train_loader = _make_dataloader(base_ds, tokenizer, batch_size=2)
+
+        config = {
+            "seed": 42,
+            "training": {
+                "num_cycles": 2,
+                "wake_epochs": 1,
+                "dream_epochs": 1,
+                "nightmare_epochs": 1,
+                "batch_size": 2,
+                "learning_rate": 5e-5,
+                "warmup_steps": 0,
+                "lr_schedule": "none",
+                "gradient_accumulation_steps": 1,
+                "save_every_phase": False,
+                "checkpoint_dir": str(tmp_path / "ckpt"),
+                "log_dir": str(tmp_path / "logs"),
+            },
+            "distortion": {
+                "schedule_across_cycles": False,
+                "strength_min": 0.2,
+                "strength_max": 0.9,
+                "dream_strength": 0.25,
+                "nightmare_strength": 0.8,
+            },
+            "compression": {
+                "finetune_after_prune": False,
+            }
+        }
+
+        dream_gen = DreamDatasetGenerator(strength=0.25)
+        nightmare_gen = NightmareDatasetGenerator(strength=0.8)
+
+        trainer = Trainer(
+            model=model,
+            config=config,
+            tokenizer=tokenizer,
+        )
+
+        trainer.train(
+            train_dataloader=train_loader,
+            dream_dataloader=train_loader,
+            nightmare_dataloader=train_loader,
+            dream_generator=dream_gen,
+            nightmare_generator=nightmare_gen,
+            dream_base_dataset=base_ds,
+            nightmare_base_dataset=base_ds,
+        )
+
+        # Stays at configured default strengths
+        assert dream_gen.strength == 0.25
+        assert nightmare_gen.strength == 0.8


### PR DESCRIPTION
## Summary

This PR implements per-cycle distortion strength scheduling (curriculum training) for the SleepCycle training loops. Early training cycles utilize mild distortions, which progressively increase in harshness up to the maximum specified strength in later cycles.

## Motivation

Paper Section 3.3 specifies a per-cycle distortion strength schedule:
s^(c) = s_min + (s_max - s_min) * (c-1) / (C-1)
This enables curriculum training to improve model stability and general robustness, but the codebase previously used a static nightmare_strength across all training cycles.

Closes #111

## Changes

- configs/default.yaml: Added distortion.schedule_across_cycles (defaulting to false) and updated strength_min default to 0.2.
- nightmarenet/utils/config.py: Added distortion.schedule_across_cycles to configuration schema and validators, and updated default strength_min to 0.2.
- nightmarenet/training/trainer.py: Added optional arguments to Trainer.train for base datasets and generators, calculated cycle_strength at the beginning of each cycle, updated generator strengths, and dynamically regenerated/re-tokenized the dream and nightmare dataloaders per cycle.
- nightmarenet/pipeline.py: Maintained generator and base dataset instances as Pipeline properties during prepare and passed them to Trainer.train.
- tests/test_strength_scheduler.py: Created unit tests verifying scheduled strength progression, config toggle backward compatibility, and correct dataset regeneration.

## Acceptance Criteria

- [x] Per-cycle strength computed using the paper formula
- [x] Early cycles use lower strength, later cycles use higher
- [x] Config distortion.schedule_across_cycles toggles the feature
- [x] Default is false (backward compatible)
- [x] Test: 3-cycle run produces different nightmare strengths per cycle
- [x] Strength values logged per cycle for verification

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to schedule distortion strength progressively across training cycles.
  * Distortion strength can now be adjusted automatically between configured minimum and maximum values.
  * Added support for regenerating training data as distortion strength changes.

* **Configuration**
  * Added `schedule_across_cycles`, disabled by default.
  * Lowered the default minimum distortion strength from `0.3` to `0.2`.

* **Tests**
  * Added coverage for enabled and disabled distortion-strength scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->