### PR TITLE
docs: add Codecov badge and CI coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
           --cov-report=xml
           --cov-report=term-missing
 
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+
       - name: Set up Node.js
         if: matrix.python-version == '3.12'
         uses: actions/setup-node@v4
@@ -105,13 +112,6 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
-        with:
-          files: coverage.xml
-          fail_ci_if_error: false
 
   security:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,13 @@ jobs:
           name: coverage-report
           path: coverage.xml
 
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![CI](https://github.com/Adit-Jain-srm/NightmareNet/actions/workflows/ci.yml/badge.svg)](https://github.com/Adit-Jain-srm/NightmareNet/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Adit-Jain-srm/NightmareNet/branch/main/graph/badge.svg)](https://codecov.io/gh/Adit-Jain-srm/NightmareNet)
 [![Tests](https://img.shields.io/badge/tests-660%2B%20passing-brightgreen)](#testing)
 [![Python](https://img.shields.io/badge/python-3.9%E2%80%933.12-blue)](#installation)
 


### PR DESCRIPTION
## Changes i did

- Upload `coverage.xml` to Codecov from the Python 3.12 CI job (`fail_ci_if_error: false`)
- Add Codecov badge to README next to the CI badge
this PR closes issue #230

## Test plan
- [x] CI passes on this PR
- [x] Codecov upload step runs on the 3.12 job
- [x] Coverage badge renders in README


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Codecov coverage badge to the README, making project test coverage easier to discover.

- **Chores**
  - Automated Python test coverage uploads to Codecov during continuous integration.
  - Coverage reporting runs for the Python 3.12 checks without blocking the overall build if the upload encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->