### PR TITLE
feat: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # Frontend dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ECSoC26"
+      - "infrastructure"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ECSoC26"
+      - "infrastructure"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ECSoC26"
+      - "infrastructure"
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
## What this PR does
Adds Dependabot configuration for automated dependency updates across npm, pip, and GitHub Actions.

## Changes
- Created `.github/dependabot.yml`
- Weekly update schedule on Mondays
- npm dependencies for frontend directory
- pip dependencies for Python packages
- GitHub Actions workflow updates
- 5 PR limit per ecosystem
- Consistent commit message prefixes
- ECSoC26 and infrastructure labels

Closes #181