### PR TITLE
chore(ci): add dependabot config for pip, npm, and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,102 @@
+version: 2
+updates:
+  # ---- Python (root pyproject.toml) ----
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      ml-deps:
+        patterns:
+          - "torch*"
+          - "transformers"
+          - "datasets"
+          - "accelerate"
+          - "tokenizers"
+      dev-deps:
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "mypy"
+          - "black"
+          - "pre-commit"
+      other-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "torch*"
+          - "transformers"
+          - "datasets"
+          - "accelerate"
+          - "tokenizers"
+          - "pytest*"
+          - "ruff"
+          - "mypy"
+          - "black"
+          - "pre-commit"
+    # Torch/transformers major bumps are frequently breaking (API + CUDA
+    # compatibility) — require a human to review major version jumps
+    # instead of letting them auto-group into a mergeable PR.
+    ignore:
+      - dependency-name: "torch*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "transformers"
+        update-types: ["version-update:semver-major"]
+
+  # ---- Frontend (Next.js / React) ----
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      next-react:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      dev-deps:
+        patterns:
+          - "eslint*"
+          - "prettier"
+          - "@types/*"
+          - "typescript"
+      other-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+          - "eslint*"
+          - "prettier"
+          - "@types/*"
+          - "typescript"
+    # React 19 / Next 16 majors change APIs enough that they need manual
+    # review rather than auto-merge candidacy.
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+
+  # ---- GitHub Actions ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    labels: ["dependencies"]
+    reviewers: ["Adit-Jain-srm"]
     groups:
       ml-deps:
         patterns:
@@ -17,28 +18,14 @@ updates:
           - "transformers"
           - "datasets"
           - "accelerate"
-          - "tokenizers"
       dev-deps:
         patterns:
           - "pytest*"
           - "ruff"
           - "mypy"
-          - "black"
-          - "pre-commit"
       other-deps:
         patterns:
           - "*"
-        exclude-patterns:
-          - "torch*"
-          - "transformers"
-          - "datasets"
-          - "accelerate"
-          - "tokenizers"
-          - "pytest*"
-          - "ruff"
-          - "mypy"
-          - "black"
-          - "pre-commit"
     # Torch/transformers major bumps are frequently breaking (API + CUDA
     # compatibility) — require a human to review major version jumps
     # instead of letting them auto-group into a mergeable PR.
@@ -54,10 +41,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    labels: ["dependencies"]
+    reviewers: ["Adit-Jain-srm"]
     groups:
       next-react:
         patterns:
@@ -68,21 +56,11 @@ updates:
       dev-deps:
         patterns:
           - "eslint*"
-          - "prettier"
           - "@types/*"
           - "typescript"
       other-deps:
         patterns:
           - "*"
-        exclude-patterns:
-          - "next"
-          - "react"
-          - "react-dom"
-          - "@types/react*"
-          - "eslint*"
-          - "prettier"
-          - "@types/*"
-          - "typescript"
     # React 19 / Next 16 majors change APIs enough that they need manual
     # review rather than auto-merge candidacy.
     ignore:
@@ -100,3 +78,16 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "chore(ci)"
+    labels: ["dependencies"]
+    reviewers: ["Adit-Jain-srm"]
+
+  # ---- Docker base images ----
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci)"
+    labels: ["dependencies"]
+    reviewers: ["Adit-Jain-srm"]
+     


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` with grouped weekly updates for pip and npm, and monthly updates for github-actions.

## Motivation
Closes #181

No automated dependency update system currently exists. This repo tracks fast-moving dependencies (PyTorch, transformers, Next.js, React) that receive frequent security patches, so stale versions can go unnoticed until a contributor hits a breaking change.

## Changes
- Added `pip` ecosystem config (root `pyproject.toml`) with `ml-deps`, `dev-deps`, and `other-deps` groups
- Added `npm` ecosystem config (`/frontend`) with `next-react`, `dev-deps`, and `other-deps` groups
- Added `github-actions` ecosystem config for workflow action version bumps
- Added `ignore` rules for major-version bumps on `torch`, `transformers`, `next`, `react`, and `react-dom` — these are the deps most likely to introduce breaking changes, so majors need manual review rather than auto-grouping into a mergeable PR
- Added an `other-deps` catch-all group on both ecosystems so dependencies outside the named groups (e.g. `fastapi`, `sqlalchemy`, `celery`, `wandb`, `opentelemetry-*` on the Python side; `framer-motion`, `gsap`, `tailwindcss`, `vitest` on the frontend side) still batch into a weekly PR instead of each spawning its own
- Set `open-pull-requests-limit: 10` on both ecosystems to prevent an initial flood of PRs
- Set commit message prefixes (`chore(deps)`, `chore(ci)`) to match this repo's Conventional Commits convention

## Technical Approach
Verified the group patterns against the actual dependency files rather than assuming a generic setup:
- `pyproject.toml` uses `[project.optional-dependencies]` extras (`dev`, `api`, `tracking`, `distributed`, `otel`, `hosted`, `adaption`, `ai`) in addition to core `dependencies` — Dependabot's pip ecosystem scans extras correctly, so all of these are covered, not just the core list.
- `frontend/package.json` was cross-checked so `next-react` and `dev-deps` patterns match real package names (`next`, `react`, `react-dom`, `@types/react*`, `eslint*`,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update monitoring for Python, frontend, and GitHub Actions.
  * Introduced scheduled update cadences with grouped dependency PRs to simplify review.
  * Added safeguards to require manual review before major updates for key machine learning and frontend libraries.
  * Included standardized labeling and commit-message prefixes for dependency-related changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->