### PR TITLE
ci: run a minimal import smoke on the api extra (#266)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+        with:
+          persist-credentials: false
+          
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,26 @@
+name: API Smoke Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          
+      - name: Install package with API extras
+        run: pip install .[api]
+        
+      - name: Run minimal import smoke test
+        run: python -c "import nightmarenet.api"
+        


### PR DESCRIPTION
## Summary
This PR adds a minimal CI smoke test workflow to ensure the `[api]` extra (which includes `python-dotenv`) installs correctly and the entry module imports without missing dependencies.

## Motivation
Fixes #266

## Acceptance Criteria
- [x] Workflow job installs `.[api]` (or equivalent)
- [x] Imports the API entry module successfully

## Pre-submission Checklist
- [x] I am assigned to the linked issue.
- [x] I have starred the repo and followed @Adit-Jain-srm.
- [x] `make check` passes locally (or equivalent validation for CI files).
- [x] PR description includes summary and linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated API smoke testing for pushes and pull requests targeting the main branch.
  * Verifies the API package installs successfully and can be imported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->