### PR TITLE
feat: add web metadata (manifest.json) to frontend

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "NightmareNet",
+  "short_name": "NightmareNet",
+  "description": "Network analysis and monitoring tool",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#6366f1",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## What this PR does
Adds PWA manifest.json for the NightmareNet frontend.

## Changes
- Created `manifest.json` with app metadata
- Configured app name, short name, and description
- Set dark theme colors matching the app design
- Added icon references for 192x192 and 512x512
- Configured standalone display mode

Partially addresses #191 (manifest.json part)

## Next steps
- Add `robots.txt`
- Add favicon files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Progressive Web App metadata for NightmareNet, including app details, launch behavior, theme colors, orientation, and supported icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->