### PR TITLE
feat: add empty states for dashboard components

### DIFF
--- a/frontend/src/components/dashboard/BenchmarkSuite.tsx
+++ b/frontend/src/components/dashboard/BenchmarkSuite.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { Progress } from "@/components/ui/Progress";
 import { useToast } from "@/components/ui/Toast";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { IconBenchmark, IconCheck, IconRunning } from "./icons";
 
 interface Benchmark {
@@ -41,6 +42,7 @@ const CATEGORY_LABEL: Record<Benchmark["category"], string> = {
 export function BenchmarkSuite() {
   const [running, setRunning] = useState<Record<string, number>>({});
   const toast = useToast();
+  const hasBenchmarks = BENCHMARKS.length > 0;
 
   const start = (b: Benchmark) => {
     if (running[b.id] !== undefined) return;
@@ -79,71 +81,82 @@ export function BenchmarkSuite() {
       icon={<IconBenchmark size={14} />}
       glow="neural"
       toolbar={
-        <Button variant="primary" size="sm" onClick={startAll}>
-          <IconRunning size={11} /> Run all
-        </Button>
+        hasBenchmarks ? (
+          <Button variant="primary" size="sm" onClick={startAll}>
+            <IconRunning size={11} /> Run all
+          </Button>
+        ) : undefined
       }
     >
-      <ul className="space-y-2">
-        {BENCHMARKS.map((b, idx) => {
-          const pct = running[b.id];
-          const isRunning = pct !== undefined;
-          return (
-            <motion.li
-              key={b.id}
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, delay: idx * 0.04 }}
-              className="rounded-lg border border-white/[0.05] bg-white/[0.02] p-3"
-            >
-              <div className="flex items-start gap-3">
-                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white/[0.04] text-slate-300">
-                  <IconBenchmark size={13} />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-slate-100">{b.name}</p>
-                    <Badge variant="outline" size="xs">{CATEGORY_LABEL[b.category]}</Badge>
-                    {b.default && <Badge variant="neural" size="xs">default</Badge>}
-                  </div>
-                  <p className="mt-0.5 text-[11px] text-slate-400">{b.description}</p>
-                  <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-slate-400">
-                    <span>~ {b.duration}</span>
-                    {b.lastScore !== null && (
-                      <span>
-                        last:{" "}
-                        <span className="font-mono text-slate-300">{b.lastScore.toFixed(1)}</span>
-                      </span>
-                    )}
-                    <span className={b.trend >= 0 ? "text-emerald-300" : "text-nightmare-soft"}>
-                      {b.trend >= 0 ? "+" : ""}
-                      {b.trend.toFixed(1)} pts
-                    </span>
-                  </div>
-                  {isRunning && (
-                    <div className="mt-2">
-                      <Progress value={pct} tone="neural" size="xs" indeterminate={pct < 5} />
+      {!hasBenchmarks ? (
+        <EmptyState
+          icon={<IconBenchmark size={18} />}
+          title="No benchmarks available"
+          description="Your benchmark suite is empty. Create or configure benchmarks to begin testing."
+          primary={{ label: "Configure Benchmarks", onClick: () => console.log("[BenchmarkSuite] empty-state primary") }}
+        />
+      ) : (
+        <ul className="space-y-2">
+          {BENCHMARKS.map((b, idx) => {
+            const pct = running[b.id];
+            const isRunning = pct !== undefined;
+            return (
+              <motion.li
+                key={b.id}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.2, delay: idx * 0.04 }}
+                className="rounded-lg border border-white/[0.05] bg-white/[0.02] p-3"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white/[0.04] text-slate-300">
+                    <IconBenchmark size={13} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold text-slate-100">{b.name}</p>
+                      <Badge variant="outline" size="xs">{CATEGORY_LABEL[b.category]}</Badge>
+                      {b.default && <Badge variant="neural" size="xs">default</Badge>}
                     </div>
-                  )}
+                    <p className="mt-0.5 text-[11px] text-slate-400">{b.description}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-slate-400">
+                      <span>~ {b.duration}</span>
+                      {b.lastScore !== null && (
+                        <span>
+                          last:{" "}
+                          <span className="font-mono text-slate-300">{b.lastScore.toFixed(1)}</span>
+                        </span>
+                      )}
+                      <span className={b.trend >= 0 ? "text-emerald-300" : "text-nightmare-soft"}>
+                        {b.trend >= 0 ? "+" : ""}
+                        {b.trend.toFixed(1)} pts
+                      </span>
+                    </div>
+                    {isRunning && (
+                      <div className="mt-2">
+                        <Progress value={pct} tone="neural" size="xs" indeterminate={pct < 5} />
+                      </div>
+                    )}
+                  </div>
+                  <Button
+                    variant={isRunning ? "ghost" : "secondary"}
+                    size="sm"
+                    onClick={() => start(b)}
+                    disabled={isRunning}
+                    loading={isRunning}
+                  >
+                    {isRunning ? "Running…" : (
+                      <>
+                        <IconCheck size={11} /> Run now
+                      </>
+                    )}
+                  </Button>
                 </div>
-                <Button
-                  variant={isRunning ? "ghost" : "secondary"}
-                  size="sm"
-                  onClick={() => start(b)}
-                  disabled={isRunning}
-                  loading={isRunning}
-                >
-                  {isRunning ? "Running…" : (
-                    <>
-                      <IconCheck size={11} /> Run now
-                    </>
-                  )}
-                </Button>
-              </div>
-            </motion.li>
-          );
-        })}
-      </ul>
+              </motion.li>
+            );
+          })}
+        </ul>
+      )}
     </Panel>
   );
 }

