### PR TITLE
feat: Computer Vision Pipeline Integration (ResNet-18 / CIFAR-10 sleep-cycle support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ Run the full Wake -> Dream -> Nightmare -> Compress cycle on SST-2 in under 10 m
 > Dev hardware target is a 4 GB VRAM laptop GPU (RTX 3050 Ti). DistilBERT and DistilGPT-2 fit comfortably; GPT-2 (124M) requires gradient checkpointing + FP16.
 
 ---
+
+## Computer Vision Support
+
+NightmareNet supports cyclic adversarial robustness training for image classification models (such as ResNet-18) on torchvision datasets (such as CIFAR-10).
+
+To run the computer vision sleep-cycle pipeline:
+```bash
+nightmarenet train --config configs/benchmark_cifar10.yaml
+```
+
+### Sleep Phases for Vision
+When `model.type: "image_classification"` is specified, text-specific configurations like `max_length` and `text_column` are automatically bypassed, and the training phases adapt to image tensors:
+* **Wake Phase**: Supervised cross-entropy training on clean image tensors.
+* **Dream Phase**: Stochastic application of mild, non-adversarial image distortions (Color Jitter, Geometric Transform, Gaussian Blur, and JPEG Compression) to boost invariance.
+* **Nightmare Phase**: Adversarial training with custom target model gradient projection (FGSM and PGD pixel perturbations).
+* **Compress Phase**: Magnitude weight pruning and RSLAD-style robust distillation directly on perturbed input images.
+* **Evaluation**: Calculates clean classification accuracy and Area Under Curve (AUC) accuracy across increasing distortion strengths.
+
+---
+
 ## Running the API + Dashboard Locally (Docker)
 
 The open-source version of NightmareNet currently supports running the **API** and **Frontend** locally. The `db`, `redis`, and `worker` services are included for future hosted functionality and are disabled by default.

--- a/configs/benchmark_cifar10.yaml
+++ b/configs/benchmark_cifar10.yaml
@@ -1,0 +1,36 @@
+# NightmareNet benchmark: CIFAR-10 classification (ResNet-18)
+# Run: python scripts/train.py --config configs/benchmark_cifar10.yaml
+
+model:
+  name: resnet18
+  type: image_classification
+  num_labels: 10
+
+dataset:
+  name: cifar10
+  max_samples: 1000
+
+training:
+  wake_epochs: 1
+  dream_epochs: 1
+  nightmare_epochs: 1
+  compress_epochs: 1
+  num_cycles: 1
+  batch_size: 8
+  learning_rate: 3.0e-5
+  device: cpu
+
+distortion:
+  dream_strength: 0.25
+  nightmare_strength: 0.75
+
+compression:
+  pruning_ratio: 0.15
+  distill_temperature: 2.0
+
+evaluation:
+  strengths: [0.1, 0.3, 0.5, 0.7, 0.9]
+  seed: 42
+
+tracking:
+  enabled: false

--- a/nightmarenet/compression/distillation.py
+++ b/nightmarenet/compression/distillation.py
@@ -26,26 +26,26 @@ def fgsm_perturb(model: nn.Module, batch: dict, epsilon: float = 0.01) -> dict:
         Batch with perturbed inputs.
     """
     model.eval()
-    
+
     is_vision = "pixel_values" in batch
     if is_vision:
         pixel_values = batch["pixel_values"].clone().detach()
         pixel_values.requires_grad_(True)
-        
+
         labels = batch.get("labels")
         if labels is None:
             with torch.no_grad():
                 outputs = model(pixel_values)
                 logits = outputs.logits if hasattr(outputs, "logits") else outputs
                 labels = logits.max(1)[1]
-                
+
         outputs = model(pixel_values, labels=labels)
         loss = outputs.loss
-        
+
         (pixel_grad,) = torch.autograd.grad(loss, pixel_values)
         perturbed_pixels = (pixel_values + epsilon * pixel_grad.sign()).detach()
         perturbed_pixels = torch.clamp(perturbed_pixels, 0.0, 1.0)
-        
+
         adv_dict = {k: v for k, v in batch.items()}
         adv_dict["pixel_values"] = perturbed_pixels
         return adv_dict
@@ -124,7 +124,11 @@ def run_distillation(
                 # Teacher logits (no grad)
                 with torch.no_grad():
                     teacher_out = teacher(**adv_batch)
-                    teacher_logits = teacher_out.logits if hasattr(teacher_out, "logits") else teacher_out
+                    teacher_logits = (
+                        teacher_out.logits
+                        if hasattr(teacher_out, "logits")
+                        else teacher_out
+                    )
 
                 # Student logits
                 student.train()
@@ -132,7 +136,11 @@ def run_distillation(
                     student_out = student(**adv_batch)
                 else:
                     student_out = student(**adv_batch, labels=batch.get("input_ids"))
-                student_logits = student_out.logits if hasattr(student_out, "logits") else student_out
+                student_logits = (
+                    student_out.logits
+                    if hasattr(student_out, "logits")
+                    else student_out
+                )
                 task_loss = student_out.loss
 
                 # KL divergence loss with temperature scaling

--- a/nightmarenet/compression/distillation.py
+++ b/nightmarenet/compression/distillation.py
@@ -19,13 +19,37 @@ def fgsm_perturb(model: nn.Module, batch: dict, epsilon: float = 0.01) -> dict:
 
     Args:
         model: The student model (used to compute loss for grad).
-        batch: Input batch dict with 'input_ids', 'attention_mask', etc.
-        epsilon: Perturbation magnitude (applied to embeddings).
+        batch: Input batch dict with 'input_ids', 'attention_mask', etc. or 'pixel_values'.
+        epsilon: Perturbation magnitude (applied to embeddings or images).
 
     Returns:
-        Batch with 'inputs_embeds' replaced by adversarially perturbed embeddings.
+        Batch with perturbed inputs.
     """
     model.eval()
+    
+    is_vision = "pixel_values" in batch
+    if is_vision:
+        pixel_values = batch["pixel_values"].clone().detach()
+        pixel_values.requires_grad_(True)
+        
+        labels = batch.get("labels")
+        if labels is None:
+            with torch.no_grad():
+                outputs = model(pixel_values)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                labels = logits.max(1)[1]
+                
+        outputs = model(pixel_values, labels=labels)
+        loss = outputs.loss
+        
+        (pixel_grad,) = torch.autograd.grad(loss, pixel_values)
+        perturbed_pixels = (pixel_values + epsilon * pixel_grad.sign()).detach()
+        perturbed_pixels = torch.clamp(perturbed_pixels, 0.0, 1.0)
+        
+        adv_dict = {k: v for k, v in batch.items()}
+        adv_dict["pixel_values"] = perturbed_pixels
+        return adv_dict
+
     input_ids = batch.get("input_ids")
     attention_mask = batch.get("attention_mask")
     labels = batch.get("labels", input_ids)
@@ -96,15 +120,19 @@ def run_distillation(
 
             use_amp = scaler is not None
             with torch.amp.autocast("cuda", enabled=use_amp):
+                is_vision = "pixel_values" in batch
                 # Teacher logits (no grad)
                 with torch.no_grad():
                     teacher_out = teacher(**adv_batch)
-                    teacher_logits = teacher_out.logits  # (B, T, V)
+                    teacher_logits = teacher_out.logits if hasattr(teacher_out, "logits") else teacher_out
 
                 # Student logits
                 student.train()
-                student_out = student(**adv_batch, labels=batch.get("input_ids"))
-                student_logits = student_out.logits  # (B, T, V)
+                if is_vision:
+                    student_out = student(**adv_batch)
+                else:
+                    student_out = student(**adv_batch, labels=batch.get("input_ids"))
+                student_logits = student_out.logits if hasattr(student_out, "logits") else student_out
                 task_loss = student_out.loss
 
                 # KL divergence loss with temperature scaling

--- a/nightmarenet/data/generator.py
+++ b/nightmarenet/data/generator.py
@@ -493,7 +493,6 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
         pixel_values = item["pixel_values"]
         labels = item["labels"]
 
-        import torch
         from nightmarenet.distortions.registry import get_vision_registry
         registry = get_vision_registry()
 
@@ -513,7 +512,8 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
                     engines.append(name)
 
         actual_strength = self.generator.strength
-        if self.phase == "nightmare" and getattr(self.generator, "strength_schedule", "uniform") != "uniform":
+        sched = getattr(self.generator, "strength_schedule", "uniform")
+        if self.phase == "nightmare" and sched != "uniform":
             strengths = self.generator._compute_strengths(len(self.dataset))
             if idx < len(strengths):
                 actual_strength = strengths[idx]
@@ -524,6 +524,8 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
                 fn = registry._engines.get(name)
                 if fn is not None and hasattr(fn, "__self__"):
                     fn.__self__.model = self.generator.target_model
-            distorted = registry.apply(name, distorted, strength=actual_strength, seed=self.generator.seed)
+            distorted = registry.apply(
+                name, distorted, strength=actual_strength, seed=self.generator.seed
+            )
 
         return {"pixel_values": distorted, "labels": labels}

--- a/nightmarenet/data/generator.py
+++ b/nightmarenet/data/generator.py
@@ -11,6 +11,7 @@ import math
 import os
 from typing import Any, Optional
 
+import torch
 from datasets import Dataset, IterableDataset
 
 from nightmarenet.distortions.adversarial import apply_adversarial_distortions
@@ -100,6 +101,9 @@ class DreamDatasetGenerator:
         Returns:
             A new Dataset/IterableDataset with mildly distorted text.
         """
+        if not hasattr(dataset, "map"):
+            return DistortedVisionDataset(dataset, self, phase="dream")
+
         import random
 
         random.seed(self.seed)
@@ -350,6 +354,9 @@ class NightmareDatasetGenerator:
         Returns:
             A new Dataset/IterableDataset with extremely perturbed text.
         """
+        if not hasattr(dataset, "map"):
+            return DistortedVisionDataset(dataset, self, phase="nightmare")
+
         import random
 
         random.seed(self.seed)
@@ -470,3 +477,53 @@ def create_generators_from_config(
     )
 
     return dream_gen, nightmare_gen
+
+
+class DistortedVisionDataset(torch.utils.data.Dataset):
+    def __init__(self, dataset, generator, phase="dream"):
+        self.dataset = dataset
+        self.generator = generator
+        self.phase = phase
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        item = self.dataset[idx]
+        pixel_values = item["pixel_values"]
+        labels = item["labels"]
+
+        import torch
+        from nightmarenet.distortions.registry import get_vision_registry
+        registry = get_vision_registry()
+
+        # Retrieve engines matching the current phase
+        engines = []
+        vision_config = self.generator.config.get("vision", {})
+        if vision_config:
+            for name, prob in vision_config.items():
+                import random
+                meta = registry.get_engine_metadata(name)
+                if meta.get("phase") == self.phase and random.random() < prob:
+                    engines.append(name)
+        else:
+            for name in registry.engine_names:
+                meta = registry.get_engine_metadata(name)
+                if meta.get("phase") == self.phase:
+                    engines.append(name)
+
+        actual_strength = self.generator.strength
+        if self.phase == "nightmare" and getattr(self.generator, "strength_schedule", "uniform") != "uniform":
+            strengths = self.generator._compute_strengths(len(self.dataset))
+            if idx < len(strengths):
+                actual_strength = strengths[idx]
+
+        distorted = pixel_values
+        for name in engines:
+            if name in ["vision_fgsm", "vision_pgd"]:
+                fn = registry._engines.get(name)
+                if fn is not None and hasattr(fn, "__self__"):
+                    fn.__self__.model = self.generator.target_model
+            distorted = registry.apply(name, distorted, strength=actual_strength, seed=self.generator.seed)
+
+        return {"pixel_values": distorted, "labels": labels}

--- a/nightmarenet/data/loader.py
+++ b/nightmarenet/data/loader.py
@@ -245,6 +245,7 @@ def load_from_config(config: dict) -> Any:
     model_type = config.get("model", {}).get("type", "")
     if model_type == "image_classification":
         import os
+
         import torch
         import torchvision.datasets as datasets
         import torchvision.transforms as transforms
@@ -259,28 +260,52 @@ def load_from_config(config: dict) -> Any:
 
         if "cifar10" in name:
             try:
-                train_dataset = datasets.CIFAR10(root="./data", train=True, download=True, transform=transform)
-                test_dataset = datasets.CIFAR10(root="./data", train=False, download=True, transform=transform)
+                train_dataset = datasets.CIFAR10(
+                    root="./data", train=True, download=True, transform=transform
+                )
+                test_dataset = datasets.CIFAR10(
+                    root="./data", train=False, download=True, transform=transform
+                )
             except Exception as e:
                 logger.warning("Failed to load CIFAR-10, falling back to FakeData: %s", e)
-                train_dataset = datasets.FakeData(size=100, image_size=(3, 32, 32), num_classes=10, transform=transform)
-                test_dataset = datasets.FakeData(size=20, image_size=(3, 32, 32), num_classes=10, transform=transform)
+                train_dataset = datasets.FakeData(
+                    size=100, image_size=(3, 32, 32), num_classes=10, transform=transform
+                )
+                test_dataset = datasets.FakeData(
+                    size=20, image_size=(3, 32, 32), num_classes=10, transform=transform
+                )
         elif "imagenet" in name:
             path = dataset_config.get("path", "./data/imagenet_subset")
             if os.path.isdir(path):
-                train_dataset = datasets.ImageFolder(root=os.path.join(path, "train"), transform=transform)
-                test_dataset = datasets.ImageFolder(root=os.path.join(path, "val"), transform=transform)
+                train_dataset = datasets.ImageFolder(
+                    root=os.path.join(path, "train"), transform=transform
+                )
+                test_dataset = datasets.ImageFolder(
+                    root=os.path.join(path, "val"), transform=transform
+                )
             else:
-                logger.warning("ImageNet subset path %s not found. Falling back to FakeData.", path)
-                train_dataset = datasets.FakeData(size=100, image_size=(3, 224, 224), num_classes=1000, transform=transform)
-                test_dataset = datasets.FakeData(size=20, image_size=(3, 224, 224), num_classes=1000, transform=transform)
+                logger.warning(
+                    "ImageNet subset path %s not found. Falling back to FakeData.", path
+                )
+                train_dataset = datasets.FakeData(
+                    size=100, image_size=(3, 224, 224), num_classes=1000, transform=transform
+                )
+                test_dataset = datasets.FakeData(
+                    size=20, image_size=(3, 224, 224), num_classes=1000, transform=transform
+                )
         else:
             logger.warning("Unknown dataset %s. Falling back to FakeData.", name)
-            train_dataset = datasets.FakeData(size=100, image_size=(3, 32, 32), num_classes=10, transform=transform)
-            test_dataset = datasets.FakeData(size=20, image_size=(3, 32, 32), num_classes=10, transform=transform)
+            train_dataset = datasets.FakeData(
+                size=100, image_size=(3, 32, 32), num_classes=10, transform=transform
+            )
+            test_dataset = datasets.FakeData(
+                size=20, image_size=(3, 32, 32), num_classes=10, transform=transform
+            )
 
         if max_samples is not None:
-            train_dataset = torch.utils.data.Subset(train_dataset, list(range(min(max_samples, len(train_dataset)))))
+            train_dataset = torch.utils.data.Subset(
+                train_dataset, list(range(min(max_samples, len(train_dataset))))
+            )
             test_limit = min(max_samples // 5 or 1, len(test_dataset))
             test_dataset = torch.utils.data.Subset(test_dataset, list(range(test_limit)))
 

--- a/nightmarenet/data/loader.py
+++ b/nightmarenet/data/loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+import torch
 from datasets import IterableDataset, load_dataset
 
 from nightmarenet.utils.validation import (
@@ -232,15 +233,59 @@ class DatasetWrapper:
         return dataset[self.text_column]
 
 
-def load_from_config(config: dict) -> DatasetWrapper:
-    """Create and load a DatasetWrapper from a config dictionary.
+def load_from_config(config: dict) -> Any:
+    """Create and load a DatasetWrapper or VisionDatasetWrapper from a config dictionary.
 
     Args:
         config: Configuration dictionary with 'dataset' and 'seed' keys.
 
     Returns:
-        Loaded DatasetWrapper instance.
+        Loaded dataset wrapper instance.
     """
+    model_type = config.get("model", {}).get("type", "")
+    if model_type == "image_classification":
+        import os
+        import torch
+        import torchvision.datasets as datasets
+        import torchvision.transforms as transforms
+
+        dataset_config = config.get("dataset", {})
+        name = dataset_config.get("name", "cifar10").lower()
+        max_samples = dataset_config.get("max_samples")
+
+        transform = transforms.Compose([
+            transforms.ToTensor(),
+        ])
+
+        if "cifar10" in name:
+            try:
+                train_dataset = datasets.CIFAR10(root="./data", train=True, download=True, transform=transform)
+                test_dataset = datasets.CIFAR10(root="./data", train=False, download=True, transform=transform)
+            except Exception as e:
+                logger.warning("Failed to load CIFAR-10, falling back to FakeData: %s", e)
+                train_dataset = datasets.FakeData(size=100, image_size=(3, 32, 32), num_classes=10, transform=transform)
+                test_dataset = datasets.FakeData(size=20, image_size=(3, 32, 32), num_classes=10, transform=transform)
+        elif "imagenet" in name:
+            path = dataset_config.get("path", "./data/imagenet_subset")
+            if os.path.isdir(path):
+                train_dataset = datasets.ImageFolder(root=os.path.join(path, "train"), transform=transform)
+                test_dataset = datasets.ImageFolder(root=os.path.join(path, "val"), transform=transform)
+            else:
+                logger.warning("ImageNet subset path %s not found. Falling back to FakeData.", path)
+                train_dataset = datasets.FakeData(size=100, image_size=(3, 224, 224), num_classes=1000, transform=transform)
+                test_dataset = datasets.FakeData(size=20, image_size=(3, 224, 224), num_classes=1000, transform=transform)
+        else:
+            logger.warning("Unknown dataset %s. Falling back to FakeData.", name)
+            train_dataset = datasets.FakeData(size=100, image_size=(3, 32, 32), num_classes=10, transform=transform)
+            test_dataset = datasets.FakeData(size=20, image_size=(3, 32, 32), num_classes=10, transform=transform)
+
+        if max_samples is not None:
+            train_dataset = torch.utils.data.Subset(train_dataset, list(range(min(max_samples, len(train_dataset)))))
+            test_limit = min(max_samples // 5 or 1, len(test_dataset))
+            test_dataset = torch.utils.data.Subset(test_dataset, list(range(test_limit)))
+
+        return VisionDatasetWrapper(train_dataset, test_dataset)
+
     dataset_config = config.get("dataset", {})
     return DatasetWrapper(
         dataset_name=dataset_config.get("name", "wikitext"),
@@ -251,3 +296,32 @@ def load_from_config(config: dict) -> DatasetWrapper:
         seed=config.get("seed", 42),
         streaming=dataset_config.get("streaming", False),
     ).load()
+
+
+class VisionItemWrapper(torch.utils.data.Dataset):
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        img, label = self.dataset[idx]
+        if not isinstance(img, torch.Tensor):
+            from torchvision.transforms.functional import to_tensor
+            img = to_tensor(img)
+        return {"pixel_values": img, "labels": label}
+
+
+class VisionDatasetWrapper:
+    def __init__(self, train_data, test_data):
+        self._train_data = VisionItemWrapper(train_data)
+        self._test_data = VisionItemWrapper(test_data)
+
+    @property
+    def train_data(self):
+        return self._train_data
+
+    @property
+    def test_data(self):
+        return self._test_data

--- a/nightmarenet/distortions/vision/nightmare.py
+++ b/nightmarenet/distortions/vision/nightmare.py
@@ -87,9 +87,10 @@ class FGSM(ImageDistortion):
 
             with torch.enable_grad():
                 outputs = self.model(input_tensor)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
                 # Predict pseudo-label if true label not provided
-                target = outputs.max(1)[1]
-                loss = self.criterion(outputs, target)
+                target = logits.max(1)[1]
+                loss = self.criterion(logits, target)
 
                 grad = torch.autograd.grad(
                     loss, input_tensor, retain_graph=False, create_graph=False
@@ -156,7 +157,8 @@ class PGD(ImageDistortion):
             input_tensor = image.clone().detach().unsqueeze(0)
             with torch.no_grad():
                 outputs = self.model(input_tensor)
-                target = outputs.max(1)[1]
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                target = logits.max(1)[1]
 
             x_adv = image.clone().detach()
 
@@ -166,7 +168,8 @@ class PGD(ImageDistortion):
 
                 with torch.enable_grad():
                     outputs = self.model(x_adv_batch)
-                    loss = self.criterion(outputs, target)
+                    logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                    loss = self.criterion(logits, target)
                     grad = torch.autograd.grad(
                         loss, x_adv_batch, retain_graph=False, create_graph=False
                     )[0]

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -402,8 +402,16 @@ class Evaluator:
                 else:
                     baseline_perplexities = baseline.get("perplexities", [])
                     trained_perplexities = trained.get("perplexities", [])
-                    baseline_scores = [1.0 / max(p, 1e-8) for p in baseline_perplexities] if baseline_perplexities else []
-                    trained_scores = [1.0 / max(p, 1e-8) for p in trained_perplexities] if trained_perplexities else []
+                    baseline_scores = (
+                        [1.0 / max(p, 1e-8) for p in baseline_perplexities]
+                        if baseline_perplexities
+                        else []
+                    )
+                    trained_scores = (
+                        [1.0 / max(p, 1e-8) for p in trained_perplexities]
+                        if trained_perplexities
+                        else []
+                    )
                 if baseline_scores and trained_scores:
                     significance = _bootstrap_ci(
                         baseline_scores,

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -113,9 +113,12 @@ class Evaluator:
         self.device = device
         self.tracker = tracker
         self.eval_config = config.get("evaluation", {})
-        self.enabled_metrics = self.eval_config.get(
-            "metrics", ["recall", "generalization", "robustness", "hallucination"]
+        default_metrics = (
+            ["classification", "robustness"]
+            if config.get("model", {}).get("type") == "image_classification"
+            else ["recall", "generalization", "robustness", "hallucination"]
         )
+        self.enabled_metrics = self.eval_config.get("metrics", default_metrics)
         self.output_dir = self.eval_config.get("output_dir", "results")
         self.significance_alpha = self.eval_config.get("significance_alpha", 0.05)
         os.makedirs(self.output_dir, exist_ok=True)
@@ -393,14 +396,15 @@ class Evaluator:
 
             # Add statistical significance testing for robustness (per-strength scores)
             if metric_name == "robustness":
-                baseline_perplexities = baseline.get("perplexities", [])
-                trained_perplexities = trained.get("perplexities", [])
-                if baseline_perplexities and trained_perplexities:
-                    # Use inverse perplexity as the metric (higher is better).
-                    # Perplexity is lower-is-better, so 1/ppl converts it to higher-is-better
-                    # for the paired statistical test to correctly interpret improvements.
-                    baseline_scores = [1.0 / max(p, 1e-8) for p in baseline_perplexities]
-                    trained_scores = [1.0 / max(p, 1e-8) for p in trained_perplexities]
+                if "accuracies" in baseline:
+                    baseline_scores = baseline.get("accuracies", [])
+                    trained_scores = trained.get("accuracies", [])
+                else:
+                    baseline_perplexities = baseline.get("perplexities", [])
+                    trained_perplexities = trained.get("perplexities", [])
+                    baseline_scores = [1.0 / max(p, 1e-8) for p in baseline_perplexities] if baseline_perplexities else []
+                    trained_scores = [1.0 / max(p, 1e-8) for p in trained_perplexities] if trained_perplexities else []
+                if baseline_scores and trained_scores:
                     significance = _bootstrap_ci(
                         baseline_scores,
                         trained_scores,
@@ -492,6 +496,23 @@ class Evaluator:
                 ]
             )
         metrics = comparison.get("metrics", {})
+
+        if "classification" in metrics and _metric_ok(metrics["classification"]):
+            r = metrics["classification"]
+            lines.extend(
+                [
+                    "### Classification",
+                    "",
+                    "| Metric | Baseline | Trained | Delta |",
+                    "|--------|----------|---------|-------|",
+                ]
+            )
+            for key in ["accuracy", "f1_weighted"]:
+                bl = r.get("baseline", {}).get(key, "N/A")
+                tr = r.get("trained", {}).get(key, "N/A")
+                delta = r.get("deltas", {}).get(key, "N/A")
+                lines.append(f"| {key} | {_fmt(bl)} | {_fmt(tr)} | {_fmt(delta, signed=True)} |")
+            lines.append("")
 
         if "recall" in metrics and _metric_ok(metrics["recall"]):
             r = metrics["recall"]

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -86,25 +86,25 @@ def quick_robustness_score(
     """
     if len(base_dataset) == 0:
         return 0.0
-    
+
     is_vision = tokenizer is None or not hasattr(base_dataset, "map")
     if is_vision:
         try:
             indices = list(range(min(subset_size, len(base_dataset))))
             subset = torch.utils.data.Subset(base_dataset, indices)
-            
+
             class DummyGenerator:
                 def __init__(self, strength, seed, config):
                     self.strength = strength
                     self.seed = seed
                     self.config = config
                     self.target_model = model
-            
+
             from nightmarenet.data.generator import DistortedVisionDataset
             dummy_gen = DummyGenerator(strength, seed=42, config={})
             distorted_ds = DistortedVisionDataset(subset, dummy_gen, phase="dream")
             dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)
-            
+
             metrics = classification_metrics(model, dataloader, device)
             return metrics.get("accuracy", 0.0)
         except Exception as e:

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -86,6 +86,31 @@ def quick_robustness_score(
     """
     if len(base_dataset) == 0:
         return 0.0
+    
+    is_vision = tokenizer is None or not hasattr(base_dataset, "map")
+    if is_vision:
+        try:
+            indices = list(range(min(subset_size, len(base_dataset))))
+            subset = torch.utils.data.Subset(base_dataset, indices)
+            
+            class DummyGenerator:
+                def __init__(self, strength, seed, config):
+                    self.strength = strength
+                    self.seed = seed
+                    self.config = config
+                    self.target_model = model
+            
+            from nightmarenet.data.generator import DistortedVisionDataset
+            dummy_gen = DummyGenerator(strength, seed=42, config={})
+            distorted_ds = DistortedVisionDataset(subset, dummy_gen, phase="dream")
+            dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)
+            
+            metrics = classification_metrics(model, dataloader, device)
+            return metrics.get("accuracy", 0.0)
+        except Exception as e:
+            logger.warning("Error during quick robustness computation: %s", e)
+            return 0.0
+
     try:
         subset = base_dataset.shuffle(seed=42).select(range(min(subset_size, len(base_dataset))))
         distorted = subset.map(
@@ -209,6 +234,16 @@ def recall_score(
     """
     model.eval()
 
+    if tokenizer is None:
+        metrics = classification_metrics(model, dataloader, device)
+        if "error" in metrics:
+            return {"metric": "recall", "token_accuracy": 0.0, "perplexity": float("inf")}
+        return {
+            "metric": "recall",
+            "token_accuracy": metrics["accuracy"],
+            "perplexity": float("inf"),
+        }
+
     if tokenizer.pad_token_id is None:
         fallback = getattr(tokenizer, "eos_token_id", None) or 0
         logger.warning("tokenizer.pad_token_id is None, falling back to %d", fallback)
@@ -311,6 +346,39 @@ def robustness_score(
     """
     if strengths is None:
         strengths = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+
+    is_vision = tokenizer is None or not hasattr(base_dataset, "map")
+    if is_vision:
+        accuracies = []
+        for strength in strengths:
+            class DummyGenerator:
+                def __init__(self, strength, seed, config):
+                    self.strength = strength
+                    self.seed = seed
+                    self.config = config
+                    self.target_model = model
+
+            from nightmarenet.data.generator import DistortedVisionDataset
+            dummy_gen = DummyGenerator(strength, seed=42, config={})
+            distorted_ds = DistortedVisionDataset(base_dataset, dummy_gen, phase="dream")
+            dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)
+
+            metrics = classification_metrics(model, dataloader, device)
+            acc = metrics.get("accuracy", 0.0)
+            accuracies.append(acc)
+            logger.info("Robustness - Strength %.1f: Accuracy = %.4f", strength, acc)
+
+        _trapz_fn = getattr(np, "trapezoid", None)
+        if _trapz_fn is None:
+            _trapz_fn = np.trapz
+        auc = float(_trapz_fn(accuracies, strengths))
+
+        return {
+            "metric": "robustness",
+            "strengths": strengths,
+            "accuracies": accuracies,
+            "auc_robustness": _safe_float(auc),
+        }
 
     perplexities = []
 
@@ -467,7 +535,7 @@ def classification_metrics(
             for batch in tqdm(dataloader, desc="Computing classification metrics"):
                 batch = {k: v.to(device) for k, v in batch.items()}
                 outputs = model(**batch)
-                logits = outputs.logits
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
                 preds = logits.argmax(dim=-1).cpu().numpy()
                 labels = batch["labels"].cpu().numpy()
                 all_preds.extend(preds.tolist())

--- a/nightmarenet/phases/ingest.py
+++ b/nightmarenet/phases/ingest.py
@@ -60,7 +60,13 @@ class IngestPhase(Phase):
         }
         with trace_phase("ingest", span_attrs):
             try:
-                if self.urls:
+                model_type = context.config.get("model", {}).get("type", "")
+                if model_type == "image_classification":
+                    from nightmarenet.data.loader import load_from_config
+                    wrapper = load_from_config(context.config)
+                    context.dataset = wrapper.train_data
+                    context.eval_dataset = wrapper.test_data
+                elif self.urls:
                     context.dataset = ingestor.from_urls(self.urls)
                 elif self.file_path:
                     context.dataset = ingestor.from_file(self.file_path)

--- a/nightmarenet/phases/prepare.py
+++ b/nightmarenet/phases/prepare.py
@@ -49,7 +49,13 @@ class PreparePhase(Phase):
                 )
                 n_total = len(base_for_split)
 
-                if eval_split_ratio > 0.0 and n_total >= _MIN_EVAL_SAMPLES:
+                model_type = context.config.get("model", {}).get("type", "")
+                if model_type == "image_classification":
+                    wake_data = base_for_split
+                    if context.eval_dataset is None:
+                        context.eval_dataset = base_for_split
+                    context.distortion_fn = lambda x, strength: x
+                elif eval_split_ratio > 0.0 and n_total >= _MIN_EVAL_SAMPLES:
                     n_eval = max(1, int(n_total * eval_split_ratio))
                     n_train = n_total - n_eval
                     wake_data = base_for_split.select(list(range(n_train)))
@@ -60,6 +66,7 @@ class PreparePhase(Phase):
                         n_eval,
                         eval_split_ratio,
                     )
+                    context.distortion_fn = apply_text_distortions
                 else:
                     if eval_split_ratio > 0.0:
                         logger.warning(
@@ -70,8 +77,7 @@ class PreparePhase(Phase):
                         )
                     wake_data = base_for_split
                     context.eval_dataset = base_for_split
-
-                context.distortion_fn = apply_text_distortions
+                    context.distortion_fn = apply_text_distortions
 
                 dream_base = (
                     context.dream_base if context.dream_base is not None else context.dataset

--- a/nightmarenet/training/phases.py
+++ b/nightmarenet/training/phases.py
@@ -96,8 +96,8 @@ class WakePhase:
             for step, batch in enumerate(progress):
                 batch = {k: v.to(self.device) for k, v in batch.items()}
                 # Only causal LM needs labels=input_ids.
-                # Sequence classification already has batch["labels"].
-                if self.model_type != "seq_classification":
+                # Sequence classification and image classification already have batch["labels"].
+                if self.model_type not in ("seq_classification", "image_classification"):
                     batch["labels"] = batch["input_ids"]
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     outputs = self.model(
@@ -269,7 +269,7 @@ class DreamPhase:
             for step, batch in enumerate(progress):
                 batch = {k: v.to(self.device) for k, v in batch.items()}
 
-                if self.model_type != "seq_classification":
+                if self.model_type not in ("seq_classification", "image_classification"):
                     batch["labels"] = batch["input_ids"]
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     outputs = self.model(**batch)
@@ -462,7 +462,7 @@ class NightmarePhase:
                 for step, batch in enumerate(progress):
                     batch = {k: v.to(self.device) for k, v in batch.items()}
 
-                    if self.model_type != "seq_classification":
+                    if self.model_type not in ("seq_classification", "image_classification"):
                         batch["labels"] = batch["input_ids"]
                     with torch.amp.autocast("cuda", enabled=use_amp):
                         outputs = self.model(**batch)
@@ -646,7 +646,7 @@ class CompressionPhase:
                     batch = {k: v.to(self.device) for k, v in batch.items()}
                     use_amp = self.scaler is not None
                     with torch.amp.autocast("cuda", enabled=use_amp):
-                        if self.model_type != "seq_classification":
+                        if self.model_type not in ("seq_classification", "image_classification"):
                             batch["labels"] = batch["input_ids"]
                         outputs = self.model(**batch)
                         loss = outputs.loss

--- a/nightmarenet/training/trainer.py
+++ b/nightmarenet/training/trainer.py
@@ -13,6 +13,7 @@ import math
 import os
 import signal
 import threading
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 import torch
@@ -55,9 +56,6 @@ _MODEL_TYPE_MAP = {
     "masked_lm": AutoModelForMaskedLM,
     "seq_classification": AutoModelForSequenceClassification,
 }
-
-
-from dataclasses import dataclass
 
 @dataclass
 class ModelOutput:
@@ -223,7 +221,8 @@ class Trainer:
                 model_cls = _MODEL_TYPE_MAP.get(self.model_type)
                 if model_cls is None:
                     raise ValueError(
-                        f"Unknown model type '{self.model_type}'. Supported: {list(_MODEL_TYPE_MAP)}"
+                        f"Unknown model type '{self.model_type}'. "
+                        f"Supported: {list(_MODEL_TYPE_MAP)}"
                     )
                 try:
                     kwargs = {}

--- a/nightmarenet/training/trainer.py
+++ b/nightmarenet/training/trainer.py
@@ -57,6 +57,27 @@ _MODEL_TYPE_MAP = {
 }
 
 
+from dataclasses import dataclass
+
+@dataclass
+class ModelOutput:
+    loss: Optional[torch.Tensor]
+    logits: torch.Tensor
+
+class VisionModelWrapper(torch.nn.Module):
+    def __init__(self, base_model, criterion=None):
+        super().__init__()
+        self.base_model = base_model
+        self.criterion = criterion or torch.nn.CrossEntropyLoss()
+
+    def forward(self, pixel_values, labels=None, **kwargs):
+        logits = self.base_model(pixel_values)
+        loss = None
+        if labels is not None:
+            loss = self.criterion(logits, labels)
+        return ModelOutput(loss=loss, logits=logits)
+
+
 def _get_device(config: dict) -> torch.device:
     """Determine the training device from config."""
     device_str = config.get("model", {}).get("device", "auto")
@@ -92,6 +113,10 @@ def _tokenize_dataset(
     label_column: Optional[str] = None,
 ) -> DataLoader:
     """Tokenize a dataset and return a DataLoader."""
+    if tokenizer is None or not hasattr(dataset, "map"):
+        return DataLoader(
+            dataset, batch_size=batch_size, shuffle=True, worker_init_fn=_worker_init_fn
+        )
 
     def tokenize_fn(examples):
         tokenized = tokenizer(
@@ -177,18 +202,36 @@ class Trainer:
                 model_name,
                 self.model_type,
             )
-            model_cls = _MODEL_TYPE_MAP.get(self.model_type)
-            if model_cls is None:
-                raise ValueError(
-                    f"Unknown model type '{self.model_type}'. Supported: {list(_MODEL_TYPE_MAP)}"
-                )
-            try:
-                kwargs = {}
-                if self.model_type == "seq_classification":
-                    kwargs["num_labels"] = self.model_config.get("num_labels", 2)
-                self.model = model_cls.from_pretrained(model_name, **kwargs)
-            except Exception as exc:
-                raise RuntimeError(f"Failed to load model '{model_name}': {exc}") from exc
+            if self.model_type == "image_classification":
+                import torchvision.models as torchvision_models
+                model_creator = None
+                for name in dir(torchvision_models):
+                    if name.lower() == model_name.lower():
+                        model_creator = getattr(torchvision_models, name)
+                        break
+                if model_creator is None:
+                    raise ValueError(
+                        f"Unknown torchvision model name '{model_name}'."
+                    )
+                num_classes = self.model_config.get("num_labels", 10)
+                try:
+                    base_model = model_creator(num_classes=num_classes)
+                except TypeError:
+                    base_model = model_creator()
+                self.model = VisionModelWrapper(base_model)
+            else:
+                model_cls = _MODEL_TYPE_MAP.get(self.model_type)
+                if model_cls is None:
+                    raise ValueError(
+                        f"Unknown model type '{self.model_type}'. Supported: {list(_MODEL_TYPE_MAP)}"
+                    )
+                try:
+                    kwargs = {}
+                    if self.model_type == "seq_classification":
+                        kwargs["num_labels"] = self.model_config.get("num_labels", 2)
+                    self.model = model_cls.from_pretrained(model_name, **kwargs)
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to load model '{model_name}': {exc}") from exc
         else:
             self.model = model
         self.model.to(self.device)
@@ -199,7 +242,9 @@ class Trainer:
 
             load_model_weights(self.model, resume_from, self.device)
 
-        if tokenizer is None:
+        if self.model_type == "image_classification":
+            self.tokenizer = None
+        elif tokenizer is None:
             has_resume = resume_from and os.path.exists(resume_from)
             tokenizer_load_path = resume_from if has_resume else model_name
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_load_path)
@@ -336,7 +381,8 @@ class Trainer:
         )
 
         # Save tokenizer
-        self.tokenizer.save_pretrained(path)
+        if self.tokenizer is not None:
+            self.tokenizer.save_pretrained(path)
 
         # Save training state
         import time
@@ -969,8 +1015,12 @@ class Trainer:
             dist.barrier()
 
         if not (dist.is_available() and dist.is_initialized()) or dist.get_rank() == 0:
-            self.model.save_pretrained(final_path)
-            self.tokenizer.save_pretrained(final_path)
+            if hasattr(self.model, "save_pretrained"):
+                self.model.save_pretrained(final_path)
+            else:
+                torch.save(self.model.state_dict(), os.path.join(final_path, "pytorch_model.bin"))
+            if self.tokenizer is not None:
+                self.tokenizer.save_pretrained(final_path)
             self._save_history()
 
         if dist.is_available() and dist.is_initialized():

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -233,7 +233,7 @@ def validate_config(config: dict) -> list[str]:
         List of validation error messages (empty if valid).
     """
     errors = []
-    
+
     model_type = _get_nested(config, "model.type")
     if model_type != "image_classification":
         if _get_nested(config, "model.max_length") is None:

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -150,10 +150,10 @@ _SCHEMA: dict[str, tuple] = {
     "model.name": (str, None, None, True),
     "model.type": (str, None, None, True),
     "model.num_labels": (int, 1, 10000, False),
-    "model.max_length": (int, 1, 8192, True),
+    "model.max_length": (int, 1, 8192, False),
     "model.device": (str, None, None, True),
     "dataset.name": (str, None, None, True),
-    "dataset.text_column": (str, None, None, True),
+    "dataset.text_column": (str, None, None, False),
     "dataset.streaming": (bool, None, None, False),
     "training.wake_epochs": (int, 0, 1000, True),
     "training.dream_epochs": (int, 0, 1000, True),
@@ -233,6 +233,14 @@ def validate_config(config: dict) -> list[str]:
         List of validation error messages (empty if valid).
     """
     errors = []
+    
+    model_type = _get_nested(config, "model.type")
+    if model_type != "image_classification":
+        if _get_nested(config, "model.max_length") is None:
+            errors.append("Missing required config key: 'model.max_length'")
+        if _get_nested(config, "dataset.text_column") is None:
+            errors.append("Missing required config key: 'dataset.text_column'")
+
     for dotted_key, (expected_type, min_val, max_val, required) in _SCHEMA.items():
         value = _get_nested(config, dotted_key)
         if value is None:

--- a/tests/test_vision_pipeline.py
+++ b/tests/test_vision_pipeline.py
@@ -1,6 +1,5 @@
 """Integration test for the computer vision sleep-cycle pipeline."""
 
-import pytest
 from nightmarenet.pipeline import Pipeline, PipelineStatus
 
 
@@ -51,7 +50,8 @@ def test_full_vision_pipeline_cycle():
 
     # 1. Ingest (mock CIFAR-10 download to force fallback to FakeData immediately)
     from unittest.mock import patch
-    with patch("torchvision.datasets.CIFAR10", side_effect=Exception("Mock network download failure")):
+    side_effect = Exception("Mock network download failure")
+    with patch("torchvision.datasets.CIFAR10", side_effect=side_effect):
         pipe.ingest()
     assert pipe.metrics.status == PipelineStatus.INGESTING
 

--- a/tests/test_vision_pipeline.py
+++ b/tests/test_vision_pipeline.py
@@ -1,0 +1,76 @@
+"""Integration test for the computer vision sleep-cycle pipeline."""
+
+import pytest
+from nightmarenet.pipeline import Pipeline, PipelineStatus
+
+
+def test_full_vision_pipeline_cycle():
+    config = {
+        "model": {
+            "name": "resnet18",
+            "type": "image_classification",
+            "num_labels": 10,
+            "device": "cpu",
+        },
+        "dataset": {
+            "name": "cifar10",
+            "max_samples": 10,
+        },
+        "training": {
+            "wake_epochs": 1,
+            "dream_epochs": 1,
+            "nightmare_epochs": 1,
+            "compress_epochs": 1,
+            "num_cycles": 1,
+            "batch_size": 2,
+            "learning_rate": 1e-4,
+            "weight_decay": 0.01,
+            "max_grad_norm": 1.0,
+            "gradient_accumulation_steps": 1,
+            "save_every_phase": False,
+            "checkpoint_dir": "checkpoints_vision",
+            "log_dir": "logs_vision",
+        },
+        "distortion": {
+            "dream_strength": 0.25,
+            "nightmare_strength": 0.75,
+        },
+        "compression": {
+            "pruning_ratio": 0.1,
+            "pruning_method": "magnitude",
+        },
+        "evaluation": {
+            "metrics": ["classification", "robustness"],
+            "strengths": [0.2, 0.6],
+        },
+        "tracking": {"backend": "none"},
+        "seed": 42,
+    }
+
+    pipe = Pipeline(config)
+
+    # 1. Ingest (mock CIFAR-10 download to force fallback to FakeData immediately)
+    from unittest.mock import patch
+    with patch("torchvision.datasets.CIFAR10", side_effect=Exception("Mock network download failure")):
+        pipe.ingest()
+    assert pipe.metrics.status == PipelineStatus.INGESTING
+
+    # 2. Prepare
+    pipe.prepare()
+    assert pipe.metrics.status == PipelineStatus.PREPARING
+
+    # 3. Train
+    pipe.train()
+
+    # 4. Evaluate
+    pipe.evaluate()
+    assert pipe.metrics.status == PipelineStatus.EVALUATING
+    assert pipe.metrics.error is None
+    assert pipe.metrics.report_md is not None
+
+    # Check that evaluation comparison results exist and are correct
+    assert pipe._context.comparison is not None
+    comparison = pipe._context.comparison
+    assert "metrics" in comparison
+    assert "classification" in comparison["metrics"]
+    assert "robustness" in comparison["metrics"]


### PR DESCRIPTION
## Summary

Adds end-to-end image classification support for the 4-phase Wake→Dream→Nightmare→Compress sleep-cycle, enabling training of torchvision models (e.g. ResNet-18) on datasets like CIFAR-10 without touching the NLP pipeline.

## Motivation

Extends NightmareNet beyond NLP to support CV robustness training.

Closes #171

## Changes

- `nightmarenet/utils/config.py` — make `max_length`/`text_column` optional for `image_classification`
- `nightmarenet/phases/ingest.py` — load torchvision datasets from config when `model.type: image_classification`
- `nightmarenet/data/loader.py` — add `VisionDatasetWrapper`, `VisionItemWrapper`; CIFAR-10 loader with FakeData fallback
- `nightmarenet/data/generator.py` — add `DistortedVisionDataset`; Dream/Nightmare generators return it for image tasks
- `nightmarenet/training/trainer.py` — add `VisionModelWrapper` (logits+loss shim); guard `save_pretrained`/`tokenizer` for vision
- `nightmarenet/training/phases.py` — guard `batch["labels"] = batch["input_ids"]` for `image_classification` in all 4 phase loops
- `nightmarenet/phases/prepare.py` — bypass NLP split for image tasks; set no-op `distortion_fn`
- `nightmarenet/distortions/vision/nightmare.py` — unpack `.logits` from wrapper outputs in FGSM/PGD
- `nightmarenet/evaluation/metrics.py` — accuracy-based evaluation for vision (branch on `is_vision`)
- `nightmarenet/evaluation/evaluator.py` — default metrics + bootstrapping for vision
- `nightmarenet/compression/distillation.py` — pixel-level perturbation; skip sequence-length attributes for vision
- `configs/benchmark_cifar10.yaml` — reference config for ResNet-18 on CIFAR-10
- `tests/test_vision_pipeline.py` — integration test: full 4-phase cycle on FakeData, CPU
- `README.md` — new **Computer Vision Support** section

## Acceptance Criteria

- [x] `model.type: image_classification` runs the full sleep-cycle without error
- [x] Existing NLP tests are unaffected (all PASS in isolation)
- [x] Integration test passes with FakeData (no internet required)
- [x] Vision distortions (FGSM/PGD) work correctly with wrapped model output

## Type

- [x] Feature (non-breaking change that adds functionality)

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors
- [x] `pytest tests/test_vision_pipeline.py` — passes
- [x] New functionality has corresponding tests (`tests/test_vision_pipeline.py`)
- [x] Commit messages follow Conventional Commits
- [x] No new imports of hosted-only libraries

## Documentation

- [x] README.md updated

## AI Disclosure

- [x] This PR includes AI-assisted code — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)

## Breaking Changes

N/A — NLP pipeline is completely unmodified.

<details>
<summary>Reviewer notes</summary>

- Vision FGSM/PGD requires a live model reference for gradient computation; this is injected dynamically per-batch in `DistortedVisionDataset.__getitem__`.
- Bootstrap CI in the evaluator skips perplexity inversion for vision (accuracy is already "higher is better").
- `distortion_fn` for image tasks is set to a no-op lambda (not `None`) to avoid None-guard issues in the robustness evaluator.
- `checkpoints_vision/`, `logs_vision/`, and `data/*.tar.gz` should be covered by `.gitignore`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for complete computer-vision image classification workflows, including CIFAR-10 and fallback datasets.
  * Added image-aware Wake, Dream, Nightmare, and Compression phases with adversarial distortion support.
  * Added a CIFAR-10 benchmark configuration using ResNet-18.
  * Added classification accuracy, F1, and robustness metrics across distortion strengths.
  * Added model export and checkpoint support for vision workflows.

* **Documentation**
  * Added guidance for configuring and evaluating computer-vision training pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->