### PR TITLE
Add semantic experiment history search

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -151,6 +151,37 @@ describe("API module", () => {
     });
   });
 
+  describe("searchExperiments", () => {
+    it("posts natural-language queries to /api/v1/search", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [{ run_id: "exp-47", relevance_score: 0.87, summary: "match", metadata: {} }],
+          filters: { status: "completed" },
+          backend: "faiss",
+        }),
+      });
+
+      const { searchExperiments } = await import("@/lib/api");
+      const result = await searchExperiments("robustness improved", 5, {
+        status: "completed",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/search",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            query: "robustness improved",
+            top_k: 5,
+            filters: { status: "completed" },
+          }),
+        })
+      );
+      expect(result.results[0].run_id).toBe("exp-47");
+    });
+  });
+
   describe("error handling", () => {
     it("extracts detail from error response", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/frontend/src/components/dashboard/ExperimentList.tsx
+++ b/frontend/src/components/dashboard/ExperimentList.tsx
@@ -281,8 +281,8 @@ export function ExperimentList({
 
   useEffect(() => {
     const trimmed = query.trim();
+    setSemanticIds(null);
     if (trimmed.length < 3) {
-      setSemanticIds(null);
       setSemanticPending(false);
       setSemanticError(false);
       return;

--- a/frontend/src/components/dashboard/ExperimentList.tsx
+++ b/frontend/src/components/dashboard/ExperimentList.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { SkeletonRows } from "@/components/ui/Skeleton";
 import { useToast } from "@/components/ui/Toast";
+import { searchExperiments } from "@/lib/api";
 import {
   IconBeaker,
   IconDownload,
@@ -269,24 +270,76 @@ export function ExperimentList({
 }: ExperimentListProps = {}) {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<"all" | Experiment["status"]>("all");
+  const [semanticIds, setSemanticIds] = useState<string[] | null>(null);
+  const [semanticPending, setSemanticPending] = useState(false);
+  const [semanticError, setSemanticError] = useState(false);
   const toast = useToast();
 
   // `experiments` defaults to the demo sample — callers can pass `[]` to
   // exercise the empty state, or a real dataset once the runs API is wired.
   const source = experiments ?? SAMPLE;
 
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 3) {
+      setSemanticIds(null);
+      setSemanticPending(false);
+      setSemanticError(false);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      const statusFilter =
+        filter === "all"
+          ? undefined
+          : { status: filter === "complete" ? "completed" : filter };
+      setSemanticPending(true);
+      setSemanticError(false);
+      searchExperiments(trimmed, 12, statusFilter)
+        .then((response) => {
+          if (cancelled) return;
+          setSemanticIds(response.results.map((result) => result.run_id));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setSemanticIds(null);
+          setSemanticError(true);
+        })
+        .finally(() => {
+          if (!cancelled) setSemanticPending(false);
+        });
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [query, filter]);
+
   const rows = useMemo(() => {
-    return source.filter((r) => {
-      if (filter !== "all" && r.status !== filter) return false;
-      if (!query.trim()) return true;
-      const q = query.toLowerCase();
-      return (
-        r.name.toLowerCase().includes(q) ||
-        r.id.toLowerCase().includes(q) ||
-        r.model.toLowerCase().includes(q)
-      );
-    });
-  }, [query, filter, source]);
+    const semanticRank = new Map((semanticIds ?? []).map((id, idx) => [id, idx]));
+    return source
+      .filter((r) => {
+        if (filter !== "all" && r.status !== filter) return false;
+        if (!query.trim()) return true;
+        if (semanticRank.has(r.id)) return true;
+        const q = query.toLowerCase();
+        return (
+          r.name.toLowerCase().includes(q) ||
+          r.id.toLowerCase().includes(q) ||
+          r.model.toLowerCase().includes(q)
+        );
+      })
+      .sort((a, b) => {
+        const aRank = semanticRank.get(a.id);
+        const bRank = semanticRank.get(b.id);
+        if (aRank === undefined && bRank === undefined) return 0;
+        if (aRank === undefined) return 1;
+        if (bRank === undefined) return -1;
+        return aRank - bRank;
+      });
+  }, [query, filter, source, semanticIds]);
 
   const sourceEmpty = source.length === 0;
 
@@ -405,8 +458,9 @@ export function ExperimentList({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             leftIcon={<IconSearch size={12} />}
-            containerClassName="w-44"
+            containerClassName="w-56"
             className="!py-1.5 !text-xs"
+            aria-label="Search experiments"
           />
           <Select
             size="sm"
@@ -446,6 +500,13 @@ export function ExperimentList({
       }
       bodyClassName={loading || sourceEmpty ? "px-4 py-4" : "px-0 py-0"}
     >
+      {semanticPending || semanticError ? (
+        <div className="border-b border-white/[0.06] px-4 py-2 text-[11px] text-slate-400">
+          {semanticPending
+            ? "Searching experiment meaning..."
+            : "Semantic search unavailable; using local matches."}
+        </div>
+      ) : null}
       {loading ? (
         <SkeletonRows rows={6} />
       ) : sourceEmpty ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -582,6 +582,32 @@ export function suggestConfig(body: SuggestConfigRequest): Promise<SuggestConfig
   });
 }
 
+// --- Experiment Search ---
+
+export interface ExperimentSearchResult {
+  run_id: string;
+  relevance_score: number;
+  summary: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface ExperimentSearchResponse {
+  results: ExperimentSearchResult[];
+  filters: Record<string, unknown>;
+  backend: string;
+}
+
+export function searchExperiments(
+  query: string,
+  topK = 10,
+  filters?: Record<string, unknown>,
+): Promise<ExperimentSearchResponse> {
+  return apiFetch<ExperimentSearchResponse>("/api/v1/search", {
+    method: "POST",
+    body: JSON.stringify({ query, top_k: topK, filters: filters ?? {} }),
+  });
+}
+
 // --- Adaption Labs: Import & Estimate ---
 
 export function importAndOptimize(body: DataImportRequest): Promise<DataOptimizeResponse> {

--- a/nightmarenet_server/app.py
+++ b/nightmarenet_server/app.py
@@ -147,6 +147,19 @@ def _attach_api_key_routes(app: Any) -> None:
     app.include_router(router)
 
 
+def _attach_search(app: Any) -> None:
+    try:
+        from nightmarenet_server.search.endpoints import build_search_router
+    except ImportError:
+        logger.info("Search router unavailable; skipping.")
+        return
+    router = build_search_router()
+    if router is None:
+        logger.info("Search router not constructed (missing optional deps).")
+        return
+    app.include_router(router)
+
+
 def _init_db_safe() -> None:
     """Best-effort init_db; never crash app startup."""
     try:
@@ -209,6 +222,7 @@ def create_app() -> Optional[Any]:
     _attach_oauth(app)
     _attach_realtime(app)
     _attach_api_key_routes(app)
+    _attach_search(app)
 
     if core_app is not None:
         app.mount("/", core_app)

--- a/nightmarenet_server/search/__init__.py
+++ b/nightmarenet_server/search/__init__.py
@@ -1,0 +1,11 @@
+"""Semantic experiment search for the hosted NightmareNet server."""
+
+from nightmarenet_server.search.embedder import ExperimentDocument, ExperimentEmbedder
+from nightmarenet_server.search.index import SearchHit, SearchIndex
+
+__all__ = [
+    "ExperimentDocument",
+    "ExperimentEmbedder",
+    "SearchHit",
+    "SearchIndex",
+]

--- a/nightmarenet_server/search/embedder.py
+++ b/nightmarenet_server/search/embedder.py
@@ -1,0 +1,219 @@
+"""Experiment metadata embedding helpers.
+
+The production path uses ``sentence-transformers/all-MiniLM-L6-v2`` when it is
+installed. A deterministic hashing fallback keeps the OSS test suite and local
+development usable without downloading model weights.
+"""
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+import numpy as np
+
+EMBEDDING_DIM = 384
+DEFAULT_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+@dataclass
+class ExperimentDocument:
+    """Structured representation of a run ready for embedding."""
+
+    run_id: str
+    experiment_id: str = ""
+    name: str = ""
+    model: str = ""
+    status: str = ""
+    phase: str = ""
+    config: Dict[str, Any] = field(default_factory=dict)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    audit_logs: List[Dict[str, Any]] = field(default_factory=list)
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+
+    def metadata(self) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "experiment_id": self.experiment_id,
+            "name": self.name,
+            "model": self.model,
+            "status": self.status,
+            "phase": self.phase,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "metrics": self.metrics,
+            "config": self.config,
+        }
+
+
+def _json_loads(raw: Optional[str]) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, default=str, separators=(",", ":"))
+
+
+def _flatten(prefix: str, value: Any) -> Iterable[str]:
+    if isinstance(value, dict):
+        for key in sorted(value):
+            child = f"{prefix}.{key}" if prefix else str(key)
+            yield from _flatten(child, value[key])
+    elif isinstance(value, list):
+        for item in value:
+            yield from _flatten(prefix, item)
+    else:
+        yield f"{prefix}: {value}"
+
+
+def _normalize(vec: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(vec))
+    if norm == 0.0:
+        return vec
+    return vec / norm
+
+
+class ExperimentEmbedder:
+    """Create 384-dimensional embeddings for experiment runs and queries."""
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL_NAME,
+        dimension: int = EMBEDDING_DIM,
+        model: Optional[Any] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.dimension = dimension
+        self._model = None if model is False else model
+        self._attempted_model_load = model is not None
+
+    def embed_run(self, run: ExperimentDocument) -> np.ndarray:
+        return self.embed_text(self.serialize_run(run))
+
+    def embed_query(self, query: str) -> np.ndarray:
+        return self.embed_text(query)
+
+    def embed_text(self, text: str) -> np.ndarray:
+        model = self._load_model()
+        if model is not None:
+            vector = model.encode([text], normalize_embeddings=True)[0]
+            return np.asarray(vector, dtype=np.float32)
+        return self._hash_embedding(text)
+
+    def serialize_run(self, run: ExperimentDocument) -> str:
+        sections = [
+            f"run_id: {run.run_id}",
+            f"experiment_id: {run.experiment_id}",
+            f"name: {run.name}",
+            f"model: {run.model}",
+            f"status: {run.status}",
+            f"phase: {run.phase}",
+            f"created_at: {run.created_at}",
+            f"started_at: {run.started_at}",
+            f"completed_at: {run.completed_at}",
+            "config:",
+            *list(_flatten("", run.config)),
+            "metrics:",
+            *list(_flatten("", run.metrics)),
+            "events:",
+            *[
+                f"{event.get('event_type', event.get('type', 'event'))}: "
+                f"{_stable_json(event.get('payload', event))}"
+                for event in run.events
+            ],
+            "audit:",
+            *[
+                f"{log.get('action', 'audit')} {log.get('resource_type', '')} "
+                f"{log.get('resource_id', '')}: {_stable_json(log.get('metadata', log))}"
+                for log in run.audit_logs
+            ],
+        ]
+        return "\n".join(str(s) for s in sections if s is not None)
+
+    def _load_model(self) -> Optional[Any]:
+        if self._attempted_model_load:
+            return self._model
+        self._attempted_model_load = True
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            self._model = None
+            return None
+        self._model = SentenceTransformer(self.model_name, device="cpu")
+        return self._model
+
+    def _hash_embedding(self, text: str) -> np.ndarray:
+        vec = np.zeros(self.dimension, dtype=np.float32)
+        tokens = [t for t in text.lower().replace("_", " ").replace("-", " ").split() if t]
+        for token in tokens:
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=16).digest()
+            idx = int.from_bytes(digest[:4], "little") % self.dimension
+            sign = 1.0 if digest[4] % 2 == 0 else -1.0
+            weight = 1.0 + math.log1p(len(token))
+            vec[idx] += sign * weight
+        if not tokens:
+            digest = hashlib.blake2b(text.encode("utf-8"), digest_size=16).digest()
+            vec[int.from_bytes(digest[:4], "little") % self.dimension] = 1.0
+        return _normalize(vec).astype(np.float32)
+
+
+def document_from_orm(
+    run: Any,
+    experiment: Optional[Any] = None,
+    audit_logs: Optional[List[Any]] = None,
+) -> ExperimentDocument:
+    """Build an :class:`ExperimentDocument` from SQLAlchemy rows."""
+    experiment = experiment or getattr(run, "experiment", None)
+    events = []
+    for event in getattr(run, "events", []) or []:
+        events.append(
+            {
+                "event_type": getattr(event, "event_type", ""),
+                "payload": _json_loads(getattr(event, "payload_json", "{}")),
+                "timestamp": str(getattr(event, "timestamp", "")),
+            }
+        )
+    logs = []
+    for log in audit_logs or []:
+        logs.append(
+            {
+                "action": getattr(log, "action", ""),
+                "resource_type": getattr(log, "resource_type", ""),
+                "resource_id": getattr(log, "resource_id", ""),
+                "metadata": _json_loads(getattr(log, "metadata_json", "{}")),
+                "timestamp": str(getattr(log, "timestamp", "")),
+            }
+        )
+    config = _json_loads(getattr(experiment, "config_json", "{}")) if experiment else {}
+    metrics = _json_loads(getattr(run, "metrics_json", "{}"))
+    return ExperimentDocument(
+        run_id=getattr(run, "id", ""),
+        experiment_id=getattr(run, "experiment_id", ""),
+        name=getattr(experiment, "name", "") if experiment else "",
+        model=str(
+            config.get("model_name")
+            or config.get("model")
+            or config.get("model_type")
+            or ""
+        ),
+        status=getattr(run, "status", ""),
+        phase=getattr(run, "phase", ""),
+        config=config,
+        metrics=metrics,
+        events=events,
+        audit_logs=logs,
+        started_at=str(getattr(run, "started_at", "") or ""),
+        completed_at=str(getattr(run, "completed_at", "") or ""),
+        created_at=str(getattr(experiment, "created_at", "") or ""),
+    )

--- a/nightmarenet_server/search/endpoints.py
+++ b/nightmarenet_server/search/endpoints.py
@@ -1,5 +1,6 @@
 """FastAPI endpoint for natural-language experiment search."""
 
+import logging
 import os
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
@@ -19,6 +20,8 @@ except ImportError:
 from nightmarenet_server.search.embedder import ExperimentEmbedder
 from nightmarenet_server.search.index import SearchIndex
 from nightmarenet_server.search.query_parser import parse_query
+
+logger = logging.getLogger(__name__)
 
 if _FASTAPI_AVAILABLE:
 
@@ -64,7 +67,8 @@ def build_search_router() -> Optional[Any]:
             embedding = get_embedder().embed_query(parsed.text)
             hits = get_index().hybrid_search(embedding, filters=filters, top_k=body.top_k)
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=f"search failed: {exc}") from exc
+            logger.exception("Experiment search failed")
+            raise HTTPException(status_code=500, detail="Internal server error.") from exc
         return SearchResponse(
             results=[
                 SearchResult(

--- a/nightmarenet_server/search/endpoints.py
+++ b/nightmarenet_server/search/endpoints.py
@@ -1,0 +1,95 @@
+"""FastAPI endpoint for natural-language experiment search."""
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+try:
+    from fastapi import APIRouter, HTTPException
+    from pydantic import BaseModel, Field
+
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    APIRouter = None  # type: ignore[assignment,misc]
+    HTTPException = None  # type: ignore[assignment,misc]
+    BaseModel = object  # type: ignore[assignment,misc]
+    Field = None  # type: ignore[assignment,misc]
+    _FASTAPI_AVAILABLE = False
+
+from nightmarenet_server.search.embedder import ExperimentEmbedder
+from nightmarenet_server.search.index import SearchIndex
+from nightmarenet_server.search.query_parser import parse_query
+
+if _FASTAPI_AVAILABLE:
+
+    class SearchRequest(BaseModel):
+        query: str = Field(..., min_length=1, max_length=1000)
+        top_k: int = Field(10, ge=1, le=50)
+        filters: Dict[str, Any] = Field(default_factory=dict)
+
+    class SearchResult(BaseModel):
+        run_id: str
+        relevance_score: float
+        summary: str
+        metadata: Dict[str, Any]
+
+    class SearchResponse(BaseModel):
+        results: List[SearchResult]
+        filters: Dict[str, Any]
+        backend: str
+
+
+@lru_cache(maxsize=1)
+def get_embedder() -> ExperimentEmbedder:
+    return ExperimentEmbedder()
+
+
+@lru_cache(maxsize=1)
+def get_index() -> SearchIndex:
+    backend = os.environ.get("NIGHTMARENET_SEARCH_BACKEND", "faiss")
+    return SearchIndex(backend=backend)
+
+
+def build_search_router() -> Optional[Any]:
+    if not _FASTAPI_AVAILABLE:
+        return None
+
+    router = APIRouter(prefix="/api/v1/search", tags=["search"])
+
+    @router.post("", response_model=SearchResponse)
+    async def search(body: SearchRequest) -> SearchResponse:
+        parsed = parse_query(body.query)
+        filters = {**parsed.filters, **body.filters}
+        try:
+            embedding = get_embedder().embed_query(parsed.text)
+            hits = get_index().hybrid_search(embedding, filters=filters, top_k=body.top_k)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"search failed: {exc}") from exc
+        return SearchResponse(
+            results=[
+                SearchResult(
+                    run_id=hit.run_id,
+                    relevance_score=round(hit.score, 6),
+                    summary=_summary(hit.metadata),
+                    metadata=hit.metadata,
+                )
+                for hit in hits
+            ],
+            filters=filters,
+            backend=get_index().backend,
+        )
+
+    return router
+
+
+def _summary(metadata: Dict[str, Any]) -> str:
+    name = metadata.get("name") or metadata.get("run_id") or "experiment"
+    model = metadata.get("model") or "unknown model"
+    status = metadata.get("status") or "unknown"
+    metrics = metadata.get("metrics") or {}
+    metric_bits = []
+    for key in ("accuracy", "robustness", "robustness_score", "loss"):
+        if key in metrics:
+            metric_bits.append(f"{key}={metrics[key]}")
+    suffix = f" ({', '.join(metric_bits)})" if metric_bits else ""
+    return f"{name} on {model} is {status}{suffix}."

--- a/nightmarenet_server/search/index.py
+++ b/nightmarenet_server/search/index.py
@@ -1,14 +1,19 @@
 """Persistent vector index for experiment search."""
 
 import json
+import logging
 import os
+import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
 from nightmarenet_server.search.embedder import EMBEDDING_DIM
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -46,45 +51,44 @@ class SearchIndex:
         self._faiss: Optional[Any] = None
         self._faiss_index: Optional[Any] = None
         self._faiss_ids: List[str] = []
+        self._lock = threading.RLock()
         self._load()
 
     def add(self, run_id: str, embedding: np.ndarray, metadata: Dict[str, Any]) -> None:
         vector = _normalize(np.asarray(embedding, dtype=np.float32))
         if vector.shape != (self.dimension,):
             raise ValueError(f"expected embedding shape {(self.dimension,)}, got {vector.shape}")
-        self._records[run_id] = {"run_id": run_id, "metadata": metadata}
-        self._vectors[run_id] = vector
-        self._rebuild_faiss()
-        self.persist()
+        with self._lock:
+            self._records[run_id] = {"run_id": run_id, "metadata": metadata}
+            self._vectors[run_id] = vector
+            self._rebuild_faiss()
+            self.persist()
 
     def delete(self, run_id: str) -> None:
-        self._records.pop(run_id, None)
-        self._vectors.pop(run_id, None)
-        self._rebuild_faiss()
-        self.persist()
+        with self._lock:
+            self._records.pop(run_id, None)
+            self._vectors.pop(run_id, None)
+            self._rebuild_faiss()
+            self.persist()
 
     def search(self, query_embedding: np.ndarray, top_k: int = 10) -> List[SearchHit]:
-        if not self._vectors:
-            return []
-        query = _normalize(np.asarray(query_embedding, dtype=np.float32))
-        if self._faiss_index is not None:
-            scores, idxs = self._faiss_index.search(
-                query.reshape(1, -1),
-                min(top_k, len(self._faiss_ids)),
-            )
-            hits = []
-            for score, idx in zip(scores[0], idxs[0]):
-                if idx < 0:
-                    continue
-                run_id = self._faiss_ids[int(idx)]
-                hits.append(SearchHit(run_id, float(score), self._records[run_id]["metadata"]))
-            return hits
-        scored = [
-            SearchHit(run_id, float(np.dot(query, vector)), self._records[run_id]["metadata"])
-            for run_id, vector in self._vectors.items()
-        ]
-        scored.sort(key=lambda hit: hit.score, reverse=True)
-        return scored[:top_k]
+        with self._lock:
+            if not self._vectors:
+                return []
+            query = _normalize(np.asarray(query_embedding, dtype=np.float32))
+            if self._faiss_index is not None:
+                scores, idxs = self._faiss_index.search(
+                    query.reshape(1, -1),
+                    min(top_k, len(self._faiss_ids)),
+                )
+                hits = []
+                for score, idx in zip(scores[0], idxs[0]):
+                    if idx < 0:
+                        continue
+                    run_id = self._faiss_ids[int(idx)]
+                    hits.append(SearchHit(run_id, float(score), self._records[run_id]["metadata"]))
+                return hits
+            return self._rank_candidates(query, list(self._vectors.items()), top_k)
 
     def hybrid_search(
         self,
@@ -93,47 +97,95 @@ class SearchIndex:
         top_k: int = 10,
     ) -> List[SearchHit]:
         filters = filters or {}
-        pool = self.search(query_embedding, top_k=max(top_k * 4, top_k))
-        hits = [hit for hit in pool if _matches_filters(hit.metadata, filters)]
-        return hits[:top_k]
+        with self._lock:
+            query = _normalize(np.asarray(query_embedding, dtype=np.float32))
+            candidates = [
+                (run_id, vector)
+                for run_id, vector in self._vectors.items()
+                if _matches_filters(self._records[run_id]["metadata"], filters)
+            ]
+            return self._rank_candidates(query, candidates, top_k)
 
     def persist(self) -> None:
-        payload = {
-            "dimension": self.dimension,
-            "records": self._records,
-            "vectors": {run_id: vector.tolist() for run_id, vector in self._vectors.items()},
-        }
-        (self.path / "index.json").write_text(json.dumps(payload, default=str), encoding="utf-8")
+        with self._lock:
+            payload = {
+                "dimension": self.dimension,
+                "records": self._records,
+                "vectors": {run_id: vector.tolist() for run_id, vector in self._vectors.items()},
+            }
+            target = self.path / "index.json"
+            fd, tmp_name = tempfile.mkstemp(
+                prefix="index.",
+                suffix=".tmp",
+                dir=str(self.path),
+                text=True,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+                    tmp.write(json.dumps(payload, default=str))
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                os.replace(tmp_name, target)
+            except Exception:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
 
     def _load(self) -> None:
-        index_path = self.path / "index.json"
-        if not index_path.exists():
+        with self._lock:
+            index_path = self.path / "index.json"
+            if not index_path.exists():
+                self._rebuild_faiss()
+                return
+            try:
+                payload = json.loads(index_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, ValueError):
+                logger.exception("Search index could not be loaded; starting with an empty index")
+                self._records = {}
+                self._vectors = {}
+                self._rebuild_faiss()
+                return
+            self.dimension = int(payload.get("dimension", self.dimension))
+            self._records = dict(payload.get("records", {}))
+            self._vectors = {
+                run_id: _normalize(np.asarray(vector, dtype=np.float32))
+                for run_id, vector in payload.get("vectors", {}).items()
+            }
             self._rebuild_faiss()
-            return
-        payload = json.loads(index_path.read_text(encoding="utf-8"))
-        self.dimension = int(payload.get("dimension", self.dimension))
-        self._records = dict(payload.get("records", {}))
-        self._vectors = {
-            run_id: _normalize(np.asarray(vector, dtype=np.float32))
-            for run_id, vector in payload.get("vectors", {}).items()
-        }
-        self._rebuild_faiss()
 
     def _rebuild_faiss(self) -> None:
-        self._faiss_index = None
-        self._faiss_ids = list(self._vectors.keys())
-        if self.backend != "faiss" or not self._faiss_ids:
-            return
-        try:
-            import faiss
-        except ImportError:
-            self._faiss = None
-            return
-        self._faiss = faiss
-        index = faiss.IndexFlatIP(self.dimension)
-        matrix = np.vstack([self._vectors[run_id] for run_id in self._faiss_ids]).astype(np.float32)
-        index.add(matrix)
-        self._faiss_index = index
+        with self._lock:
+            self._faiss_index = None
+            self._faiss_ids = list(self._vectors.keys())
+            if self.backend != "faiss" or not self._faiss_ids:
+                return
+            try:
+                import faiss
+            except ImportError:
+                self._faiss = None
+                return
+            self._faiss = faiss
+            index = faiss.IndexFlatIP(self.dimension)
+            matrix = np.vstack([self._vectors[run_id] for run_id in self._faiss_ids]).astype(
+                np.float32
+            )
+            index.add(matrix)
+            self._faiss_index = index
+
+    def _rank_candidates(
+        self,
+        query: np.ndarray,
+        candidates: List[Tuple[str, np.ndarray]],
+        top_k: int,
+    ) -> List[SearchHit]:
+        scored = [
+            SearchHit(run_id, float(np.dot(query, vector)), self._records[run_id]["metadata"])
+            for run_id, vector in candidates
+        ]
+        scored.sort(key=lambda hit: hit.score, reverse=True)
+        return scored[:top_k]
 
 
 def _lookup_metric(metrics: Dict[str, Any], field: str) -> Optional[float]:

--- a/nightmarenet_server/search/index.py
+++ b/nightmarenet_server/search/index.py
@@ -1,0 +1,187 @@
+"""Persistent vector index for experiment search."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from nightmarenet_server.search.embedder import EMBEDDING_DIM
+
+
+@dataclass
+class SearchHit:
+    run_id: str
+    score: float
+    metadata: Dict[str, Any]
+
+
+def _normalize(vector: np.ndarray) -> np.ndarray:
+    vector = np.asarray(vector, dtype=np.float32)
+    norm = float(np.linalg.norm(vector))
+    if norm == 0.0:
+        return vector
+    return vector / norm
+
+
+class SearchIndex:
+    """FAISS-backed index with a NumPy fallback and disk persistence."""
+
+    def __init__(
+        self,
+        backend: str = "faiss",
+        path: Optional[str] = None,
+        dimension: int = EMBEDDING_DIM,
+    ) -> None:
+        self.backend = backend
+        self.dimension = dimension
+        self.path = Path(
+            path or os.environ.get("NIGHTMARENET_SEARCH_INDEX", ".nightmarenet_search")
+        )
+        self.path.mkdir(parents=True, exist_ok=True)
+        self._records: Dict[str, Dict[str, Any]] = {}
+        self._vectors: Dict[str, np.ndarray] = {}
+        self._faiss: Optional[Any] = None
+        self._faiss_index: Optional[Any] = None
+        self._faiss_ids: List[str] = []
+        self._load()
+
+    def add(self, run_id: str, embedding: np.ndarray, metadata: Dict[str, Any]) -> None:
+        vector = _normalize(np.asarray(embedding, dtype=np.float32))
+        if vector.shape != (self.dimension,):
+            raise ValueError(f"expected embedding shape {(self.dimension,)}, got {vector.shape}")
+        self._records[run_id] = {"run_id": run_id, "metadata": metadata}
+        self._vectors[run_id] = vector
+        self._rebuild_faiss()
+        self.persist()
+
+    def delete(self, run_id: str) -> None:
+        self._records.pop(run_id, None)
+        self._vectors.pop(run_id, None)
+        self._rebuild_faiss()
+        self.persist()
+
+    def search(self, query_embedding: np.ndarray, top_k: int = 10) -> List[SearchHit]:
+        if not self._vectors:
+            return []
+        query = _normalize(np.asarray(query_embedding, dtype=np.float32))
+        if self._faiss_index is not None:
+            scores, idxs = self._faiss_index.search(
+                query.reshape(1, -1),
+                min(top_k, len(self._faiss_ids)),
+            )
+            hits = []
+            for score, idx in zip(scores[0], idxs[0]):
+                if idx < 0:
+                    continue
+                run_id = self._faiss_ids[int(idx)]
+                hits.append(SearchHit(run_id, float(score), self._records[run_id]["metadata"]))
+            return hits
+        scored = [
+            SearchHit(run_id, float(np.dot(query, vector)), self._records[run_id]["metadata"])
+            for run_id, vector in self._vectors.items()
+        ]
+        scored.sort(key=lambda hit: hit.score, reverse=True)
+        return scored[:top_k]
+
+    def hybrid_search(
+        self,
+        query_embedding: np.ndarray,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+    ) -> List[SearchHit]:
+        filters = filters or {}
+        pool = self.search(query_embedding, top_k=max(top_k * 4, top_k))
+        hits = [hit for hit in pool if _matches_filters(hit.metadata, filters)]
+        return hits[:top_k]
+
+    def persist(self) -> None:
+        payload = {
+            "dimension": self.dimension,
+            "records": self._records,
+            "vectors": {run_id: vector.tolist() for run_id, vector in self._vectors.items()},
+        }
+        (self.path / "index.json").write_text(json.dumps(payload, default=str), encoding="utf-8")
+
+    def _load(self) -> None:
+        index_path = self.path / "index.json"
+        if not index_path.exists():
+            self._rebuild_faiss()
+            return
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+        self.dimension = int(payload.get("dimension", self.dimension))
+        self._records = dict(payload.get("records", {}))
+        self._vectors = {
+            run_id: _normalize(np.asarray(vector, dtype=np.float32))
+            for run_id, vector in payload.get("vectors", {}).items()
+        }
+        self._rebuild_faiss()
+
+    def _rebuild_faiss(self) -> None:
+        self._faiss_index = None
+        self._faiss_ids = list(self._vectors.keys())
+        if self.backend != "faiss" or not self._faiss_ids:
+            return
+        try:
+            import faiss
+        except ImportError:
+            self._faiss = None
+            return
+        self._faiss = faiss
+        index = faiss.IndexFlatIP(self.dimension)
+        matrix = np.vstack([self._vectors[run_id] for run_id in self._faiss_ids]).astype(np.float32)
+        index.add(matrix)
+        self._faiss_index = index
+
+
+def _lookup_metric(metrics: Dict[str, Any], field: str) -> Optional[float]:
+    parts = field.split(".")
+    value: Any = metrics
+    for part in parts:
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _contains_term(value: Any, term: str) -> bool:
+    return term in json.dumps(value, default=str).lower()
+
+
+def _matches_filters(metadata: Dict[str, Any], filters: Dict[str, Any]) -> bool:
+    status = filters.get("status")
+    if status and str(metadata.get("status", "")).lower() != str(status).lower():
+        return False
+    model = filters.get("model")
+    if model and str(model).lower() not in str(metadata.get("model", "")).lower():
+        return False
+    created_after = filters.get("created_after")
+    if created_after and str(metadata.get("created_at", "")) < str(created_after):
+        return False
+    for term in filters.get("exclude_terms", []):
+        if _contains_term(metadata, str(term).lower()):
+            return False
+    for metric_filter in filters.get("metrics", []):
+        actual = _lookup_metric(metadata.get("metrics", {}), metric_filter["field"])
+        if actual is None:
+            actual = _lookup_metric(metadata.get("config", {}), metric_filter["field"])
+        if actual is None or not _compare(actual, metric_filter["op"], metric_filter["value"]):
+            return False
+    return True
+
+
+def _compare(actual: float, op: str, expected: float) -> bool:
+    if op == ">":
+        return actual > expected
+    if op == ">=":
+        return actual >= expected
+    if op == "<":
+        return actual < expected
+    if op == "<=":
+        return actual <= expected
+    return actual == expected

--- a/nightmarenet_server/search/query_parser.py
+++ b/nightmarenet_server/search/query_parser.py
@@ -1,0 +1,70 @@
+"""Natural-language search query parsing."""
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+
+@dataclass
+class ParsedQuery:
+    text: str
+    filters: Dict[str, Any] = field(default_factory=dict)
+    terms: List[str] = field(default_factory=list)
+
+
+_STATUS_RE = re.compile(r"\b(completed|complete|failed|running|queued|pending)\b", re.I)
+_MODEL_RE = re.compile(r"\b(?:model|using|used)\s+([A-Za-z0-9_.\-/]+)", re.I)
+_METRIC_RE = re.compile(
+    r"\b([A-Za-z_][A-Za-z0-9_.-]*(?:\s+[A-Za-z_][A-Za-z0-9_.-]*)?)"
+    r"\s*(>=|<=|>|<|=)\s*(-?\d+(?:\.\d+)?)",
+    re.I,
+)
+_FIELD_PREFIXES = {"and", "or", "where", "with", "having", "whose"}
+
+
+def _normalize_field(raw: str) -> str:
+    parts = raw.lower().split()
+    while len(parts) > 1 and parts[0] in _FIELD_PREFIXES:
+        parts = parts[1:]
+    return "_".join(parts)
+
+
+def parse_query(query: str) -> ParsedQuery:
+    """Extract lightweight structured filters from natural language."""
+    filters: Dict[str, Any] = {}
+    terms: List[str] = []
+    raw = query.strip()
+
+    status_match = _STATUS_RE.search(raw)
+    if status_match:
+        status = status_match.group(1).lower()
+        filters["status"] = "completed" if status == "complete" else status
+
+    model_match = _MODEL_RE.search(raw)
+    if model_match:
+        filters["model"] = model_match.group(1).lower()
+
+    metrics = []
+    for metric, op, raw_value in _METRIC_RE.findall(raw):
+        metrics.append(
+            {
+                "field": _normalize_field(metric),
+                "op": op,
+                "value": float(raw_value),
+            }
+        )
+    if metrics:
+        filters["metrics"] = metrics
+
+    if "last week" in raw.lower():
+        filters["created_after"] = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+
+    not_terms = re.findall(r"\bnot\s+([A-Za-z0-9_.-]+)", raw, flags=re.I)
+    if not_terms:
+        filters["exclude_terms"] = [t.lower() for t in not_terms]
+
+    for token in re.findall(r"[A-Za-z][A-Za-z0-9_.-]{2,}", raw):
+        terms.append(token.lower())
+
+    return ParsedQuery(text=raw, filters=filters, terms=terms)

--- a/nightmarenet_server/search/reindex.py
+++ b/nightmarenet_server/search/reindex.py
@@ -1,11 +1,14 @@
 """Backfill the experiment search index from the hosted database."""
 
 import argparse
+import logging
 import os
 from typing import Any, List
 
 from nightmarenet_server.search.embedder import ExperimentEmbedder, document_from_orm
 from nightmarenet_server.search.index import SearchIndex
+
+logger = logging.getLogger(__name__)
 
 
 def reindex(database_url: str, index_path: str = "", backend: str = "faiss") -> int:
@@ -19,17 +22,20 @@ def reindex(database_url: str, index_path: str = "", backend: str = "faiss") -> 
     try:
         runs: List[Any] = session.query(Run).all()
         for run in runs:
-            experiment = getattr(run, "experiment", None)
-            audit_logs = []
-            if experiment is not None:
-                audit_logs = (
-                    session.query(AuditLog)
-                    .filter(AuditLog.resource_id.in_([run.id, experiment.id]))
-                    .all()
-                )
-            doc = document_from_orm(run, experiment=experiment, audit_logs=audit_logs)
-            index.add(doc.run_id, embedder.embed_run(doc), doc.metadata())
-            count += 1
+            try:
+                experiment = getattr(run, "experiment", None)
+                audit_logs = []
+                if experiment is not None:
+                    audit_logs = (
+                        session.query(AuditLog)
+                        .filter(AuditLog.resource_id.in_([run.id, experiment.id]))
+                        .all()
+                    )
+                doc = document_from_orm(run, experiment=experiment, audit_logs=audit_logs)
+                index.add(doc.run_id, embedder.embed_run(doc), doc.metadata())
+                count += 1
+            except Exception:
+                logger.exception("Failed to index run %s; continuing", getattr(run, "id", ""))
     finally:
         session.close()
     return count

--- a/nightmarenet_server/search/reindex.py
+++ b/nightmarenet_server/search/reindex.py
@@ -1,0 +1,55 @@
+"""Backfill the experiment search index from the hosted database."""
+
+import argparse
+import os
+from typing import Any, List
+
+from nightmarenet_server.search.embedder import ExperimentEmbedder, document_from_orm
+from nightmarenet_server.search.index import SearchIndex
+
+
+def reindex(database_url: str, index_path: str = "", backend: str = "faiss") -> int:
+    from nightmarenet_server.models import AuditLog, Run, get_session_factory
+
+    session_factory = get_session_factory(database_url)
+    session = session_factory()
+    embedder = ExperimentEmbedder()
+    index = SearchIndex(backend=backend, path=index_path or None)
+    count = 0
+    try:
+        runs: List[Any] = session.query(Run).all()
+        for run in runs:
+            experiment = getattr(run, "experiment", None)
+            audit_logs = []
+            if experiment is not None:
+                audit_logs = (
+                    session.query(AuditLog)
+                    .filter(AuditLog.resource_id.in_([run.id, experiment.id]))
+                    .all()
+                )
+            doc = document_from_orm(run, experiment=experiment, audit_logs=audit_logs)
+            index.add(doc.run_id, embedder.embed_run(doc), doc.metadata())
+            count += 1
+    finally:
+        session.close()
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Rebuild the NightmareNet experiment search index."
+    )
+    parser.add_argument("--database-url", default=os.environ.get("NIGHTMARENET_DATABASE_URL"))
+    parser.add_argument("--index-path", default=os.environ.get("NIGHTMARENET_SEARCH_INDEX", ""))
+    parser.add_argument("--backend", default=os.environ.get("NIGHTMARENET_SEARCH_BACKEND", "faiss"))
+    args = parser.parse_args()
+    if not args.database_url:
+        from nightmarenet_server.models.base import DEFAULT_DATABASE_URL
+
+        args.database_url = DEFAULT_DATABASE_URL
+    count = reindex(args.database_url, index_path=args.index_path, backend=args.backend)
+    print(f"Indexed {count} runs")
+
+
+if __name__ == "__main__":
+    main()

--- a/nightmarenet_server/tasks/training.py
+++ b/nightmarenet_server/tasks/training.py
@@ -91,6 +91,36 @@ def _update_run_status(
         session.close()
 
 
+def _upsert_search_index(session_factory: Any, run_id: str) -> None:
+    """Best-effort semantic indexing for completed runs."""
+    try:
+        from nightmarenet_server.models import AuditLog, Run
+        from nightmarenet_server.search.embedder import ExperimentEmbedder, document_from_orm
+        from nightmarenet_server.search.endpoints import get_index
+    except ImportError:
+        return
+
+    session = session_factory()
+    try:
+        run = session.get(Run, run_id)
+        if run is None:
+            return
+        experiment = getattr(run, "experiment", None)
+        audit_logs = []
+        if experiment is not None:
+            audit_logs = (
+                session.query(AuditLog)
+                .filter(AuditLog.resource_id.in_([run.id, experiment.id]))
+                .all()
+            )
+        doc = document_from_orm(run, experiment=experiment, audit_logs=audit_logs)
+        get_index().add(doc.run_id, ExperimentEmbedder().embed_run(doc), doc.metadata())
+    except Exception:
+        logger.exception("Failed to update search index for run %s", run_id)
+    finally:
+        session.close()
+
+
 def _get_session_factory() -> Any:
     """Build a session factory using the configured DB URL."""
     from nightmarenet_server.models.base import (
@@ -185,6 +215,7 @@ def execute_pipeline(run_id: str, config: Dict[str, Any]) -> Dict[str, Any]:
         run_id,
         {"type": "completed", "run_id": run_id, "metrics": metrics},
     )
+    _upsert_search_index(session_factory, run_id)
     return metrics
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ hosted = [
     "psycopg[binary]>=3.1.0",
 ]
 search = [
-    "sentence-transformers>=3.0.0",
-    "faiss-cpu>=1.8.0",
+    "sentence-transformers>=2.2.0",
+    "faiss-cpu>=1.7.0",
 ]
 adaption = [
     "adaption>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ hosted = [
     "pyjwt>=2.8.0",
     "psycopg[binary]>=3.1.0",
 ]
+search = [
+    "sentence-transformers>=3.0.0",
+    "faiss-cpu>=1.8.0",
+]
 adaption = [
     "adaption>=0.1.0",
 ]
@@ -95,6 +99,7 @@ nightmarenet = "nightmarenet.cli:main"
 nightmarenet-train = "scripts.train:main"
 nightmarenet-generate = "scripts.generate_data:main"
 nightmarenet-evaluate = "scripts.evaluate:main"
+nightmarenet-reindex-search = "nightmarenet_server.search.reindex:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -142,4 +147,4 @@ follow_imports = "skip"
 follow_imports_for_stubs = false
 
 [tool.setuptools.packages.find]
-include = ["nightmarenet*", "scripts"]
+include = ["nightmarenet*", "nightmarenet_server*", "scripts"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
 
@@ -37,6 +39,14 @@ def test_index_crud_and_persistence(tmp_path) -> None:
     assert loaded.search(vector) == []
 
 
+def test_index_starts_empty_when_persisted_file_is_corrupt(tmp_path) -> None:
+    (tmp_path / "index.json").write_text("{not-json", encoding="utf-8")
+
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+
+    assert index.search(np.zeros(384, dtype=np.float32)) == []
+
+
 def test_hybrid_filtering(tmp_path) -> None:
     index = SearchIndex(path=str(tmp_path), backend="numpy")
     query = np.zeros(384, dtype=np.float32)
@@ -74,6 +84,46 @@ def test_hybrid_filtering(tmp_path) -> None:
         filters={"metrics": [{"field": "nightmare_strength", "op": ">", "value": 0.7}]},
     )
     assert [hit.run_id for hit in config_hits] == ["good"]
+
+
+def test_hybrid_filtering_filters_before_ranking(tmp_path) -> None:
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+    query = np.zeros(384, dtype=np.float32)
+    query[0] = 1
+
+    for i in range(8):
+        vector = np.zeros(384, dtype=np.float32)
+        vector[0] = 1.0 - (i * 0.01)
+        vector[1] = i * 0.01
+        vector = vector / np.linalg.norm(vector)
+        index.add(f"completed-{i}", vector, {"status": "completed"})
+
+    failed = np.zeros(384, dtype=np.float32)
+    failed[0] = 0.2
+    failed[2] = 0.8
+    failed = failed / np.linalg.norm(failed)
+    index.add("failed-match", failed, {"status": "failed"})
+
+    hits = index.hybrid_search(query, filters={"status": "failed"}, top_k=1)
+
+    assert [hit.run_id for hit in hits] == ["failed-match"]
+
+
+def test_index_supports_concurrent_access(tmp_path) -> None:
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+    query = np.zeros(384, dtype=np.float32)
+    query[0] = 1
+
+    def add_and_search(i: int) -> None:
+        vector = np.zeros(384, dtype=np.float32)
+        vector[i % 384] = 1
+        index.add(f"run-{i}", vector, {"status": "completed"})
+        index.search(query, top_k=5)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(add_and_search, range(24)))
+
+    assert len(index.search(query, top_k=50)) == 24
 
 
 def test_query_parser_extracts_filters() -> None:
@@ -129,3 +179,87 @@ def test_search_endpoint_returns_ranked_results(monkeypatch, tmp_path) -> None:
     assert body["results"][0]["run_id"] == "exp-47"
     assert body["results"][0]["relevance_score"] > 0
     assert body["filters"]["status"] == "completed"
+
+
+def test_search_endpoint_hides_internal_errors(monkeypatch) -> None:
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from nightmarenet_server.search import endpoints as search_endpoints
+
+    class BrokenEmbedder:
+        def embed_query(self, query: str) -> np.ndarray:
+            raise RuntimeError("secret internal path /tmp/index.faiss")
+
+    monkeypatch.setattr(search_endpoints, "get_embedder", lambda: BrokenEmbedder())
+
+    app = fastapi.FastAPI()
+    app.include_router(search_endpoints.build_search_router())
+    client = testclient.TestClient(app)
+
+    response = client.post("/api/v1/search", json={"query": "anything"})
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error."
+
+
+def test_reindex_continues_after_bad_run(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("sqlalchemy")
+    from nightmarenet_server.models import (
+        Experiment,
+        Org,
+        Project,
+        Run,
+        get_session_factory,
+        init_db,
+    )
+    from nightmarenet_server.search import reindex as reindex_module
+
+    db_url = f"sqlite:///{tmp_path / 'runs.db'}"
+    init_db(db_url)
+    session_factory = get_session_factory(db_url)
+    session = session_factory()
+    try:
+        org = Org(id="org-1", name="Org")
+        project = Project(id="project-1", org_id="org-1", name="Project")
+        experiment = Experiment(
+            id="experiment-1",
+            project_id="project-1",
+            name="Experiment",
+            config_json="{}",
+        )
+        session.add_all(
+            [
+                org,
+                project,
+                experiment,
+                Run(id="bad-run", experiment_id="experiment-1", status="completed"),
+                Run(id="good-run", experiment_id="experiment-1", status="completed"),
+            ]
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    class DummyEmbedder:
+        def embed_run(self, doc: object) -> np.ndarray:
+            vector = np.zeros(384, dtype=np.float32)
+            vector[0] = 1
+            return vector
+
+    original_document_from_orm = reindex_module.document_from_orm
+
+    def document_from_orm(run: object, **kwargs: object) -> object:
+        if getattr(run, "id", "") == "bad-run":
+            raise ValueError("bad row")
+        return original_document_from_orm(run, **kwargs)
+
+    monkeypatch.setattr(reindex_module, "ExperimentEmbedder", lambda: DummyEmbedder())
+    monkeypatch.setattr(reindex_module, "document_from_orm", document_from_orm)
+
+    count = reindex_module.reindex(
+        db_url,
+        index_path=str(tmp_path / "search-index"),
+        backend="numpy",
+    )
+
+    assert count == 1

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+
+from nightmarenet_server.search.embedder import ExperimentDocument, ExperimentEmbedder
+from nightmarenet_server.search.index import SearchIndex
+from nightmarenet_server.search.query_parser import parse_query
+
+
+def test_embedding_determinism_without_model() -> None:
+    embedder = ExperimentEmbedder(model=False)
+    doc = ExperimentDocument(
+        run_id="exp-1",
+        name="synonym stress",
+        config={"distortions": ["synonym"], "nightmare_strength": 0.8},
+        metrics={"robustness": 0.72},
+    )
+
+    first = embedder.embed_run(doc)
+    second = embedder.embed_run(doc)
+
+    assert first.shape == (384,)
+    assert np.allclose(first, second)
+
+
+def test_index_crud_and_persistence(tmp_path) -> None:
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+    vector = np.zeros(384, dtype=np.float32)
+    vector[0] = 1
+
+    index.add("run-1", vector, {"status": "completed"})
+    assert index.search(vector, top_k=1)[0].run_id == "run-1"
+
+    loaded = SearchIndex(path=str(tmp_path), backend="numpy")
+    assert loaded.search(vector, top_k=1)[0].metadata["status"] == "completed"
+
+    loaded.delete("run-1")
+    assert loaded.search(vector) == []
+
+
+def test_hybrid_filtering(tmp_path) -> None:
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+    query = np.zeros(384, dtype=np.float32)
+    query[2] = 1
+    index.add(
+        "good",
+        query,
+        {
+            "status": "completed",
+            "model": "DistilBERT",
+            "metrics": {"robustness": 0.82},
+            "config": {"nightmare_strength": 0.8},
+        },
+    )
+    other = np.zeros(384, dtype=np.float32)
+    other[3] = 1
+    index.add(
+        "bad",
+        other,
+        {"status": "failed", "model": "GPT-2", "metrics": {"robustness": 0.2}},
+    )
+
+    hits = index.hybrid_search(
+        query,
+        filters={
+            "status": "completed",
+            "metrics": [{"field": "robustness", "op": ">", "value": 0.7}],
+        },
+    )
+
+    assert [hit.run_id for hit in hits] == ["good"]
+
+    config_hits = index.hybrid_search(
+        query,
+        filters={"metrics": [{"field": "nightmare_strength", "op": ">", "value": 0.7}]},
+    )
+    assert [hit.run_id for hit in config_hits] == ["good"]
+
+
+def test_query_parser_extracts_filters() -> None:
+    parsed = parse_query("completed runs where nightmare strength > 0.7 and not char_swap")
+
+    assert parsed.filters["status"] == "completed"
+    assert parsed.filters["exclude_terms"] == ["char_swap"]
+    assert parsed.filters["metrics"][0] == {
+        "field": "nightmare_strength",
+        "op": ">",
+        "value": 0.7,
+    }
+
+
+def test_search_endpoint_returns_ranked_results(monkeypatch, tmp_path) -> None:
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from nightmarenet_server.search import endpoints as search_endpoints
+
+    index = SearchIndex(path=str(tmp_path), backend="numpy")
+    vector = np.zeros(384, dtype=np.float32)
+    vector[5] = 1
+    index.add(
+        "exp-47",
+        vector,
+        {
+            "run_id": "exp-47",
+            "name": "char-swap robustness",
+            "model": "DistilBERT",
+            "status": "completed",
+            "metrics": {"robustness": 0.91},
+        },
+    )
+
+    class DummyEmbedder:
+        def embed_query(self, query: str) -> np.ndarray:
+            return vector
+
+    monkeypatch.setattr(search_endpoints, "get_embedder", lambda: DummyEmbedder())
+    monkeypatch.setattr(search_endpoints, "get_index", lambda: index)
+
+    app = fastapi.FastAPI()
+    app.include_router(search_endpoints.build_search_router())
+    client = testclient.TestClient(app)
+
+    response = client.post(
+        "/api/v1/search",
+        json={"query": "completed runs with robustness > 0.8", "top_k": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["results"][0]["run_id"] == "exp-47"
+    assert body["results"][0]["relevance_score"] > 0
+    assert body["filters"]["status"] == "completed"


### PR DESCRIPTION
## Summary

This PR adds semantic search support for the Experiment History panel, allowing users to query experiment runs with natural language instead of only basic string matching and column filters.

## Changes

- Added a new `nightmarenet_server.search` module for experiment search.
- Added `ExperimentEmbedder` to serialize experiment config, metrics, events, and audit metadata into a 384-dimensional embedding space.
- Added a persistent vector `SearchIndex` with FAISS support and a NumPy fallback for local/test environments.
- Added lightweight natural-language query parsing for structured filters such as status, metric thresholds, config thresholds, and excluded terms.
- Added `POST /api/v1/search` for semantic + structured hybrid search.
- Added best-effort search index updates after successful training run completion.
- Added a `nightmarenet-reindex-search` command for backfilling existing runs.
- Updated the Experiment History search bar to call semantic search while preserving local fuzzy matching as a fallback.
- Added backend tests for embedding determinism, index persistence/CRUD, hybrid filtering, query parsing, and the search endpoint.
- Added frontend API client support for `/api/v1/search`.

## Tests

Passed locally:

```bash
python -m pytest tests\test_search.py
python -m ruff check nightmarenet_server\search tests\test_search.py nightmarenet_server\app.py nightmarenet_server\tasks\training.py
python -m compileall nightmarenet_server\search nightmarenet_server\app.py nightmarenet_server\tasks\training.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic, natural-language experiment search with relevance-ranked results.
  * Supports hybrid filtering (status/model, time windows, exclusions, and metric comparisons) plus debounced searching in the experiment list with inline status feedback.
  * Completed runs are automatically indexed for faster searches.
  * Added a command to rebuild the search index.

* **Tests**
  * Expanded automated coverage for embedding determinism, index persistence/CRUD, hybrid filtering, query parsing, endpoint behavior, and reindexing robustness.

* **Chores**
  * Updated packaging to include optional search dependencies and a new reindex CLI entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->