--- a/frontend/src/components/dashboard/ModelComparison.tsx
+++ b/frontend/src/components/dashboard/ModelComparison.tsx
@@ -6,6 +6,7 @@ import { Panel } from "./Panel";
 import { Badge } from "@/components/ui/Badge";
 import { Select } from "@/components/ui/Select";
 import { Progress } from "@/components/ui/Progress";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useDemoMode } from "@/lib/hooks";
 import { IconTrend } from "./icons";
 
@@ -104,6 +105,7 @@ export function ModelComparison() {
   const [a, setA] = useState("base");
   const [b, setB] = useState("hardened");
   const { isLive } = useDemoMode();
+  const hasEnoughModels = Object.keys(MODELS).length >= 2;
   const ma = MODELS[a];
   const mb = MODELS[b];
 
@@ -114,56 +116,69 @@ export function ModelComparison() {
       icon={<IconTrend size={14} />}
       glow="neural"
       toolbar={
-        <div className="flex items-center gap-2">
-          {!isLive && <Badge variant="warning" size="xs">demo data</Badge>}
-          <Badge variant="neural" size="xs">5 metrics</Badge>
-        </div>
+        hasEnoughModels ? (
+          <div className="flex items-center gap-2">
+            {!isLive && <Badge variant="warning" size="xs">demo data</Badge>}
+            <Badge variant="neural" size="xs">5 metrics</Badge>
+          </div>
+        ) : undefined
       }
     >
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <Select
-          size="sm"
-          label="Model A"
-          value={a}
-          onChange={setA}
-          options={Object.values(MODELS).map((m) => ({ value: m.id, label: m.name }))}
+      {!hasEnoughModels ? (
+        <EmptyState
+          icon={<IconTrend size={18} />}
+          title="Insufficient models"
+          description="Model comparison requires at least two models. Add another model to compare performance."
+          primary={{ label: "Add Model", onClick: () => console.log("[ModelComparison] empty-state primary") }}
         />
-        <Select
-          size="sm"
-          label="Model B"
-          value={b}
-          onChange={setB}
-          options={Object.values(MODELS).map((m) => ({ value: m.id, label: m.name }))}
-        />
-      </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Select
+              size="sm"
+              label="Model A"
+              value={a}
+              onChange={setA}
+              options={Object.values(MODELS).map((m) => ({ value: m.id, label: m.name }))}
+            />
+            <Select
+              size="sm"
+              label="Model B"
+              value={b}
+              onChange={setB}
+              options={Object.values(MODELS).map((m) => ({ value: m.id, label: m.name }))}
+            />
+          </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-3">
-        <div className="rounded-lg border border-emerald-500/15 bg-emerald-500/[0.04] p-2.5">
-          <p className="text-[10px] uppercase tracking-widest text-emerald-300">Model A</p>
-          <p className="truncate text-sm text-slate-100">{ma.name}</p>
-          <p className="text-[10px] text-slate-400">{ma.size} · {ma.flops} · trained on {ma.trainedOn}</p>
-        </div>
-        <div className="rounded-lg border border-slate-500/15 bg-white/[0.02] p-2.5">
-          <p className="text-[10px] uppercase tracking-widest text-slate-400">Model B</p>
-          <p className="truncate text-sm text-slate-100">{mb.name}</p>
-          <p className="text-[10px] text-slate-400">{mb.size} · {mb.flops} · trained on {mb.trainedOn}</p>
-        </div>
-      </div>
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div className="rounded-lg border border-emerald-500/15 bg-emerald-500/[0.04] p-2.5">
+              <p className="text-[10px] uppercase tracking-widest text-emerald-300">Model A</p>
+              <p className="truncate text-sm text-slate-100">{ma.name}</p>
+              <p className="text-[10px] text-slate-400">{ma.size} · {ma.flops} · trained on {ma.trainedOn}</p>
+            </div>
+            <div className="rounded-lg border border-slate-500/15 bg-white/[0.02] p-2.5">
+              <p className="text-[10px] uppercase tracking-widest text-slate-400">Model B</p>
+              <p className="truncate text-sm text-slate-100">{mb.name}</p>
+              <p className="text-[10px] text-slate-400">{mb.size} · {mb.flops} · trained on {mb.trainedOn}</p>
+            </div>
+          </div>
 
-      <div className="mt-4 space-y-1 border-t border-white/[0.04] pt-2">
-        <MetricRow label="Robustness" a={ma.robustness} b={mb.robustness} format={(n) => n.toFixed(0)} />
-        <MetricRow label="Accuracy" a={ma.accuracy} b={mb.accuracy} format={(n) => `${n.toFixed(1)}%`} />
-        <MetricRow label="Latency" a={ma.latency} b={mb.latency} higherIsBetter={false} format={(n) => `${n}ms`} />
-        <MetricRow label="Compute Cost" a={ma.cost} b={mb.cost} higherIsBetter={false} format={(n) => `${n.toFixed(2)}×`} />
-      </div>
+          <div className="mt-4 space-y-1 border-t border-white/[0.04] pt-2">
+            <MetricRow label="Robustness" a={ma.robustness} b={mb.robustness} format={(n) => n.toFixed(0)} />
+            <MetricRow label="Accuracy" a={ma.accuracy} b={mb.accuracy} format={(n) => `${n.toFixed(1)}%`} />
+            <MetricRow label="Latency" a={ma.latency} b={mb.latency} higherIsBetter={false} format={(n) => `${n}ms`} />
+            <MetricRow label="Compute Cost" a={ma.cost} b={mb.cost} higherIsBetter={false} format={(n) => `${n.toFixed(2)}×`} />
+          </div>
 
-      <div className="mt-3">
-        <p className="mb-1 text-[10px] uppercase tracking-widest text-slate-400">Composite score</p>
-        <div className="grid grid-cols-2 gap-2">
-          <Progress value={(ma.robustness + ma.accuracy) / 2} tone="success" size="sm" showValue label={ma.name.split(" · ")[1] ?? "A"} />
-          <Progress value={(mb.robustness + mb.accuracy) / 2} tone="neural" size="sm" showValue label={mb.name.split(" · ")[1] ?? "B"} />
-        </div>
-      </div>
+          <div className="mt-3">
+            <p className="mb-1 text-[10px] uppercase tracking-widest text-slate-400">Composite score</p>
+            <div className="grid grid-cols-2 gap-2">
+              <Progress value={(ma.robustness + ma.accuracy) / 2} tone="success" size="sm" showValue label={ma.name.split(" · ")[1] ?? "A"} />
+              <Progress value={(mb.robustness + mb.accuracy) / 2} tone="neural" size="sm" showValue label={mb.name.split(" · ")[1] ?? "B"} />
+            </div>
+          </div>
+        </>
+      )}
     </Panel>
   );
 }

