### PR TITLE
[Docs]: Fix README hero - still claims Image Synthesis / GAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NightmareNet
 
-**Deep Learning Adversarial Network for Image Synthesis**
+**Autonomous Adversarial Robustness Training Platform**
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Adit-Jain-srm/NightmareNet)
 [![Python](https://img.shields.io/badge/Python-3.9+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 [![Last Commit](https://img.shields.io/github/last-commit/Adit-Jain-srm/NightmareNet)](https://github.com/Adit-Jain-srm/NightmareNet)
 
-*A generative adversarial network exploring the boundaries of AI-generated imagery.*
+*A cyclic training paradigm (Wake / Dream / Nightmare / Compress) exploring the boundaries of AI robustness.*
 
 </div>
 


### PR DESCRIPTION
Fixes issue #218. Updates the README hero title and tagline to accurately describe the autonomous adversarial robustness training platform.