### PR TITLE
feat: Add Vision distortions foundation and Gaussian Noise

### DIFF
--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -20,9 +20,12 @@ import importlib.metadata
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
+import torch
+
 from nightmarenet.distortions.base import BaseDistortion
 
 DistortionFn = Callable[[str, float, Optional[int]], str]
+VisionDistortionFn = Callable[[torch.Tensor, float, Optional[int]], torch.Tensor]
 
 logger = logging.getLogger(__name__)
 
@@ -183,3 +186,145 @@ def get_registry() -> DistortionRegistry:
     if _default_registry is None:
         _default_registry = DistortionRegistry()
     return _default_registry
+
+
+class VisionDistortionRegistry:
+    """Plugin registry for vision distortion engines.
+
+    Supports registration of custom distortion functions that follow
+    the signature: (image: torch.Tensor, strength: float, seed: Optional[int]) -> torch.Tensor
+    """
+
+    def __init__(self) -> None:
+        self._engines: Dict[str, VisionDistortionFn] = {}
+        self._metadata: Dict[str, Dict[str, Any]] = {}
+        self._register_builtins()
+        self._discover_plugins()
+
+    def _register_builtins(self) -> None:
+        from nightmarenet.distortions.vision.gaussian_noise import GaussianNoise
+
+        noise_engine = GaussianNoise()
+        self.register(
+            noise_engine.name,
+            noise_engine.distort,
+            metadata={
+                "phase": noise_engine.phase,
+                "description": noise_engine.description,
+                "source": "builtin",
+            },
+        )
+
+    def _discover_plugins(self) -> None:
+        """Discover and load third-party vision distortion plugins via entry points."""
+        try:
+            eps = importlib.metadata.entry_points(group="nightmarenet.distortions.vision")
+        except TypeError:
+            try:
+                all_eps = importlib.metadata.entry_points()
+                eps = all_eps.get("nightmarenet.distortions.vision", [])  # type: ignore[attr-defined, assignment]
+            except Exception:
+                eps = []  # type: ignore[assignment]
+
+        from nightmarenet.distortions.vision.base import ImageDistortion
+
+        for ep in eps:
+            try:
+                cls = ep.load()
+                instance = cls()
+                if isinstance(instance, ImageDistortion) and instance.validate():
+                    self.register(instance.name, instance.distort, metadata={
+                        'phase': instance.phase,
+                        'description': instance.description,
+                        'source': 'plugin',
+                        'package': ep.dist.name if hasattr(ep, 'dist') and ep.dist else 'unknown',
+                    })
+                    logger.info(f"Loaded vision distortion plugin '{ep.name}' from {ep.value}")
+            except Exception as e:
+                logger.warning(f"Failed to load vision distortion plugin '{ep.name}': {e}")
+
+    def register(
+        self,
+        name: str,
+        fn: VisionDistortionFn,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Register a vision distortion engine."""
+        if not callable(fn):
+            raise TypeError(f"Distortion function must be callable, got {type(fn)}")
+        self._engines[name] = fn
+        self._metadata[name] = metadata or {}
+
+    def unregister(self, name: str) -> None:
+        """Remove a registered vision distortion engine."""
+        self._engines.pop(name, None)
+        self._metadata.pop(name, None)
+
+    def apply(
+        self,
+        name: str,
+        image: torch.Tensor,
+        strength: float = 0.3,
+        seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Apply a named vision distortion to an image tensor."""
+        if name not in self._engines:
+            available = ", ".join(sorted(self._engines.keys()))
+            raise KeyError(f"Unknown vision distortion '{name}'. Available: {available}")
+        return self._engines[name](image, strength, seed)
+
+    def list_engines(self) -> List[Dict[str, Any]]:
+        """List all registered vision distortion engines with metadata."""
+        return [
+            {"name": name, **self._metadata.get(name, {})}
+            for name in sorted(self._engines.keys())
+        ]
+
+    def list_engines_by_source(self) -> Dict[str, List[Dict[str, Any]]]:
+        """List engines grouped by source (builtin, plugin, custom)."""
+        result: Dict[str, List[Dict[str, Any]]] = {"builtin": [], "plugin": [], "custom": []}
+        for name in sorted(self._engines.keys()):
+            source = self._metadata.get(name, {}).get("source", "custom")
+            result.setdefault(source, []).append({"name": name, **self._metadata.get(name, {})})
+        return result
+
+    def get_engine_metadata(self, name: str) -> Dict[str, Any]:
+        """Get metadata for a specific engine."""
+        return self._metadata.get(name, {})
+
+    def register_decorator(
+        self,
+        name: str,
+        phase: str = "custom",
+        description: str = "",
+    ):
+        """Decorator for registering vision distortion functions."""
+        def decorator(fn: VisionDistortionFn) -> VisionDistortionFn:
+            self.register(name, fn, metadata={
+                'phase': phase,
+                'description': description,
+                'source': 'custom',
+            })
+            return fn
+        return decorator
+
+    @property
+    def engine_names(self) -> List[str]:
+        return sorted(self._engines.keys())
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._engines
+
+    def __len__(self) -> int:
+        return len(self._engines)
+
+
+_default_vision_registry: Optional[VisionDistortionRegistry] = None
+
+
+def get_vision_registry() -> VisionDistortionRegistry:
+    """Get the global vision distortion registry (lazy singleton)."""
+    global _default_vision_registry
+    if _default_vision_registry is None:
+        _default_vision_registry = VisionDistortionRegistry()
+    return _default_vision_registry

--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -239,9 +239,9 @@ class VisionDistortionRegistry:
                         'source': 'plugin',
                         'package': ep.dist.name if hasattr(ep, 'dist') and ep.dist else 'unknown',
                     })
