### PR TITLE
feat: implement nightmare-phase vision adversarial attacks

### DIFF
--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -220,6 +220,12 @@ class VisionDistortionRegistry:
             JPEGCompression,
         )
         from nightmarenet.distortions.vision.gaussian_noise import GaussianNoise
+        from nightmarenet.distortions.vision.nightmare import (
+            FGSM,
+            PGD,
+            AdversarialPatch,
+            PixelPerturbation,
+        )
 
         noise_engine = GaussianNoise()
         self.register(
@@ -237,6 +243,10 @@ class VisionDistortionRegistry:
             GeometricTransform(),
             GaussianBlur(),
             JPEGCompression(),
+            FGSM(),
+            PGD(),
+            AdversarialPatch(),
+            PixelPerturbation(),
         ]:
             self.register(
                 engine.name,

--- a/nightmarenet/distortions/vision/__init__.py
+++ b/nightmarenet/distortions/vision/__init__.py
@@ -7,6 +7,12 @@ from nightmarenet.distortions.vision.dream import (
     GeometricTransform,
     JPEGCompression,
 )
+from nightmarenet.distortions.vision.nightmare import (
+    FGSM,
+    PGD,
+    AdversarialPatch,
+    PixelPerturbation,
+)
 
 __all__ = [
     "ImageDistortion",
@@ -14,4 +20,8 @@ __all__ = [
     "GeometricTransform",
     "GaussianBlur",
     "JPEGCompression",
+    "FGSM",
+    "PGD",
+    "AdversarialPatch",
+    "PixelPerturbation",
 ]

--- a/nightmarenet/distortions/vision/nightmare.py
+++ b/nightmarenet/distortions/vision/nightmare.py
@@ -1,0 +1,247 @@
+"""Nightmare-phase vision adversarial attack distortion engines."""
+
+from typing import Callable, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from nightmarenet.distortions.vision.base import ImageDistortion
+
+
+class PixelPerturbation(ImageDistortion):
+    """L-infinity bounded random pixel perturbation (model-free)."""
+
+    name = "vision_pixel_perturbation"
+    phase = "nightmare"
+    description = "L-infinity bounded random pixel perturbation"
+
+    def __init__(self, epsilon: float = 0.1) -> None:
+        self.epsilon = epsilon
+
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        if strength <= 0.0:
+            return image.clone()
+
+        eps = strength * self.epsilon
+
+        gen = None
+        if seed is not None:
+            gen = torch.Generator(device=image.device)
+            gen.manual_seed(seed)
+
+        # Generate uniform random noise in [-eps, eps]
+        if gen is not None:
+            noise = (
+                torch.rand(image.shape, generator=gen, device=image.device, dtype=image.dtype)
+                * 2.0
+                - 1.0
+            ) * eps
+        else:
+            noise = (
+                torch.rand(image.shape, device=image.device, dtype=image.dtype) * 2.0 - 1.0
+            ) * eps
+
+        perturbed = image + noise
+        return torch.clamp(perturbed, 0.0, 1.0)
+
+
+class FGSM(ImageDistortion):
+    """Fast Gradient Sign Method (FGSM) single-step adversarial attack."""
+
+    name = "vision_fgsm"
+    phase = "nightmare"
+    description = "Fast Gradient Sign Method single-step adversarial attack"
+
+    def __init__(
+        self,
+        model: Optional[nn.Module] = None,
+        criterion: Optional[Union[nn.Module, Callable]] = None,
+        epsilon: float = 0.1,
+    ) -> None:
+        self.model = model
+        self.criterion = criterion or nn.CrossEntropyLoss()
+        self.epsilon = epsilon
+        self.fallback = PixelPerturbation(epsilon=epsilon)
+
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        if strength <= 0.0:
+            return image.clone()
+
+        if self.model is None:
+            return self.fallback.distort(image, strength, seed)
+
+        original_mode = self.model.training
+        self.model.eval()
+
+        try:
+            # We need to run with gradient enabled
+            input_tensor = image.clone().detach().unsqueeze(0)
+            input_tensor.requires_grad_(True)
+
+            with torch.enable_grad():
+                outputs = self.model(input_tensor)
+                # Predict pseudo-label if true label not provided
+                target = outputs.max(1)[1]
+                loss = self.criterion(outputs, target)
+
+                grad = torch.autograd.grad(
+                    loss, input_tensor, retain_graph=False, create_graph=False
+                )[0]
+
+            eps = strength * self.epsilon
+            grad_sign = grad.sign().squeeze(0).detach()
+            perturbed = image + eps * grad_sign
+
+            return torch.clamp(perturbed, 0.0, 1.0)
+        finally:
+            if original_mode:
+                self.model.train()
+
+
+class PGD(ImageDistortion):
+    """Projected Gradient Descent (PGD) multi-step adversarial attack."""
+
+    name = "vision_pgd"
+    phase = "nightmare"
+    description = "Projected Gradient Descent multi-step adversarial attack"
+
+    def __init__(
+        self,
+        model: Optional[nn.Module] = None,
+        criterion: Optional[Union[nn.Module, Callable]] = None,
+        epsilon: float = 0.1,
+        steps: int = 10,
+        alpha: Optional[float] = None,
+    ) -> None:
+        self.model = model
+        self.criterion = criterion or nn.CrossEntropyLoss()
+        self.epsilon = epsilon
+        self.steps = steps
+        self.alpha = alpha
+        self.fallback = PixelPerturbation(epsilon=epsilon)
+
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        if strength <= 0.0:
+            return image.clone()
+
+        if self.model is None:
+            return self.fallback.distort(image, strength, seed)
+
+        original_mode = self.model.training
+        self.model.eval()
+
+        try:
+            num_steps = max(1, int(strength * self.steps))
+            eps = strength * self.epsilon
+
+            # Step size per iteration
+            if self.alpha is not None:
+                step_size = strength * self.alpha
+            else:
+                step_size = eps / max(1, num_steps)
+
+            # Predict targets using clean image
+            input_tensor = image.clone().detach().unsqueeze(0)
+            with torch.no_grad():
+                outputs = self.model(input_tensor)
+                target = outputs.max(1)[1]
+
+            x_adv = image.clone().detach()
+
+            for _ in range(num_steps):
+                x_adv_batch = x_adv.clone().detach().unsqueeze(0)
+                x_adv_batch.requires_grad_(True)
+
+                with torch.enable_grad():
+                    outputs = self.model(x_adv_batch)
+                    loss = self.criterion(outputs, target)
+                    grad = torch.autograd.grad(
+                        loss, x_adv_batch, retain_graph=False, create_graph=False
+                    )[0]
+
+                # Update step
+                grad_sign = grad.sign().squeeze(0).detach()
+                x_adv = x_adv + step_size * grad_sign
+
+                # Project back to epsilon-ball
+                x_adv = torch.clamp(x_adv, image - eps, image + eps)
+
+                # Clamp to valid image pixel range
+                x_adv = torch.clamp(x_adv, 0.0, 1.0)
+
+            return x_adv.detach()
+        finally:
+            if original_mode:
+                self.model.train()
+
+
+class AdversarialPatch(ImageDistortion):
+    """Applies a random noise patch to the image at a random location."""
+
+    name = "vision_adversarial_patch"
+    phase = "nightmare"
+    description = "Applies a random noise patch at a random location scaled by strength"
+
+    def __init__(self, patch_size: Union[int, Tuple[int, int]] = 8) -> None:
+        self.patch_size = patch_size
+
+    def distort(
+        self, image: torch.Tensor, strength: float, seed: Optional[int] = None
+    ) -> torch.Tensor:
+        if strength <= 0.0:
+            return image.clone()
+
+        c, h, w = image.shape
+
+        if isinstance(self.patch_size, int):
+            ph, pw = self.patch_size, self.patch_size
+        else:
+            ph, pw = self.patch_size
+
+        # Clamp patch size to image dimensions
+        ph = min(ph, h)
+        pw = min(pw, w)
+
+        if ph <= 0 or pw <= 0:
+            return image.clone()
+
+        gen = None
+        if seed is not None:
+            gen = torch.Generator(device=image.device)
+            gen.manual_seed(seed)
+
+        # Get random top-left coordinate (y, x)
+        if h - ph > 0:
+            if gen is not None:
+                y = torch.randint(0, h - ph + 1, (1,), generator=gen, device=image.device).item()
+            else:
+                y = torch.randint(0, h - ph + 1, (1,), device=image.device).item()
+        else:
+            y = 0
+
+        if w - pw > 0:
+            if gen is not None:
+                x = torch.randint(0, w - pw + 1, (1,), generator=gen, device=image.device).item()
+            else:
+                x = torch.randint(0, w - pw + 1, (1,), device=image.device).item()
+        else:
+            x = 0
+
+        # Generate noise patch
+        if gen is not None:
+            noise = torch.rand((c, ph, pw), generator=gen, device=image.device, dtype=image.dtype)
+        else:
+            noise = torch.rand((c, ph, pw), device=image.device, dtype=image.dtype)
+
+        # Blend original patch area with the noise patch
+        distorted = image.clone()
+        orig_patch = image[:, y : y + ph, x : x + pw]
+        distorted[:, y : y + ph, x : x + pw] = (1.0 - strength) * orig_patch + strength * noise
+
+        return torch.clamp(distorted, 0.0, 1.0)

--- a/tests/test_distortion_vision.py
+++ b/tests/test_distortion_vision.py
@@ -10,6 +10,12 @@ from nightmarenet.distortions.vision.dream import (
     JPEGCompression,
 )
 from nightmarenet.distortions.vision.gaussian_noise import GaussianNoise
+from nightmarenet.distortions.vision.nightmare import (
+    FGSM,
+    PGD,
+    AdversarialPatch,
+    PixelPerturbation,
+)
 from nightmarenet.distortions.vision.utils import to_pil, to_tensor
 
 
@@ -142,3 +148,130 @@ def test_dream_distortions_single_channel():
         distorted = distortion.distort(img, strength=0.5, seed=42)
         assert distorted.shape == (1, 32, 32)
         assert torch.all(distorted >= 0.0) and torch.all(distorted <= 1.0)
+
+
+class MockClassifier(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(3 * 32 * 32, 2)
+
+    def forward(self, x):
+        x_flat = x.view(x.size(0), -1)
+        return self.linear(x_flat)
+
+
+def test_nightmare_distortions_registration():
+    """Test that all nightmare distortions are loaded in the registry."""
+    registry = get_vision_registry()
+    expected_names = [
+        "vision_pixel_perturbation",
+        "vision_fgsm",
+        "vision_pgd",
+        "vision_adversarial_patch",
+    ]
+    for name in expected_names:
+        assert name in registry
+
+
+def test_pixel_perturbation_properties():
+    """Test basic properties of PixelPerturbation."""
+    distortion = PixelPerturbation(epsilon=0.1)
+    img = torch.ones(3, 32, 32) * 0.5
+
+    # Strength 0.0 is no-op
+    assert torch.all(distortion.distort(img, strength=0.0) == img)
+
+    # Determinism
+    res1 = distortion.distort(img, strength=0.8, seed=42)
+    res2 = distortion.distort(img, strength=0.8, seed=42)
+    assert torch.all(res1 == res2)
+
+    # Different seeds produce different outputs
+    res3 = distortion.distort(img, strength=0.8, seed=43)
+    assert not torch.all(res1 == res3)
+
+    # L-inf bounds respected: perturbed - img <= eps
+    # eps = strength * epsilon = 0.8 * 0.1 = 0.08
+    diff = torch.abs(res1 - img)
+    assert torch.all(diff <= 0.080001)  # allow tiny float tolerance
+    assert torch.all(res1 >= 0.0) and torch.all(res1 <= 1.0)
+
+
+def test_adversarial_patch_properties():
+    """Test properties of AdversarialPatch."""
+    distortion = AdversarialPatch(patch_size=8)
+    img = torch.ones(3, 32, 32) * 0.5
+
+    # Strength 0.0 is no-op
+    assert torch.all(distortion.distort(img, strength=0.0) == img)
+
+    # Determinism
+    res1 = distortion.distort(img, strength=0.8, seed=42)
+    res2 = distortion.distort(img, strength=0.8, seed=42)
+    assert torch.all(res1 == res2)
+
+    # Check bounds
+    assert torch.all(res1 >= 0.0) and torch.all(res1 <= 1.0)
+
+    # Grayscale handling
+    gray_img = torch.ones(1, 32, 32) * 0.5
+    res_gray = distortion.distort(gray_img, strength=0.8, seed=42)
+    assert res_gray.shape == (1, 32, 32)
+
+
+def test_adversarial_patch_oversized():
+    """Test that patch sizes larger than the image are clamped correctly."""
+    distortion = AdversarialPatch(patch_size=64)
+    img = torch.ones(3, 32, 32) * 0.5
+    res = distortion.distort(img, strength=1.0, seed=42)
+    # Since patch size is clamped to 32x32, the entire image becomes noise
+    assert res.shape == (3, 32, 32)
+
+
+def test_gradient_attacks_fallback():
+    """Test that FGSM and PGD fall back to PixelPerturbation if no model is provided."""
+    img = torch.ones(3, 32, 32) * 0.5
+
+    fgsm = FGSM(model=None, epsilon=0.1)
+    pgd = PGD(model=None, epsilon=0.1)
+    fallback = PixelPerturbation(epsilon=0.1)
+
+    fgsm_res = fgsm.distort(img, strength=0.5, seed=42)
+    pgd_res = pgd.distort(img, strength=0.5, seed=42)
+    fallback_res = fallback.distort(img, strength=0.5, seed=42)
+
+    assert torch.all(fgsm_res == fallback_res)
+    assert torch.all(pgd_res == fallback_res)
+
+
+def test_gradient_attacks_with_model():
+    """Test FGSM and PGD execution with a mock model."""
+    model = MockClassifier()
+    # Set to training mode initially to verify restoration
+    model.train()
+
+    img = torch.ones(3, 32, 32) * 0.5
+    fgsm = FGSM(model=model, epsilon=0.1)
+    pgd = PGD(model=model, epsilon=0.1, steps=5)
+
+    fgsm_res = fgsm.distort(img, strength=1.0)
+    pgd_res = pgd.distort(img, strength=1.0)
+
+    # Output shapes
+    assert fgsm_res.shape == (3, 32, 32)
+    assert pgd_res.shape == (3, 32, 32)
+
+    # Output values bounded
+    assert torch.all(fgsm_res >= 0.0) and torch.all(fgsm_res <= 1.0)
+    assert torch.all(pgd_res >= 0.0) and torch.all(pgd_res <= 1.0)
+
+    # L-inf limits respected (at strength 1.0, eps = 0.1)
+    assert torch.all(torch.abs(fgsm_res - img) <= 0.10001)
+    assert torch.all(torch.abs(pgd_res - img) <= 0.10001)
+
+    # Attacks should modify the image
+    assert not torch.all(fgsm_res == img)
+    assert not torch.all(pgd_res == img)
+
+    # Verify model mode is restored
+    assert model.training


### PR DESCRIPTION
## Summary

This PR implements the four vision-domain adversarial attack distortions for the sleep-cycle Nightmare phase: Fast Gradient Sign Method (FGSM), Projected Gradient Descent (PGD), Adversarial Patch, and Pixel Perturbation.

## Motivation

Completes the third part of the Computer Vision support module (Vision 3/4) under Issue #170, enabling adversarial training and model robustness evaluation against worst-case perturbations on image data.

Closes #170

## Changes

- [NEW] [nightmare.py](file:///e:/OPEN%20SOURCE/NightmareNet/nightmarenet/distortions/vision/nightmare.py): Implements `PixelPerturbation`, `FGSM`, `PGD`, and `AdversarialPatch` subclasses of `ImageDistortion`.
- [MODIFY] [__init__.py](file:///e:/OPEN%20SOURCE/NightmareNet/nightmarenet/distortions/vision/__init__.py): Exports the four new vision nightmare attacks.
- [MODIFY] [registry.py](file:///e:/OPEN%20SOURCE/NightmareNet/nightmarenet/distortions/registry.py): Registers the four new built-in engines in `VisionDistortionRegistry`.
- [MODIFY] [test_distortion_vision.py](file:///e:/OPEN%20SOURCE/NightmareNet/tests/test_distortion_vision.py): Appends comprehensive test coverage for the newly added attacks (determinism, no-ops, bounds, grayscale, model fallback, and gradients).

## Acceptance Criteria

- [x] FGSM attack: correct gradient sign computation, epsilon scaled by strength
- [x] PGD attack: iterative with projection, configurable steps
- [x] Adversarial patch: random position, configurable patch size
- [x] Pixel perturbation: L-inf bounded, no model required
- [x] All extend `ImageDistortion` ABC
- [x] Graceful fallback when model not provided (use non-gradient attacks)
- [x] Output clamped to [0, 1] after perturbation
- [x] Deterministic with fixed seed (except gradient-based which depend on model state)
- [x] Tests: attack produces different output from input, L-inf bounds respected, fallback works

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors (All checks passed!)
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (Success: no issues found in 84 source files)
- [x] `pytest tests/` — all tests pass (20 tests passed successfully)
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)

## Screenshots (if UI/UX change)

N/A (No frontend or visual changes)

## Breaking Changes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added four vision distortions: pixel perturbation, FGSM, PGD, and adversarial patches.
  - Registered the new distortions for discovery alongside existing vision effects.
  - Added deterministic controls, configurable strength, bounded image outputs, and model-free fallbacks for gradient-based effects.

- **Tests**
  - Added coverage for registration, reproducibility, image bounds, patch sizing, fallback behavior, and model-based attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->