### PR TITLE
fix: align root Dockerfile with python 3.12 and healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Builder stage ---
-FROM python:3.11-slim AS builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
@@ -10,9 +10,13 @@ COPY scripts/ scripts/
 RUN pip install --no-cache-dir --prefix=/install ".[api]"
 
 # --- Runtime stage ---
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder
 COPY --from=builder /install /usr/local
@@ -31,5 +35,8 @@ RUN groupadd --gid 1000 appuser && \
 USER appuser
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl --fail --silent http://127.0.0.1:8000/api/v1/health || exit 1
 
 ENTRYPOINT ["uvicorn", "nightmarenet.api.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Changes i  made 
- Bump root `Dockerfile` from Python 3.11 to 3.12 (both stages)
- Install `curl` and add the same HEALTHCHECK used in `docker/Dockerfile.api`
This pr closes issue #226
## Test plan
- [ ] `docker build .` succeeds
- [ ] Container health check hits `/api/v1/health`