-                    logger.info(f"Loaded vision distortion plugin '{ep.name}' from {ep.value}")
+                    logger.info("Loaded vision distortion plugin '%s' from %s", ep.name, ep.value)
             except Exception as e:
-                logger.warning(f"Failed to load vision distortion plugin '{ep.name}': {e}")
+                logger.warning("Failed to load vision distortion plugin '%s': %s", ep.name, e)
 
     def register(
         self,

--- a/nightmarenet/distortions/vision/__init__.py
+++ b/nightmarenet/distortions/vision/__init__.py
@@ -1,0 +1,5 @@
+"""Computer Vision (image-based) distortions."""
+
+from nightmarenet.distortions.vision.base import ImageDistortion
+
+__all__ = ["ImageDistortion"]

--- a/nightmarenet/distortions/vision/base.py
+++ b/nightmarenet/distortions/vision/base.py
@@ -1,0 +1,44 @@
+"""Base class for vision (image-based) distortion engines."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+
+
+class ImageDistortion(ABC):
+    """Base class for all vision distortion engines.
+
+    Plugin authors should inherit from this class to ensure their vision
+    distortion engines follow the expected contract.
+    """
+
+    name: str = ""
+    phase: str = "custom"  # dream, nightmare, or custom
+    description: str = ""
+
+    @abstractmethod
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        """Apply distortion to an image tensor at the given strength.
+
+        Args:
+            image: Input image tensor of shape (C, H, W) normalized to [0, 1]
+            strength: Float in [0.0, 1.0] controlling distortion intensity
+            seed: Optional random seed for reproducibility
+
+        Returns:
+            Distorted image tensor of shape (C, H, W) normalized to [0, 1]
+
+        Contract:
+            - strength=0.0 should be a no-op
+            - strength=1.0 should produce maximum distortion
+            - Same (image, strength, seed) must produce deterministic output
+            - Output must be clamped to [0, 1]
+        """
+        ...
+
+    def validate(self) -> bool:
+        """Self-validation: returns True if the engine is properly configured."""
+        return bool(self.name)

--- a/nightmarenet/distortions/vision/gaussian_noise.py
+++ b/nightmarenet/distortions/vision/gaussian_noise.py
@@ -1,0 +1,38 @@
+"""Gaussian noise vision distortion."""
+
+from typing import Optional
+
+import torch
+
+from nightmarenet.distortions.vision.base import ImageDistortion
+
+
+class GaussianNoise(ImageDistortion):
+    """Adds Gaussian noise to an image tensor."""
+
+    name = "vision_gaussian_noise"
+    phase = "nightmare"
+    description = "Adds Gaussian noise to the image scaled by strength"
+
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        if strength <= 0.0:
+            return image.clone()
+
+        gen = None
+        if seed is not None:
+            gen = torch.Generator(device=image.device)
+            gen.manual_seed(seed)
+
+        # Scale noise intensity by strength.
+        # A standard deviation of strength / 2.0 provides noticeable
+        # but bounded noise at strength 1.0.
+        std = strength / 2.0
+
+        noise = torch.randn(
+            image.shape, generator=gen, device=image.device, dtype=image.dtype
+        ) * std
+        distorted = image + noise
+
+        return torch.clamp(distorted, 0.0, 1.0)

--- a/nightmarenet/distortions/vision/utils.py
+++ b/nightmarenet/distortions/vision/utils.py
@@ -1,0 +1,15 @@
+"""Utilities for vision distortions."""
+
+import torch
+import torchvision.transforms.functional as functional
+from PIL import Image
+
+
+def to_tensor(img: Image.Image) -> torch.Tensor:
+    """Convert a PIL Image to a PyTorch tensor (C, H, W) in [0, 1]."""
+    return functional.to_tensor(img)
+
+
+def to_pil(tensor: torch.Tensor) -> Image.Image:
+    """Convert a PyTorch tensor (C, H, W) in [0, 1] to a PIL Image."""
+    return functional.to_pil_image(tensor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ keywords = ["ai", "training", "robustness", "distortion", "machine-learning", "s
 
 dependencies = [
     "torch>=2.0.0",
+    "torchvision>=0.15.0",
     "transformers>=4.30.0",
     "datasets>=2.14.0",
     "numpy>=1.24.0",

--- a/tests/test_distortion_vision.py
+++ b/tests/test_distortion_vision.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+from PIL import Image
+
+from nightmarenet.distortions.registry import get_vision_registry
+from nightmarenet.distortions.vision.base import ImageDistortion
+from nightmarenet.distortions.vision.gaussian_noise import GaussianNoise
+from nightmarenet.distortions.vision.utils import to_pil, to_tensor
+
+
+def test_vision_registry_singleton():
+    """Test that get_vision_registry returns a singleton."""
+    r1 = get_vision_registry()
+    r2 = get_vision_registry()
+    assert r1 is r2
+
+
+def test_vision_registry_builtin_loaded():
+    """Test that builtin gaussian noise is loaded."""
+    registry = get_vision_registry()
+    assert "vision_gaussian_noise" in registry
+
+
+def test_gaussian_noise_no_op():
+    """Test that strength 0.0 is a no-op."""
+    noise = GaussianNoise()
+    img = torch.zeros(3, 32, 32)
+    distorted = noise.distort(img, strength=0.0)
+    assert torch.all(img == distorted)
+
+
+def test_gaussian_noise_determinism():
+    """Test that the same seed produces the same output."""
+    noise = GaussianNoise()
+    img = torch.zeros(3, 32, 32)
+    
+    distorted1 = noise.distort(img, strength=0.5, seed=42)
+    distorted2 = noise.distort(img, strength=0.5, seed=42)
+    
+    assert torch.all(distorted1 == distorted2)
+
+
+def test_gaussian_noise_different_seeds():
+    """Test that different seeds produce different outputs."""
+    noise = GaussianNoise()
+    img = torch.zeros(3, 32, 32)
+    
+    distorted1 = noise.distort(img, strength=0.5, seed=42)
+    distorted2 = noise.distort(img, strength=0.5, seed=43)
+    
+    assert not torch.all(distorted1 == distorted2)
+
+
+def test_gaussian_noise_bounds():
+    """Test that gaussian noise output is bounded between 0 and 1."""
+    noise = GaussianNoise()
+    # image full of 0.5
+    img = torch.ones(3, 32, 32) * 0.5
+    distorted = noise.distort(img, strength=1.0)
+    
+    assert torch.all(distorted >= 0.0)
+    assert torch.all(distorted <= 1.0)
+
+
+def test_utils_conversions():
+    """Test PIL to Tensor and Tensor to PIL conversions."""
+    # Create a random RGB image
+    img = Image.new("RGB", (32, 32), color="red")
+    
+    tensor = to_tensor(img)
+    assert tensor.shape == (3, 32, 32)
+    assert isinstance(tensor, torch.Tensor)
+    
+    img_back = to_pil(tensor)
+    assert isinstance(img_back, Image.Image)
+    assert img_back.size == (32, 32)
+
+
+def test_vision_registry_apply():
+    """Test applying a vision distortion via the registry."""
+    registry = get_vision_registry()
+    img = torch.ones(3, 32, 32) * 0.5
+    
+    distorted = registry.apply("vision_gaussian_noise", img, strength=0.5, seed=123)
+    assert distorted.shape == (3, 32, 32)
+    assert torch.all(distorted >= 0.0) and torch.all(distorted <= 1.0)

--- a/tests/test_distortion_vision.py
+++ b/tests/test_distortion_vision.py
@@ -1,9 +1,7 @@
-import pytest
 import torch
 from PIL import Image
 
 from nightmarenet.distortions.registry import get_vision_registry
-from nightmarenet.distortions.vision.base import ImageDistortion
 from nightmarenet.distortions.vision.gaussian_noise import GaussianNoise
 from nightmarenet.distortions.vision.utils import to_pil, to_tensor
 
@@ -33,10 +31,10 @@ def test_gaussian_noise_determinism():
     """Test that the same seed produces the same output."""
     noise = GaussianNoise()
     img = torch.zeros(3, 32, 32)
-    
+
     distorted1 = noise.distort(img, strength=0.5, seed=42)
     distorted2 = noise.distort(img, strength=0.5, seed=42)
-    
+
     assert torch.all(distorted1 == distorted2)
 
 
@@ -44,10 +42,10 @@ def test_gaussian_noise_different_seeds():
     """Test that different seeds produce different outputs."""
     noise = GaussianNoise()
     img = torch.zeros(3, 32, 32)
-    
+
     distorted1 = noise.distort(img, strength=0.5, seed=42)
     distorted2 = noise.distort(img, strength=0.5, seed=43)
-    
+
     assert not torch.all(distorted1 == distorted2)
 
 
@@ -57,7 +55,7 @@ def test_gaussian_noise_bounds():
     # image full of 0.5
     img = torch.ones(3, 32, 32) * 0.5
     distorted = noise.distort(img, strength=1.0)
-    
+
     assert torch.all(distorted >= 0.0)
     assert torch.all(distorted <= 1.0)
 
@@ -66,11 +64,11 @@ def test_utils_conversions():
     """Test PIL to Tensor and Tensor to PIL conversions."""
     # Create a random RGB image
     img = Image.new("RGB", (32, 32), color="red")
-    
+
     tensor = to_tensor(img)
     assert tensor.shape == (3, 32, 32)
     assert isinstance(tensor, torch.Tensor)
-    
+
     img_back = to_pil(tensor)
     assert isinstance(img_back, Image.Image)
     assert img_back.size == (32, 32)
@@ -80,7 +78,15 @@ def test_vision_registry_apply():
     """Test applying a vision distortion via the registry."""
     registry = get_vision_registry()
     img = torch.ones(3, 32, 32) * 0.5
-    
+
     distorted = registry.apply("vision_gaussian_noise", img, strength=0.5, seed=123)
     assert distorted.shape == (3, 32, 32)
     assert torch.all(distorted >= 0.0) and torch.all(distorted <= 1.0)
+
+
+def test_gaussian_noise_empty_tensor():
+    """Test empty tensor handling (e.g. shape with 0 dimension)."""
+    noise = GaussianNoise()
+    img = torch.zeros(3, 0, 0)
+    distorted = noise.distort(img, strength=0.5, seed=42)
+    assert distorted.shape == (3, 0, 0)


### PR DESCRIPTION
## Summary
Adds the foundational module, registry, and utilities for image-based distortions in NightmareNet.

## Motivation
Part of the broader Computer Vision support initiative, this introduces the `ImageDistortion` base class, segregates vision tools into `VisionDistortionRegistry` to preserve typing constraints for string-based operations, and provides a built-in Gaussian Noise distortion.
Closes #168

## Changes
- Updated `pyproject.toml` to include `torchvision>=0.15.0`.
- Created `nightmarenet/distortions/vision/base.py` defining `ImageDistortion(ABC)`.
- Implemented `GaussianNoise` in `vision/gaussian_noise.py`.
- Added PIL <-> Tensor utility converters in `vision/utils.py`.
- Added `VisionDistortionRegistry` in `registry.py`.
- Added unit tests checking determinism, bounds, and PIL conversions.

## Acceptance Criteria
- [x] `ImageDistortion` ABC with `distort()` method signature
- [x] Gaussian noise implementation: strength 0 = no-op, strength 1 = heavy noise
- [x] Output clamped to [0, 1]
- [x] Deterministic with fixed seed
- [x] Registered in distortion registry
- [x] PIL <-> Tensor converters
- [x] Tests: determinism, strength bounds, empty tensor handling, registry round-trip

## Type
- [x] Feature (non-breaking change that adds functionality)

## Pre-submission Requirements
- [x] I have **starred** this repository ⭐
- [x] I have **followed** @Adit-Jain-srm
- [x] I have read CONTRIBUTING.md in full

## Quality Checklist
- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation
- [x] No documentation needed (test-only or internal refactor)

## AI Disclosure
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations
- [x] Not applicable (no security-sensitive changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added image-based (vision) distortion support alongside existing text distortions.
  - Introduced a vision distortion framework with a built-in Gaussian noise engine (strength scaling, clamped output, and optional deterministic seeding).
  - Added utilities to convert between PIL images and normalized tensors.
  - Enabled vision distortion plugin discovery and registry-based application.
- **Tests**
  - Expanded tests for the vision registry, Gaussian noise determinism/no-op behavior, output bounds, empty-tensor handling, and conversion correctness.
- **Chores**
  - Added a required `torchvision` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->