### PR TITLE
feat: add optional MLflow experiment tracking support

### DIFF
--- a/configs/examples/mlflow-tracking.yaml
+++ b/configs/examples/mlflow-tracking.yaml
@@ -1,0 +1,4 @@
+tracking:
+  backend: mlflow
+  tracking_uri: http://127.0.0.1:5000
+  experiment: NightmareNet

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -348,7 +348,7 @@ def robustness_score(
     inv_ppls = [1.0 / max(p, 1e-8) for p in perplexities]
     _trapz_fn = getattr(np, "trapezoid", None)
     if _trapz_fn is None:
-        _trapz_fn = getattr(np, "trapz")
+        _trapz_fn = np.trapz  # type: ignore[attr-defined]
     auc = float(_trapz_fn(inv_ppls, strengths))
 
     return {

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -348,7 +348,7 @@ def robustness_score(
     inv_ppls = [1.0 / max(p, 1e-8) for p in perplexities]
     _trapz_fn = getattr(np, "trapezoid", None)
     if _trapz_fn is None:
-        _trapz_fn = np.trapz  # type: ignore[attr-defined]
+        _trapz_fn = getattr(np, "trapz")
     auc = float(_trapz_fn(inv_ppls, strengths))
 
     return {

--- a/nightmarenet/pipeline_runner.py
+++ b/nightmarenet/pipeline_runner.py
@@ -22,7 +22,7 @@ from nightmarenet.pipeline import Pipeline
 try:
     from opentelemetry import context as otel_context
 except ImportError:
-    otel_context = None
+    otel_context = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 

--- a/nightmarenet/training/trainer.py
+++ b/nightmarenet/training/trainer.py
@@ -359,6 +359,11 @@ class Trainer:
         torch.save(state, os.path.join(path, "training_state.pt"))
         logger.info("Checkpoint saved: %s (including training state)", path)
 
+        try:
+            self.tracker.log_artifact(path)
+        except Exception as e:
+            logger.warning("Failed to log checkpoint artifact to tracker: %s", e)
+
         # Post-save validation and complete file hashes update
         meta_path = os.path.join(path, "metadata.json")
         try:

--- a/nightmarenet/utils/tracking.py
+++ b/nightmarenet/utils/tracking.py
@@ -36,8 +36,8 @@ class ExperimentTracker:
         self.project = project
         self.run_name = run_name
         self._step = 0
-        self._writer = None
-        self._run = None
+        self._writer: Any = None
+        self._run: Any = None
 
         self.run_id = str(uuid.uuid4())
 
@@ -209,7 +209,9 @@ class ExperimentTracker:
                 import mlflow
 
                 if os.path.isdir(path):
-                    mlflow.log_artifacts(path)
+                    # Preserve the directory name to prevent root-level overwrites
+                    artifact_path = os.path.basename(os.path.normpath(path)) or None
+                    mlflow.log_artifacts(path, artifact_path=artifact_path)
                 elif os.path.exists(path):
                     mlflow.log_artifact(path)
                 else:

--- a/nightmarenet/utils/tracking.py
+++ b/nightmarenet/utils/tracking.py
@@ -14,10 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 class ExperimentTracker:
-    """Unified experiment tracker wrapping wandb/tensorboard/none backends.
+    """Unified experiment tracker wrapping wandb/tensorboard/none/mlflow backends.
 
     Args:
-        backend: Tracking backend name: "none", "wandb", or "tensorboard".
+        backend: Tracking backend name: "none", "wandb", "tensorboard", or "mlflow".
         project: Project name for the tracking platform.
         run_name: Optional name for this experiment run.
         config: Optional hyperparameter config to log.
@@ -76,6 +76,25 @@ class ExperimentTracker:
                 logger.warning("tensorboard not installed; falling back to no-op tracker.")
                 self.backend = "none"
 
+        elif self.backend == "mlflow":
+            try:
+                import mlflow
+
+                tracking_cfg = config.get("tracking", {}) if config else {}
+                tracking_uri = tracking_cfg.get("tracking_uri")
+                experiment_name = tracking_cfg.get("experiment", self.project)
+                if tracking_uri:
+                    mlflow.set_tracking_uri(tracking_uri)
+                mlflow.set_experiment(experiment_name)
+                self._run = mlflow.start_run(run_name=self.run_name)
+                logger.info("MLflow tracking initialized (experiment=%s).", experiment_name)
+            except ImportError:
+                logger.warning("mlflow not installed; falling back to no-op tracker.")
+                self.backend = "none"
+            except Exception as exc:
+                logger.warning("Failed to init mlflow: %s; falling back to no-op.", exc)
+                self.backend = "none"
+
         elif self.backend != "none":
             logger.warning("Unknown tracking backend '%s'; using no-op.", self.backend)
             self.backend = "none"
@@ -105,6 +124,15 @@ class ExperimentTracker:
             for key, value in metrics.items():
                 if isinstance(value, (int, float)):
                     self._writer.add_scalar(key, value, global_step=step)
+        elif self.backend == "mlflow":
+            try:
+                import mlflow
+
+                num_metrics = {k: v for k, v in metrics.items() if isinstance(v, (int, float))}
+                if num_metrics:
+                    mlflow.log_metrics(num_metrics, step=step)
+            except Exception as exc:
+                logger.warning("Failed to log metrics to MLflow: %s", exc)
 
     def log_phase(self, cycle: int, phase: str, metrics: dict[str, Any]) -> None:
         """Log metrics for a specific training phase.
@@ -152,6 +180,43 @@ class ExperimentTracker:
                     flat[section] = values
             self._writer.add_hparams(flat, {})
 
+        elif self.backend == "mlflow":
+            try:
+                import mlflow
+
+                flat = {}
+                for section, values in config.items():
+                    if isinstance(values, dict):
+                        for k, v in values.items():
+                            if isinstance(v, (str, int, float, bool)):
+                                flat[f"{section}/{k}"] = v
+                    elif isinstance(values, (str, int, float, bool)):
+                        flat[section] = values
+                mlflow.log_params(flat)
+            except Exception as exc:
+                logger.warning("Failed to log config to MLflow: %s", exc)
+
+    def log_artifact(self, path: str) -> None:
+        """Log an artifact file or directory.
+
+        Args:
+            path: Local path to the file or directory.
+        """
+        if self.backend == "mlflow":
+            try:
+                import os
+
+                import mlflow
+
+                if os.path.isdir(path):
+                    mlflow.log_artifacts(path)
+                elif os.path.exists(path):
+                    mlflow.log_artifact(path)
+                else:
+                    logger.warning("Artifact path does not exist: %s", path)
+            except Exception as exc:
+                logger.warning("Failed to log artifact to MLflow: %s", exc)
+
     def get_lineage(self) -> dict:
         """Return stored training lineage."""
         return self.lineage
@@ -167,6 +232,15 @@ class ExperimentTracker:
         elif self.backend == "tensorboard" and self._writer is not None:
             self._writer.close()
             logger.info("TensorBoard writer closed.")
+
+        elif self.backend == "mlflow":
+            try:
+                import mlflow
+
+                mlflow.end_run()
+                logger.info("MLflow run finished.")
+            except Exception as exc:
+                logger.warning("Failed to finish MLflow run: %s", exc)
 
 
 def create_tracker_from_config(config: dict) -> ExperimentTracker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ tracking = [
     "wandb>=0.16.0",
     "tensorboard>=2.14.0",
 ]
+mlflow = ["mlflow>=2.0"]
 distributed = [
     "accelerate>=0.25.0",
 ]

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -60,8 +60,8 @@ def main():
         "--tracker",
         type=str,
         default=None,
-        choices=["none", "wandb", "tensorboard"],
-        help="Override tracking backend (none, wandb, tensorboard).",
+        choices=["none", "wandb", "tensorboard", "mlflow"],
+        help="Override tracking backend (none, wandb, tensorboard, mlflow).",
     )
     args = parser.parse_args()
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -40,8 +40,8 @@ def main():
         "--tracker",
         type=str,
         default=None,
-        choices=["none", "wandb", "tensorboard"],
-        help="Override tracking backend (none, wandb, tensorboard).",
+        choices=["none", "wandb", "tensorboard", "mlflow"],
+        help="Override tracking backend (none, wandb, tensorboard, mlflow).",
     )
     args = parser.parse_args()
 
@@ -114,7 +114,7 @@ def main():
             text_column,
             max_length,
             batch_size,
-            label_column
+            label_column,
         )
         dream_dataloader = _tokenize_dataset(
             dream_data, trainer.tokenizer, text_column, max_length, batch_size, label_column

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -6,7 +6,7 @@ from nightmarenet.utils.tracking import ExperimentTracker
 def test_mlflow_tracker_basic(tmp_path):
     # Use local file backend for mlflow
     mlruns_dir = tmp_path / "mlruns"
-    tracking_uri = f"file://{mlruns_dir}"
+    tracking_uri = mlruns_dir.as_uri()
 
     config = {
         "tracking": {"backend": "mlflow", "tracking_uri": tracking_uri, "experiment": "TestMLflow"}
@@ -18,9 +18,9 @@ def test_mlflow_tracker_basic(tmp_path):
         config=config,
     )
 
-    # Check if mlflow is installed (soft-skip if not)
-    if tracker.backend == "none":
-        pytest.skip("mlflow is not installed")
+    # Skip test if mlflow is not installed
+    pytest.importorskip("mlflow")
+    assert tracker.backend == "mlflow", "Tracker should initialize with mlflow backend"
 
     # Log params
     tracker.log_config({"training": {"learning_rate": 0.001, "batch_size": 32}})
@@ -53,3 +53,7 @@ def test_mlflow_tracker_basic(tmp_path):
 
     assert float(run.data.metrics.get("loss")) == 0.5
     assert float(run.data.metrics.get("accuracy")) == 0.9
+
+    # Verify artifact
+    artifacts = client.list_artifacts(run.info.run_id)
+    assert any(a.path == "test_artifact.txt" for a in artifacts)

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -1,0 +1,55 @@
+import pytest
+
+from nightmarenet.utils.tracking import ExperimentTracker
+
+
+def test_mlflow_tracker_basic(tmp_path):
+    # Use local file backend for mlflow
+    mlruns_dir = tmp_path / "mlruns"
+    tracking_uri = f"file://{mlruns_dir}"
+
+    config = {
+        "tracking": {"backend": "mlflow", "tracking_uri": tracking_uri, "experiment": "TestMLflow"}
+    }
+
+    tracker = ExperimentTracker(
+        backend="mlflow",
+        project="TestMLflow",
+        config=config,
+    )
+
+    # Check if mlflow is installed (soft-skip if not)
+    if tracker.backend == "none":
+        pytest.skip("mlflow is not installed")
+
+    # Log params
+    tracker.log_config({"training": {"learning_rate": 0.001, "batch_size": 32}})
+
+    # Log metrics
+    tracker.log_metrics({"loss": 0.5, "accuracy": 0.9})
+
+    # Log artifact
+    artifact_file = tmp_path / "test_artifact.txt"
+    artifact_file.write_text("hello world")
+    tracker.log_artifact(str(artifact_file))
+
+    # Finish run
+    tracker.finish()
+
+    # Verify using mlflow API
+    import mlflow
+
+    client = mlflow.tracking.MlflowClient(tracking_uri=tracking_uri)
+    experiment = client.get_experiment_by_name("TestMLflow")
+    assert experiment is not None
+
+    runs = client.search_runs([experiment.experiment_id])
+    assert len(runs) == 1
+
+    run = runs[0]
+
+    assert run.data.params.get("training/learning_rate") == "0.001"
+    assert run.data.params.get("training/batch_size") == "32"
+
+    assert float(run.data.metrics.get("loss")) == 0.5
+    assert float(run.data.metrics.get("accuracy")) == 0.9


### PR DESCRIPTION
## Summary

Add optional MLflow experiment tracking support by extending the existing `ExperimentTracker` abstraction while preserving compatibility with the existing WandB and TensorBoard integrations.

## Motivation

NightmareNet currently supports experiment tracking through WandB and TensorBoard but lacks native MLflow support. This change introduces MLflow as an optional backend, allowing users to log experiment parameters, metrics, and checkpoint artifacts without modifying the existing training workflow.

Closes #343

## Changes

- Added an optional `mlflow` dependency in `pyproject.toml`.
- Extended `nightmarenet/utils/tracking.py` to support the `mlflow` backend.
- Added MLflow initialization, parameter logging, metric logging, artifact logging, and run finalization.
- Added `log_artifact()` support to `ExperimentTracker`.
- Integrated checkpoint artifact logging in `nightmarenet/training/trainer.py`.
- Added `mlflow` as a supported tracking backend in:
  - `scripts/train.py`
  - `scripts/evaluate.py`
- Added example configuration:
  - `configs/examples/mlflow-tracking.yaml`
- Added tests for the MLflow tracker:
  - `tests/test_mlflow_tracker.py`

## Acceptance Criteria

- [x] Added optional MLflow experiment tracking support.
- [x] Hyperparameters are logged to MLflow.
- [x] Training metrics are logged during execution.
- [x] Checkpoints are logged as MLflow artifacts.
- [x] Existing WandB and TensorBoard functionality remains unchanged.
- [x] MLflow integration gracefully falls back when unavailable.
- [x] Added tests covering MLflow tracking functionality.
- [x] Added an example MLflow configuration.

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [ ] I have **starred** this repository ⭐
- [ ] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [ ] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [x] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [x] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

N/A

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

This implementation extends the existing tracking abstraction instead of introducing a new tracking package, keeping the change backward compatible and minimizing the overall diff. MLflow support is optional and all MLflow operations are wrapped to avoid impacting training if the dependency is unavailable or tracking fails.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **MLflow** as an experiment-tracking option for training and evaluation, including metrics, flattened config parameters, and checkpoint/file/directory artifact logging.
  - Introduced a local MLflow example configuration.
  - Added an MLflow integration test; added the `tracking` extra dependency for MLflow.

- **Bug Fixes**
  - Checkpoint saving no longer fails if artifact logging errors (warning instead).
  - Improved AUC trapezoid fallback behavior when `np.trapezoid` isn’t available.

- **Tests**
  - Added coverage for MLflow runs, metrics, params, and artifact persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->