### PR TITLE
[Infra]: Add root .env.example documenting all environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# ==============================================================================
+# NightmareNet Backend & Infrastructure Environment Variables
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# API / Core Configuration
+# ------------------------------------------------------------------------------
+# The API key required to authenticate with the backend API.
+# NIGHTMARENET_API_KEY=your_secret_api_key_here
+
+# Allowed origins for Cross-Origin Resource Sharing (CORS). Comma-separated.
+# NIGHTMARENET_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# The log level for the backend API (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+# NIGHTMARENET_LOG_LEVEL=INFO
+
+# ------------------------------------------------------------------------------
+# Docker Compose Port Mapping
+# ------------------------------------------------------------------------------
+# The port on which the API container will be exposed to the host machine.
+# API_PORT=8000
+
+# The port on which the frontend container will be exposed to the host machine.
+# FRONTEND_PORT=3000
+
+# ------------------------------------------------------------------------------
+# PostgreSQL Database Configuration (Hosted Profile)
+# ------------------------------------------------------------------------------
+# POSTGRES_USER=nightmare
+# POSTGRES_PASSWORD=nightmare_secret
+# POSTGRES_DB=nightmarenet
+# POSTGRES_HOST=db
+# POSTGRES_PORT=5432
+
+# ------------------------------------------------------------------------------
+# Redis Configuration (Hosted Profile)
+# ------------------------------------------------------------------------------
+# REDIS_HOST=redis
+# REDIS_PORT=6379
+# REDIS_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -98,7 +98,18 @@ Run the full Wake -> Dream -> Nightmare -> Compress cycle on SST-2 in under 10 m
 ---
 ## Running the API + Dashboard Locally (Docker)
 
-The open-source version of NightmareNet currently supports running the **API** and **Frontend** locally. The `db`, `redis`, and `worker` services are included for future hosted functionality and are disabled by default.
+### Tooling Versions
+
+For tooling consistency, this repository includes a `.python-version` file (Python 3.12) and a `.nvmrc` file (Node 20). If you use tools like `pyenv`, `asdf`, or `nvm`, they will automatically switch to the correct versions when you navigate into the directory.
+
+### Environment Variables
+
+To get started, copy the provided example environment files and customize them if needed:
+```bash
+cp .env.example .env
+cp frontend/.env.example frontend/.env
+```
+The defaults in these files are sufficient for a local functional setup.
 
 ### Default (functional) setup
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,18 @@
+# ==============================================================================
+# NightmareNet Frontend Environment Variables
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Next.js Server-Side Configuration
+# ------------------------------------------------------------------------------
+# URL used by Next.js rewrites to proxy requests to the backend API.
+# NEXT_API_REWRITE_URL=http://localhost:8000/api
+
+# ------------------------------------------------------------------------------
+# Next.js Client-Side (Public) Configuration
+# ------------------------------------------------------------------------------
+# The public base URL for the backend API, accessible from the browser.
+# NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# The current build SHA or version string for display in the dashboard.
+# NEXT_PUBLIC_BUILD_SHA=dev


### PR DESCRIPTION
Fixes issue #228. Adds .env.example to the root and frontend directories to document required environment variables.