### PR TITLE
fix: add Python 3.10 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Things i did

- Add `3.10` to the CI Python matrix so it matches the `pyproject.toml` classifier
 This PR closes issue #229 
## Test plan
- [ ] CI runs a Python 3.10 job
- [ ] Tests pass on 3.10