### PR TITLE
feat: add CLI verbosity flags (--verbose/-v and --quiet/-q)

### DIFF
--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -571,13 +571,14 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"%(prog)s {__version__}",
         help="Show the installed nightmarenet version and exit",
     )
-    parser.add_argument(
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument(
         "-v",
         "--verbose",
         action="store_true",
         help="Enable verbose output (DEBUG level logging)",
     )
-    parser.add_argument(
+    verbosity_group.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -711,10 +712,6 @@ def main(argv: Optional[list] = None) -> int:
         return 0
 
     # Set up logging based on verbosity flags
-    if getattr(args, "verbose", False) and getattr(args, "quiet", False):
-        print("Error: --verbose and --quiet are mutually exclusive", file=sys.stderr)
-        return 1
-
     log_level = "INFO"
     if getattr(args, "verbose", False):
         log_level = "DEBUG"

--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -712,6 +712,8 @@ def main(argv: Optional[list] = None) -> int:
         return 0
 
     # Set up logging based on verbosity flags
+    # Disable console logging for evaluate --json to avoid contaminating JSON output
+    json_mode = args.command == "evaluate" and getattr(args, "json", False)
     log_level = "INFO"
     if getattr(args, "verbose", False):
         log_level = "DEBUG"
@@ -720,7 +722,7 @@ def main(argv: Optional[list] = None) -> int:
 
     from nightmarenet.utils.logging_config import setup_logging
 
-    setup_logging(log_level=log_level, console=True, file_logging=False)
+    setup_logging(log_level=log_level, console=not json_mode, file_logging=False)
 
     commands = {
         "train": cmd_train,

--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -571,6 +571,18 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"%(prog)s {__version__}",
         help="Show the installed nightmarenet version and exit",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output (DEBUG level logging)",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress informational output (only ERROR level logging)",
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # train
@@ -697,6 +709,21 @@ def main(argv: Optional[list] = None) -> int:
     if not args.command:
         parser.print_help()
         return 0
+
+    # Set up logging based on verbosity flags
+    if getattr(args, "verbose", False) and getattr(args, "quiet", False):
+        print("Error: --verbose and --quiet are mutually exclusive", file=sys.stderr)
+        return 1
+
+    log_level = "INFO"
+    if getattr(args, "verbose", False):
+        log_level = "DEBUG"
+    elif getattr(args, "quiet", False):
+        log_level = "ERROR"
+
+    from nightmarenet.utils.logging_config import setup_logging
+
+    setup_logging(log_level=log_level, console=True, file_logging=False)
 
     commands = {
         "train": cmd_train,

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -26,32 +26,20 @@ def test_version_flag_prints_installed_version(capsys):
     assert "nightmarenet" in captured.out
 
 
-def test_verbose_flag_parses():
+@pytest.mark.parametrize(
+    "flag,expected_verbose,expected_quiet",
+    [
+        ("--verbose", True, False),
+        ("-v", True, False),
+        ("--quiet", False, True),
+        ("-q", False, True),
+    ],
+)
+def test_verbosity_flags_parse(flag, expected_verbose, expected_quiet):
     parser = build_parser()
-    args = parser.parse_args(["--verbose", "train", "--config", "test.yaml"])
-    assert args.verbose is True
-    assert args.quiet is False
-
-
-def test_verbose_short_flag_parses():
-    parser = build_parser()
-    args = parser.parse_args(["-v", "train", "--config", "test.yaml"])
-    assert args.verbose is True
-    assert args.quiet is False
-
-
-def test_quiet_flag_parses():
-    parser = build_parser()
-    args = parser.parse_args(["--quiet", "train", "--config", "test.yaml"])
-    assert args.quiet is True
-    assert args.verbose is False
-
-
-def test_quiet_short_flag_parses():
-    parser = build_parser()
-    args = parser.parse_args(["-q", "train", "--config", "test.yaml"])
-    assert args.quiet is True
-    assert args.verbose is False
+    args = parser.parse_args([flag, "train", "--config", "test.yaml"])
+    assert args.verbose is expected_verbose
+    assert args.quiet is expected_quiet
 
 
 def test_default_verbosity():
@@ -61,20 +49,11 @@ def test_default_verbosity():
     assert args.quiet is False
 
 
-def test_verbose_and_quiet_mutually_exclusive():
-    from nightmarenet.cli import main
-    import sys
-    from io import StringIO
+def test_verbose_and_quiet_mutually_exclusive(capsys):
+    parser = build_parser()
 
-    # Capture stderr
-    old_stderr = sys.stderr
-    sys.stderr = StringIO()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--verbose", "--quiet", "train", "--config", "test.yaml"])
 
-    result = main(["--verbose", "--quiet", "train", "--config", "test.yaml"])
-
-    sys.stderr.seek(0)
-    error_output = sys.stderr.read()
-    sys.stderr = old_stderr
-
-    assert result == 1
-    assert "mutually exclusive" in error_output
+    captured = capsys.readouterr()
+    assert "not allowed with argument" in captured.err

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,4 +1,4 @@
-"""Tests for the `nightmarenet --version` CLI flag."""
+"""Tests for the `nightmarenet --version` CLI flag and verbosity flags."""
 
 import pytest
 
@@ -24,3 +24,57 @@ def test_version_flag_prints_installed_version(capsys):
     captured = capsys.readouterr()
     assert __version__ in captured.out
     assert "nightmarenet" in captured.out
+
+
+def test_verbose_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(["--verbose", "train", "--config", "test.yaml"])
+    assert args.verbose is True
+    assert args.quiet is False
+
+
+def test_verbose_short_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(["-v", "train", "--config", "test.yaml"])
+    assert args.verbose is True
+    assert args.quiet is False
+
+
+def test_quiet_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(["--quiet", "train", "--config", "test.yaml"])
+    assert args.quiet is True
+    assert args.verbose is False
+
+
+def test_quiet_short_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(["-q", "train", "--config", "test.yaml"])
+    assert args.quiet is True
+    assert args.verbose is False
+
+
+def test_default_verbosity():
+    parser = build_parser()
+    args = parser.parse_args(["train", "--config", "test.yaml"])
+    assert args.verbose is False
+    assert args.quiet is False
+
+
+def test_verbose_and_quiet_mutually_exclusive():
+    from nightmarenet.cli import main
+    import sys
+    from io import StringIO
+
+    # Capture stderr
+    old_stderr = sys.stderr
+    sys.stderr = StringIO()
+
+    result = main(["--verbose", "--quiet", "train", "--config", "test.yaml"])
+
+    sys.stderr.seek(0)
+    error_output = sys.stderr.read()
+    sys.stderr = old_stderr
+
+    assert result == 1
+    assert "mutually exclusive" in error_output


### PR DESCRIPTION
## Summary

Add global CLI verbosity flags (`--verbose/-v` and `--quiet/-q`) to control logging output, with mutual exclusivity, logging integration, and comprehensive test coverage.

## Motivation

The CLI previously always emitted logs at the default INFO level, providing no way to increase diagnostic output or suppress non-error messages. This PR introduces configurable verbosity levels while preserving the existing default behavior.

Closes #242

## Changes

- Updated `nightmarenet/cli.py`
  - Added global `--verbose` (`-v`) flag to enable `DEBUG` level logging
  - Added global `--quiet` (`-q`) flag to limit output to `ERROR` level
  - Added validation to ensure `--verbose` and `--quiet` cannot be used together
  - Integrated verbosity flags with `setup_logging()`
  - Preserved the existing `INFO` logging level when no verbosity flag is provided
- Updated `tests/test_cli_version.py`
  - Added tests for `--verbose`
  - Added tests for `-v`
  - Added tests for `--quiet`
  - Added tests for `-q`
  - Added tests verifying default verbosity behavior
  - Added tests ensuring mutually exclusive flag validation

## Acceptance Criteria

- [x] `--verbose` flag is available on all CLI subcommands
- [x] `--quiet` flag suppresses informational output (errors only)
- [x] Default behavior remains unchanged (`INFO` logging)
- [x] `nightmarenet --quiet train --config x.yaml` runs silently on success
- [x] `nightmarenet --verbose evaluate ...` enables debug logging
- [x] CLI help documents both verbosity flags
- [x] Automated tests verify verbosity flag parsing and behavior

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [ ] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [x] No secrets, keys, or credentials in code or comments
- [x] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | N/A |
| Desktop (light mode) | N/A |
| Mobile (375px) | N/A |

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

This PR introduces configurable logging verbosity for the CLI while maintaining full backward compatibility. The implementation integrates directly with the existing logging infrastructure, validates mutually exclusive flags, and includes comprehensive tests covering long and short flag forms, default behavior, and error handling. Existing CLI behavior remains unchanged unless a verbosity flag is explicitly provided.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added global `--verbose` (`-v`) and `--quiet` (`-q`) options to control command-line output.
  - Verbose mode shows detailed diagnostic messages, while quiet mode limits output to errors.
  - The CLI now reports an error when both options are used together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->