### PR TITLE
[Infra]: Ship py.typed marker in package wheel/sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,6 @@ follow_imports_for_stubs = false
 
 [tool.setuptools.packages.find]
 include = ["nightmarenet*", "scripts"]
+
+[tool.setuptools.package-data]
+nightmarenet = ["py.typed"]


### PR DESCRIPTION
Fixes issue #222. Adds [tool.setuptools.package-data] to pyproject.toml to ensure py.typed is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Type information is now included in packaged distributions, improving compatibility with static type-checking tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->