### PR TITLE
[Docs]: Replace static CI-passing badge with live GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 **The first platform that actively improves model robustness through biologically-grounded training cycles.**
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
-[![CI](https://img.shields.io/badge/CI-passing-brightgreen)](.github/workflows/ci.yml)
+[![CI](https://github.com/Adit-Jain-srm/NightmareNet/actions/workflows/ci.yml/badge.svg)](https://github.com/Adit-Jain-srm/NightmareNet/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/badge/tests-558%2B%20passing-brightgreen)](#testing)
 [![Python](https://img.shields.io/badge/python-3.9%E2%80%933.12-blue)](#installation)
 


### PR DESCRIPTION
Fixes issue #220. Replaces the hardcoded CI-passing badge with the live GitHub Actions status badge URL.