### PR TITLE
Fix config sync: move output_dir/output_format to evaluation, add label_column

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -99,6 +99,8 @@ evaluation:
   eval_split_ratio: 0.2         # Fraction of ingested data held out for evaluation; 0.0 disables splitting
   # glue_tasks: null            # null = all tasks; or list: ["sst2", "mrpc"]
   # glue_max_samples: null      # Limit per-task samples for quick runs
+  output_dir: "results"         # Directory for evaluation results and reports
+  output_format: "json"         # "json" or "markdown"
   # Certified robustness (randomized smoothing) — only used if "certification" is
   # uncommented above. Compute-expensive (n forward passes per certified sample), so it
   # is opt-in and budget-capped rather than running by default.
@@ -111,14 +113,13 @@ evaluation:
     subset_size: 50        # Number of samples to certify (controls total compute)
     budget: 100000          # Max total forward passes (n * subset_size); n is reduced
                              # proportionally (with a warning) if this would be exceeded
+    label_column: "label"   # Column name containing ground-truth labels (for seq_classification datasets)
 
 # Experiment tracking
 tracking:
   backend: none        # none|wandb|tensorboard
   project: nightmarenet
   log_dir: logs/runs
-  output_dir: "results"
-  output_format: "json"  # "json" or "markdown"
 
   # Generate EU AI Act Article 15 compliance reports
   compliance_report: false

--- a/nightmarenet/phases/evaluate.py
+++ b/nightmarenet/phases/evaluate.py
@@ -89,7 +89,8 @@ class EvaluatePhase(Phase):
                 if tracking_cfg.get("compliance_report", False):
                     from nightmarenet.compliance.report import generate_report
 
-                    output_dir = tracking_cfg.get("output_dir", "results")
+                    eval_cfg = context.config.get("evaluation", {})
+                    output_dir = eval_cfg.get("output_dir", "results")
                     model_path = ""
                     training_cfg = context.config.get("training", {})
                     checkpoint_dir = training_cfg.get("checkpoint_dir")


### PR DESCRIPTION
## Summary

Synchronize `configs/default.yaml` with `DEFAULT_CONFIG` by aligning configuration structure and documenting all evaluator-supported configuration keys.

## Motivation

The sample configuration had drifted from `DEFAULT_CONFIG`, resulting in misplaced settings and undocumented configuration options. This PR aligns the YAML configuration with the application's expected structure to ensure configuration values are loaded correctly and accurately documented.

Closes #221

## Changes

- Updated `configs/default.yaml`
  - Moved `output_dir` from `tracking` to `evaluation`
  - Moved `output_format` from `tracking` to `evaluation`
  - Added `label_column: "label"` to the `certification` configuration with an explanatory comment
- Updated `nightmarenet/phases/evaluate.py`
  - Read `output_dir` from the `evaluation` configuration instead of the `tracking` configuration
- Verified that the sample configuration matches the structure defined by `DEFAULT_CONFIG`
- Confirmed evaluator behavior using the synchronized configuration

## Acceptance Criteria

- [x] `configs/default.yaml` matches the structure of `DEFAULT_CONFIG`
- [x] `output_dir` is defined under the `evaluation` configuration
- [x] `output_format` is defined under the `evaluation` configuration
- [x] `label_column` is documented in the certification configuration
- [x] Evaluator reads configuration values from the correct location
- [x] Configuration loads successfully without errors
- [x] Existing evaluator tests continue to pass

## Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [ ] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [ ] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [x] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [x] No secrets, keys, or credentials in code or comments
- [x] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | N/A |
| Desktop (light mode) | N/A |
| Mobile (375px) | N/A |

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

This PR resolves configuration drift between the documented YAML configuration and the application's internal defaults. It aligns configuration placement with `DEFAULT_CONFIG`, updates the evaluator to read the correct configuration path, and documents the previously missing `label_column` setting. The change is backward compatible aside from correcting the configuration hierarchy, and all evaluator tests continue to pass.

</details>