--- a/frontend/src/components/dashboard/RobustnessRadar.tsx
+++ b/frontend/src/components/dashboard/RobustnessRadar.tsx
@@ -28,7 +28,7 @@ const SERIES: RadarSeries[] = [
 
 export function RobustnessRadar() {
   const { isLive } = useDemoMode();
-  const hasEvaluationData = SERIES.length > 0;
+  const hasEvaluationData = SERIES.length >= 2;
   const size = 280;
   const cx = size / 2;
   const cy = size / 2;

--- a/frontend/src/components/dashboard/RobustnessRadar.tsx
+++ b/frontend/src/components/dashboard/RobustnessRadar.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { Panel } from "./Panel";
 import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useDemoMode } from "@/lib/hooks";
 import { IconRadar } from "./icons";
 
@@ -27,6 +28,7 @@ const SERIES: RadarSeries[] = [
 
 export function RobustnessRadar() {
   const { isLive } = useDemoMode();
+  const hasEvaluationData = SERIES.length > 0;
   const size = 280;
   const cx = size / 2;
   const cy = size / 2;
@@ -48,104 +50,117 @@ export function RobustnessRadar() {
       icon={<IconRadar size={14} />}
       glow="dream"
       toolbar={
-        <div className="flex items-center gap-2">
-          {!isLive && <Badge variant="warning" size="xs">demo data</Badge>}
-          <Badge variant="success" size="xs">avg +18.4</Badge>
-        </div>
+        hasEvaluationData ? (
+          <div className="flex items-center gap-2">
+            {!isLive && <Badge variant="warning" size="xs">demo data</Badge>}
+            <Badge variant="success" size="xs">avg +18.4</Badge>
+          </div>
+        ) : undefined
       }
     >
-      <div className="flex flex-col items-center gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="group" aria-label="Robustness radar">
-          <defs>
-            <radialGradient id="rad-grad" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stopColor="var(--color-neural)" stopOpacity="0.04" />
-              <stop offset="100%" stopColor="var(--color-neural)" stopOpacity="0" />
-            </radialGradient>
-          </defs>
-          <circle cx={cx} cy={cy} r={radius} fill="url(#rad-grad)" />
-          {[0.25, 0.5, 0.75, 1].map((f) => (
-            <polygon
-              key={f}
-              points={AXES.map((_, i) => point(i, f).join(",")).join(" ")}
-              fill="none"
-              stroke="rgba(255,255,255,0.04)"
-            />
-          ))}
-          {AXES.map((_, i) => {
-            const [px, py] = point(i, 1);
-            return <line key={i} x1={cx} y1={cy} x2={px} y2={py} stroke="rgba(255,255,255,0.04)" />;
-          })}
-
-          {SERIES.map((s, idx) => (
-            <g key={s.label}>
-              <motion.polygon
-                points={polygonFor(s.values)}
-                fill={s.color}
-                fillOpacity={idx === 0 ? 0.15 : 0.08}
-                stroke={s.color}
-                strokeWidth={idx === 0 ? 1.6 : 1.2}
-                strokeDasharray={idx === 0 ? undefined : "3 3"}
-                initial={{ scale: 0, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={{ duration: 0.7, delay: idx * 0.15 }}
-                style={{ transformOrigin: `${cx}px ${cy}px`, filter: idx === 0 ? `drop-shadow(0 0 6px ${s.color})` : undefined }}
-              />
-              {s.values.map((v, i) => {
-                const [px, py] = point(i, v / 100);
-                return <circle key={i} cx={px} cy={py} r={idx === 0 ? 2.5 : 1.5} fill={s.color} />;
+      {!hasEvaluationData ? (
+        <EmptyState
+          icon={<IconRadar size={18} />}
+          title="No evaluation data"
+          description="There are currently no robustness metrics to display. Run an evaluation to generate radar data."
+          primary={{ label: "Run Evaluation", onClick: () => console.log("[RobustnessRadar] empty-state primary") }}
+        />
+      ) : (
+        <>
+          <div className="flex flex-col items-center gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="group" aria-label="Robustness radar">
+              <defs>
+                <radialGradient id="rad-grad" cx="50%" cy="50%" r="50%">
+                  <stop offset="0%" stopColor="var(--color-neural)" stopOpacity="0.04" />
+                  <stop offset="100%" stopColor="var(--color-neural)" stopOpacity="0" />
+                </radialGradient>
+              </defs>
+              <circle cx={cx} cy={cy} r={radius} fill="url(#rad-grad)" />
+              {[0.25, 0.5, 0.75, 1].map((f) => (
+                <polygon
+                  key={f}
+                  points={AXES.map((_, i) => point(i, f).join(",")).join(" ")}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.04)"
+                />
+              ))}
+              {AXES.map((_, i) => {
+                const [px, py] = point(i, 1);
+                return <line key={i} x1={cx} y1={cy} x2={px} y2={py} stroke="rgba(255,255,255,0.04)" />;
               })}
-            </g>
-          ))}
 
-          {AXES.map((a, i) => {
-            const [px, py] = point(i, 1.16);
-            return (
-              <text
-                key={a.key}
-                x={px}
-                y={py}
-                textAnchor="middle"
-                dominantBaseline="middle"
-                fontSize="10"
-                fill="rgba(148,163,184,0.85)"
-                className="font-mono uppercase tracking-wider"
-              >
-                {a.label}
-              </text>
-            );
-          })}
-        </svg>
+              {SERIES.map((s, idx) => (
+                <g key={s.label}>
+                  <motion.polygon
+                    points={polygonFor(s.values)}
+                    fill={s.color}
+                    fillOpacity={idx === 0 ? 0.15 : 0.08}
+                    stroke={s.color}
+                    strokeWidth={idx === 0 ? 1.6 : 1.2}
+                    strokeDasharray={idx === 0 ? undefined : "3 3"}
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ duration: 0.7, delay: idx * 0.15 }}
+                    style={{ transformOrigin: `${cx}px ${cy}px`, filter: idx === 0 ? `drop-shadow(0 0 6px ${s.color})` : undefined }}
+                  />
+                  {s.values.map((v, i) => {
+                    const [px, py] = point(i, v / 100);
+                    return <circle key={i} cx={px} cy={py} r={idx === 0 ? 2.5 : 1.5} fill={s.color} />;
+                  })}
+                </g>
+              ))}
 
-        <div className="w-full flex-1 space-y-2 lg:max-w-[180px]">
-          {AXES.map((a, i) => {
-            const h = SERIES[0].values[i];
-            const b = SERIES[1].values[i];
-            const delta = h - b;
-            return (
-              <div key={a.key} className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-[11px] uppercase tracking-widest text-slate-400">{a.label}</span>
-                  <span className="font-mono text-xs text-emerald-300">+{delta}</span>
-                </div>
-                <div className="mt-1 flex items-center gap-2 text-[11px]">
-                  <span className="font-mono text-slate-100">{h}</span>
-                  <span className="text-slate-300">vs</span>
-                  <span className="font-mono text-slate-400">{b}</span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+              {AXES.map((a, i) => {
+                const [px, py] = point(i, 1.16);
+                return (
+                  <text
+                    key={a.key}
+                    x={px}
+                    y={py}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize="10"
+                    fill="rgba(148,163,184,0.85)"
+                    className="font-mono uppercase tracking-wider"
+                  >
+                    {a.label}
+                  </text>
+                );
+              })}
+            </svg>
 
-      <div className="mt-3 flex items-center justify-center gap-4 text-[11px]">
-        {SERIES.map((s) => (
-          <span key={s.label} className="inline-flex items-center gap-1.5 text-slate-400">
-            <span className="inline-block h-2 w-2 rounded-full" style={{ background: s.color, boxShadow: `0 0 6px ${s.color}` }} />
-            {s.label}
-          </span>
-        ))}
-      </div>
+            <div className="w-full flex-1 space-y-2 lg:max-w-[180px]">
+              {AXES.map((a, i) => {
+                const h = SERIES[0].values[i];
+                const b = SERIES[1].values[i];
+                const delta = h - b;
+                return (
+                  <div key={a.key} className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[11px] uppercase tracking-widest text-slate-400">{a.label}</span>
+                      <span className="font-mono text-xs text-emerald-300">+{delta}</span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-2 text-[11px]">
+                      <span className="font-mono text-slate-100">{h}</span>
+                      <span className="text-slate-300">vs</span>
+                      <span className="font-mono text-slate-400">{b}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-3 flex items-center justify-center gap-4 text-[11px]">
+            {SERIES.map((s) => (
+              <span key={s.label} className="inline-flex items-center gap-1.5 text-slate-400">
+                <span className="inline-block h-2 w-2 rounded-full" style={{ background: s.color, boxShadow: `0 0 6px ${s.color}` }} />
+                {s.label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary

Add empty state UI for RobustnessRadar, ModelComparison, and BenchmarkSuite when no data is available.

## Motivation

These dashboard components previously rendered empty or incomplete views when required data was unavailable. This change provides consistent empty states with contextual messaging and placeholder actions, improving the user experience and preventing confusing blank panels.

Closes #319

## Changes

- Added `EmptyState` to `src/components/dashboard/RobustnessRadar.tsx`
- Added `EmptyState` to `src/components/dashboard/ModelComparison.tsx`
- Added `EmptyState` to `src/components/dashboard/BenchmarkSuite.tsx`
- Introduced descriptive boolean flags (`hasEvaluationData`, `hasEnoughModels`, `hasBenchmarks`) to avoid repeated conditional checks.
- Hid toolbar actions when no data is available.
- Added placeholder primary CTA actions using repository-style console logs.

## Acceptance Criteria

- [x] RobustnessRadar displays an empty state when no evaluation data is available.
- [x] ModelComparison displays an empty state when fewer than two models are available.
- [x] BenchmarkSuite displays an empty state when no benchmarks are configured.
- [x] Existing functionality remains unchanged when data is present.

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (UI-only change)

## AI Disclosure

- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)

## Screenshots (if UI/UX change)

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | *(attach screenshot)* |
| Desktop (light mode) | *(attach screenshot)* |
| Mobile (375px) | *(attach screenshot)* |

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

This change is limited to UI rendering. Existing behavior when data is available remains unchanged. The primary CTA actions currently use placeholder console logs and can be replaced with real navigation or modal actions in the future.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear empty states for Benchmark Suite, Model Comparison, and Robustness Radar panels.
  * Benchmark Suite now hides run controls when no benchmarks are available.
  * Model Comparison now prompts users to add models when fewer than two are available.
  * Robustness Radar now prompts users to run an evaluation when data is unavailable.
  * Existing benchmark, comparison, and radar views remain available when data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->