### PR TITLE
docs: update stale test counts to 660+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Distributed multi-GPU execution support
 - Distortion registry with configurable distortion pipelines
 - Comprehensive evaluation and benchmarking framework
-- 522+ automated unit tests covering training phases, API endpoints, CLI, and distortion modules
+- 660+ automated unit tests covering training phases, API endpoints, CLI, and distortion modules

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![CI](https://img.shields.io/badge/CI-passing-brightgreen)](.github/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-558%2B%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-660%2B%20passing-brightgreen)](#testing)
 [![Python](https://img.shields.io/badge/python-3.9%E2%80%933.12-blue)](#installation)
 
 *Wake. Dream. Nightmare. Compress. Repeat.*
@@ -418,7 +418,7 @@ If you use NightmareNet in academic work, please cite:
 ## Testing
 
 ```bash
-pytest --cov=nightmarenet --cov-report=term-missing tests/ -v --tb=short   # 558+ tests
+pytest --cov=nightmarenet --cov-report=term-missing tests/ -v --tb=short   # 660+ tests
 pytest -m slow tests/test_distortion_fuzz.py -v                            # 1000+ sample fuzz suite
 ruff check .                         # zero lint errors
 mypy nightmarenet/                   # type check

--- a/docs/product-improvement-backlog.md
+++ b/docs/product-improvement-backlog.md
@@ -34,7 +34,7 @@ Tracked through the `consumer-product-improvement` skill's *Analyze → Critique
 - **[shipped]** WebSocket live progress — `/ws/runs/{run_id}` endpoint in OSS app, PipelineLab auto-upgrades from polling to WS.
 - **[shipped]** 18 code review fixes — critical runtime crash, stale metrics, dead code, license mismatch, deprecated APIs.
 - **[shipped]** Repo cleanup — removed 8,400+ lines of junk (duplicate skill dirs, compiled JS in source, dead components, stale docs).
-- **[shipped]** README rewrite — real benchmark results, 434+ test badge, frontend section, removed stale PyPI badge.
+- **[shipped]** README rewrite — real benchmark results, 660+ test badge, frontend section, removed stale PyPI badge.
 
 ## Top of backlog (next iteration)
 

--- a/docs/research/paper-draft.md
+++ b/docs/research/paper-draft.md
@@ -381,7 +381,7 @@ This is an early-stage validation; we explicitly note:
    `TextAttack` library is straightforward and is the v2 priority.
 4. **Single cycle (and only half of it).** The full Wake → Dream → Nightmare →
    Compress cycle with `num_cycles ≥ 3` (the sleep-inspired core thesis) is
-   implemented in `Pipeline.run()` and validated by 522+ unit tests, but is not
+   implemented in `Pipeline.run()` and validated by 660+ unit tests, but is not
    yet benchmark-measured.
 5. **Single dataset / model.** SST-2 / DistilBERT only. Generalization to
    AG News, IMDB, BERT-base, GPT-2-class models is on the v2 roadmap.


### PR DESCRIPTION
## Summary

Updated the stale test count claims across all documentation files to a unified floor of `660+` as requested.

## Motivation

The documentation displayed outdated test counts across multiple files. This unifies the claim to match the current test suite capacity.

Closes #219

## Changes

- Updated the test badge and text claims in `README.md` to `660+`.
- Updated test counts in `CHANGELOG.md`.
- Updated test counts in `docs/research/paper-draft.md`.
- Updated test counts in `docs/product-improvement-backlog.md`.

## Acceptance Criteria

- [⨉] All five locations updated to the same current floor count

- [⨉] PR description includes pytest --co -q output showing the real number

- [⨉] No other changes in the PR (docs-only, focused)

- [⨉] Badge text in README matches the updated number

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [⨉] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [⨉] I have **starred** this repository ⭐
- [⨉] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [⨉] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [⨉] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [ ] No `from __future__ import annotations` added under `nightmarenet/api/`
- [ ] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [ ] No documentation needed (test-only or internal refactor)
- [⨉] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [⨉] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [⨉] CHANGELOG entry added (if user-facing change)

## AI Disclosure

<!-- Required by CONTRIBUTING.md. Check one. -->

- [⨉] This PR is entirely human-written
- [ ] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [⨉] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

<!-- Required by CONTRIBUTING.md for any frontend change. All three are needed. -->

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | |
| Desktop (light mode) | |
| Mobile (375px) | |

## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>

**Proof of Test Count (Acceptance Criteria #2):**
Ran `pytest --co -q | tail -1` locally on `main`:
`623/634 tests collected (11 deselected) in 15.53s`
<img width="1058" height="64" alt="image" src="https://github.com/user-attachments/assets/b127cee0-764e-4cbc-b374-f77d0daa3226" />

*(Note: My local environment collected 634 tests due to missing some optional heavy dependencies, but I have documented the `660+` floor based on the authoritative count provided in the issue description).*
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reported automated test coverage counts across the changelog, README, product backlog, and research documentation.
  * The documented total is now listed as 660+ tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->