### PR TITLE
feat: add websocket reconnect with exponential backoff

### DIFF
--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Wifi, WifiOff, RefreshCw } from "lucide-react";
+import type { WsConnectionStatus } from "@/lib/websocket";
+import { MAX_RECONNECT_ATTEMPTS } from "@/lib/websocket";
+
+interface ConnectionStatusProps {
+  status: WsConnectionStatus;
+  attempt?: number;
+  onReconnect?: () => void;
+}
+
+export function ConnectionStatus({
+  status,
+  attempt = 0,
+  onReconnect,
+}: ConnectionStatusProps) {
+  if (status === "connected") {
+    return (
+      <div className="inline-flex items-center gap-1.5 text-xs text-emerald-400/80">
+        <Wifi className="w-3.5 h-3.5" />
+        Live
+      </div>
+    );
+  }
+
+  if (status === "reconnecting") {
+    return (
+      <div className="inline-flex items-center gap-1.5 text-xs text-amber-300/90">
+        <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+        Reconnecting{attempt > 0 ? ` (${attempt}/${MAX_RECONNECT_ATTEMPTS})` : "…"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2 text-xs text-red-300/90">
+      <WifiOff className="w-3.5 h-3.5" />
+      <span>Disconnected</span>
+      {onReconnect && (
+        <button
+          type="button"
+          onClick={onReconnect}
+          className="px-2 py-0.5 rounded border border-white/15 hover:bg-white/5 text-white cursor-pointer"
+        >
+          Reconnect
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PipelineLab.tsx
+++ b/frontend/src/components/PipelineLab.tsx
@@ -221,7 +221,7 @@ export default function PipelineLab() {
           const parsed = JSON.parse(saved);
           if (Array.isArray(parsed)) {
             req.webhooks = parsed
-              .map((wh: any) => ({
+              .map((wh) => ({
                 url: wh.url || "",
                 events: wh.events || [],
               }))

--- a/frontend/src/components/PipelineLab.tsx
+++ b/frontend/src/components/PipelineLab.tsx
@@ -30,6 +30,9 @@ import {
   type PipelineStatusResponse,
   type PipelineReportResponse,
 } from "@/lib/api";
+import { buildRunWsUrl, MAX_RECONNECT_ATTEMPTS } from "@/lib/websocket";
+import { useWebSocket } from "@/hooks/useWebSocket";
+import { ConnectionStatus } from "@/components/ConnectionStatus";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 
@@ -105,87 +108,90 @@ export default function PipelineLab() {
   const [error, setError] = useState<string | null>(null);
   const [isLaunching, setIsLaunching] = useState(false);
   const pollRef = useRef<NodeJS.Timeout | null>(null);
-  const wsRef = useRef<WebSocket | null>(null);
 
-  /* ── Cleanup on unmount ── */
-  useEffect(() => {
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
-    };
-  }, []);
-
-  /* ── WebSocket live progress (with polling fallback) ── */
-  const startPolling = useCallback((id: string) => {
-    if (pollRef.current) clearInterval(pollRef.current);
-    if (wsRef.current) { wsRef.current.close(); wsRef.current = null; }
-
-    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const wsUrl = `${wsProtocol}//${window.location.host}/ws/runs/${id}`;
-
-    try {
-      const ws = new WebSocket(wsUrl);
-      wsRef.current = ws;
-
-      ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          if (data.error) {
-            setError(data.error);
-            return;
-          }
-          setPipelineStatus(data);
-          if (data.event === "complete" || !data.is_running) {
-            if (data.has_report) {
-              getPipelineReport(id).then(setReport).catch(() => {});
-              setStep("complete");
-            } else if (data.status === "failed") {
-              setError(data.error || "Pipeline failed.");
-            }
-            ws.close();
-            wsRef.current = null;
-          }
-        } catch { /* malformed message */ }
-      };
-
-      ws.onerror = () => {
-        ws.close();
-        wsRef.current = null;
-        startPollingFallback(id);
-      };
-
-      ws.onclose = () => { wsRef.current = null; };
-    } catch {
-      startPollingFallback(id);
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
     }
   }, []);
 
+  const applyStatusUpdate = useCallback((id: string, data: PipelineStatusResponse & { event?: string }) => {
+    setPipelineStatus(data);
+    if (data.event === "complete" || !data.is_running) {
+      stopPolling();
+      if (data.has_report || data.status === "complete") {
+        getPipelineReport(id).then(setReport).catch(() => {});
+        setStep("complete");
+      } else if (data.status === "failed") {
+        setError(data.error || "Pipeline failed.");
+      }
+    }
+  }, [stopPolling]);
+
   const startPollingFallback = useCallback((id: string) => {
-    if (pollRef.current) clearInterval(pollRef.current);
+    stopPolling();
     pollRef.current = setInterval(async () => {
       try {
         const s = await getPipelineStatus(id);
-        setPipelineStatus(s);
-        if (!s.is_running) {
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (s.status === "complete" && s.has_report) {
-            try {
-              const r = await getPipelineReport(id);
-              setReport(r);
-            } catch { /* report not ready yet */ }
-            setStep("complete");
-          } else if (s.status === "failed") {
-            setError(s.error || "Pipeline failed.");
-          }
-        }
+        applyStatusUpdate(id, s);
       } catch {
         /* network hiccup — keep polling */
       }
     }, 3000);
-  }, []);
+  }, [applyStatusUpdate, stopPolling]);
+
+  const wsEnabled = step === "running" && !!runId;
+  const wsUrl = wsEnabled && runId ? buildRunWsUrl(runId) : null;
+
+  const handleWsMessage = useCallback((raw: unknown) => {
+    if (!runId || !raw || typeof raw !== "object") return;
+    const data = raw as PipelineStatusResponse & { event?: string };
+    if (data.error && data.is_running) {
+      setError(data.error);
+      return;
+    }
+    applyStatusUpdate(runId, data);
+  }, [runId, applyStatusUpdate]);
+
+  const refreshAfterReconnect = useCallback(async () => {
+    if (!runId) return;
+    stopPolling();
+    try {
+      const s = await getPipelineStatus(runId);
+      applyStatusUpdate(runId, s);
+    } catch {
+      /* will catch up on next WS message */
+    }
+  }, [runId, applyStatusUpdate, stopPolling]);
+
+  const {
+    status: wsStatus,
+    attempt: wsAttempt,
+    reconnect: reconnectWs,
+    disconnect: disconnectWs,
+  } = useWebSocket({
+    url: wsUrl,
+    enabled: wsEnabled,
+    onMessage: handleWsMessage,
+    onReconnect: refreshAfterReconnect,
+  });
+
+  /* Poll only after WS retries are exhausted — not during the initial connect. */
+  useEffect(() => {
+    if (wsEnabled && runId && wsStatus === "disconnected" && wsAttempt >= MAX_RECONNECT_ATTEMPTS) {
+      startPollingFallback(runId);
+    }
+    if (wsStatus === "connected") {
+      stopPolling();
+    }
+  }, [wsEnabled, runId, wsStatus, wsAttempt, startPollingFallback, stopPolling]);
+
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
 
   /* ── Launch pipeline ── */
   const handleLaunch = async () => {
@@ -241,7 +247,6 @@ export default function PipelineLab() {
       setRunId(status.run_id);
       setPipelineStatus(status);
       setStep("running");
-      startPolling(status.run_id);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to launch pipeline");
     } finally {
@@ -254,7 +259,8 @@ export default function PipelineLab() {
     if (!runId) return;
     try {
       await cancelPipeline(runId);
-      if (pollRef.current) clearInterval(pollRef.current);
+      stopPolling();
+      disconnectWs();
     } catch { /* best effort */ }
   };
 
@@ -491,6 +497,13 @@ export default function PipelineLab() {
                 >
                 <div className="text-center mb-6 -mt-2">
                   <p className="text-sm text-gray-400 font-mono">{runId}</p>
+                  <div className="mt-2 flex justify-center">
+                    <ConnectionStatus
+                      status={wsStatus}
+                      attempt={wsAttempt}
+                      onReconnect={wsStatus === "disconnected" ? reconnectWs : undefined}
+                    />
+                  </div>
                 </div>
 
                 {/* Phase progress */}
@@ -624,7 +637,15 @@ export default function PipelineLab() {
 
                 <div className="flex justify-center gap-4">
                   <button
-                    onClick={() => { setStep("source"); setRunId(null); setPipelineStatus(null); setReport(null); setError(null); }}
+                    onClick={() => {
+                      stopPolling();
+                      disconnectWs();
+                      setStep("source");
+                      setRunId(null);
+                      setPipelineStatus(null);
+                      setReport(null);
+                      setError(null);
+                    }}
                     className="px-6 py-2.5 rounded-lg border border-white/10 text-white text-sm hover:bg-white/5 transition cursor-pointer"
                   >
                     Run Another Pipeline

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -30,139 +30,112 @@ export function useWebSocket({
 }: UseWebSocketOptions): UseWebSocketResult {
   const [status, setStatus] = useState<WsConnectionStatus>("disconnected");
   const [attempt, setAttempt] = useState(0);
+  const [connectionKey, setConnectionKey] = useState(0);
 
   const wsRef = useRef<WebSocket | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const attemptRef = useRef(0);
-  const intentionalClose = useRef(false);
-  const everOpened = useRef(false);
-  const urlRef = useRef(url);
+  const blockedUrlRef = useRef<string | null>(null);
+  const hasConnectedRef = useRef(false);
+  const previousUrlRef = useRef<string | null>(null);
 
-  const onMessageRef = useRef(onMessage);
-  const onReconnectRef = useRef(onReconnect);
-  onMessageRef.current = onMessage;
-  onReconnectRef.current = onReconnect;
-  urlRef.current = url;
-
-  const clearTimer = () => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
+  const disconnect = useCallback(() => {
+    blockedUrlRef.current = url;
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.close();
+      wsRef.current = null;
     }
-  };
+    setAttempt(0);
+    setStatus("disconnected");
+    setConnectionKey((key) => key + 1);
+  }, [url]);
 
-  const closeSocket = () => {
-    if (!wsRef.current) return;
-    wsRef.current.onopen = null;
-    wsRef.current.onmessage = null;
-    wsRef.current.onerror = null;
-    wsRef.current.onclose = null;
-    wsRef.current.close();
-    wsRef.current = null;
-  };
-
-  const connectRef = useRef<() => void>(() => {});
-
-  connectRef.current = () => {
-    const target = urlRef.current;
-    if (!target) return;
-
-    clearTimer();
-    closeSocket();
-    intentionalClose.current = false;
+  const reconnect = useCallback(() => {
+    blockedUrlRef.current = null;
+    setAttempt(0);
     setStatus("reconnecting");
+    setConnectionKey((key) => key + 1);
+  }, []);
 
-    try {
-      const ws = new WebSocket(target);
+  useEffect(() => {
+    if (!enabled || !url || blockedUrlRef.current === url) return;
+    const targetUrl = url;
+
+    if (previousUrlRef.current !== targetUrl) {
+      previousUrlRef.current = targetUrl;
+      hasConnectedRef.current = false;
+    }
+
+    let active = true;
+    let retryCount = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function scheduleRetry() {
+      if (!active) return;
+
+      if (retryCount >= MAX_RECONNECT_ATTEMPTS) {
+        setStatus("disconnected");
+        return;
+      }
+
+      const delay = nextBackoffMs(retryCount);
+      retryCount += 1;
+      setAttempt(retryCount);
+      setStatus("reconnecting");
+      retryTimer = setTimeout(connect, delay);
+    }
+
+    function connect() {
+      if (!active) return;
+
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(targetUrl);
+      } catch {
+        scheduleRetry();
+        return;
+      }
       wsRef.current = ws;
 
       ws.onopen = () => {
-        const wasReconnect = everOpened.current && attemptRef.current > 0;
-        everOpened.current = true;
-        attemptRef.current = 0;
+        const reconnected = hasConnectedRef.current;
+        hasConnectedRef.current = true;
+        retryCount = 0;
         setAttempt(0);
         setStatus("connected");
-        if (wasReconnect) onReconnectRef.current?.();
+        if (reconnected) onReconnect?.();
       };
 
       ws.onmessage = (event) => {
         try {
-          onMessageRef.current?.(JSON.parse(event.data));
+          onMessage?.(JSON.parse(event.data));
         } catch {
           /* ignore bad payloads */
         }
       };
 
       ws.onerror = () => {
-        // reconnect happens in onclose
+        ws.close();
       };
 
       ws.onclose = () => {
+        if (!active) return;
         wsRef.current = null;
-        if (intentionalClose.current) {
-          setStatus("disconnected");
-          return;
-        }
-        if (attemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
-          setStatus("disconnected");
-          return;
-        }
-        const delay = nextBackoffMs(attemptRef.current);
-        setStatus("reconnecting");
-        timerRef.current = setTimeout(() => {
-          attemptRef.current += 1;
-          setAttempt(attemptRef.current);
-          connectRef.current();
-        }, delay);
+        scheduleRetry();
       };
-    } catch {
-      if (attemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
-        setStatus("disconnected");
-        return;
-      }
-      const delay = nextBackoffMs(attemptRef.current);
-      setStatus("reconnecting");
-      timerRef.current = setTimeout(() => {
-        attemptRef.current += 1;
-        setAttempt(attemptRef.current);
-        connectRef.current();
-      }, delay);
-    }
-  };
-
-  const disconnect = useCallback(() => {
-    intentionalClose.current = true;
-    clearTimer();
-    closeSocket();
-    attemptRef.current = 0;
-    setAttempt(0);
-    setStatus("disconnected");
-  }, []);
-
-  const reconnect = useCallback(() => {
-    attemptRef.current = 0;
-    setAttempt(0);
-    everOpened.current = true;
-    connectRef.current();
-  }, []);
-
-  useEffect(() => {
-    if (!enabled || !url) {
-      disconnect();
-      return;
     }
 
-    everOpened.current = false;
-    attemptRef.current = 0;
-    setAttempt(0);
-    connectRef.current();
+    retryTimer = setTimeout(connect, 0);
 
     return () => {
-      intentionalClose.current = true;
-      clearTimer();
-      closeSocket();
+      active = false;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
     };
-  }, [url, enabled, disconnect]);
+  }, [url, enabled, connectionKey, onMessage, onReconnect]);
 
   return { status, attempt, reconnect, disconnect };
 }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  MAX_RECONNECT_ATTEMPTS,
+  nextBackoffMs,
+  type WsConnectionStatus,
+} from "@/lib/websocket";
+
+export interface UseWebSocketOptions {
+  url: string | null;
+  enabled?: boolean;
+  onMessage?: (data: unknown) => void;
+  /** Fired after a successful reconnect so callers can refresh state. */
+  onReconnect?: () => void;
+}
+
+export interface UseWebSocketResult {
+  status: WsConnectionStatus;
+  attempt: number;
+  reconnect: () => void;
+  disconnect: () => void;
+}
+
+export function useWebSocket({
+  url,
+  enabled = true,
+  onMessage,
+  onReconnect,
+}: UseWebSocketOptions): UseWebSocketResult {
+  const [status, setStatus] = useState<WsConnectionStatus>("disconnected");
+  const [attempt, setAttempt] = useState(0);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptRef = useRef(0);
+  const intentionalClose = useRef(false);
+  const everOpened = useRef(false);
+  const urlRef = useRef(url);
+
+  const onMessageRef = useRef(onMessage);
+  const onReconnectRef = useRef(onReconnect);
+  onMessageRef.current = onMessage;
+  onReconnectRef.current = onReconnect;
+  urlRef.current = url;
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const closeSocket = () => {
+    if (!wsRef.current) return;
+    wsRef.current.onopen = null;
+    wsRef.current.onmessage = null;
+    wsRef.current.onerror = null;
+    wsRef.current.onclose = null;
+    wsRef.current.close();
+    wsRef.current = null;
+  };
+
+  const connectRef = useRef<() => void>(() => {});
+
+  connectRef.current = () => {
+    const target = urlRef.current;
+    if (!target) return;
+
+    clearTimer();
+    closeSocket();
+    intentionalClose.current = false;
+    setStatus("reconnecting");
+
+    try {
+      const ws = new WebSocket(target);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        const wasReconnect = everOpened.current && attemptRef.current > 0;
+        everOpened.current = true;
+        attemptRef.current = 0;
+        setAttempt(0);
+        setStatus("connected");
+        if (wasReconnect) onReconnectRef.current?.();
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          onMessageRef.current?.(JSON.parse(event.data));
+        } catch {
+          /* ignore bad payloads */
+        }
+      };
+
+      ws.onerror = () => {
+        // reconnect happens in onclose
+      };
+
+      ws.onclose = () => {
+        wsRef.current = null;
+        if (intentionalClose.current) {
+          setStatus("disconnected");
+          return;
+        }
+        if (attemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
+          setStatus("disconnected");
+          return;
+        }
+        const delay = nextBackoffMs(attemptRef.current);
+        setStatus("reconnecting");
+        timerRef.current = setTimeout(() => {
+          attemptRef.current += 1;
+          setAttempt(attemptRef.current);
+          connectRef.current();
+        }, delay);
+      };
+    } catch {
+      if (attemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
+        setStatus("disconnected");
+        return;
+      }
+      const delay = nextBackoffMs(attemptRef.current);
+      setStatus("reconnecting");
+      timerRef.current = setTimeout(() => {
+        attemptRef.current += 1;
+        setAttempt(attemptRef.current);
+        connectRef.current();
+      }, delay);
+    }
+  };
+
+  const disconnect = useCallback(() => {
+    intentionalClose.current = true;
+    clearTimer();
+    closeSocket();
+    attemptRef.current = 0;
+    setAttempt(0);
+    setStatus("disconnected");
+  }, []);
+
+  const reconnect = useCallback(() => {
+    attemptRef.current = 0;
+    setAttempt(0);
+    everOpened.current = true;
+    connectRef.current();
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !url) {
+      disconnect();
+      return;
+    }
+
+    everOpened.current = false;
+    attemptRef.current = 0;
+    setAttempt(0);
+    connectRef.current();
+
+    return () => {
+      intentionalClose.current = true;
+      clearTimer();
+      closeSocket();
+    };
+  }, [url, enabled, disconnect]);
+
+  return { status, attempt, reconnect, disconnect };
+}

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -1,0 +1,13 @@
+export type WsConnectionStatus = "connected" | "reconnecting" | "disconnected";
+
+export const MAX_RECONNECT_ATTEMPTS = 10;
+
+/** Exponential backoff: 1s, 2s, 4s, 8s, 16s, then capped at 30s. */
+export function nextBackoffMs(attempt: number): number {
+  return Math.min(1000 * Math.pow(2, attempt), 30_000);
+}
+
+export function buildRunWsUrl(runId: string): string {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}/ws/runs/${runId}`;
+}


### PR DESCRIPTION
## Summary
PipelineLab's WebSocket had no reconnect path — a blip left the UI stuck on stale data. This adds a small reconnecting client with exponential backoff, a status indicator, and a state refresh after reconnect.
Closes issue #344
## Before / After
**Before:** disconnect → silent stale UI, no retry.
**After:** auto-retry (1s → 30s, max 10), status chip, manual Reconnect after exhaustion, `getPipelineStatus` refresh on reconnect.
## Acceptance criteria (from #344)
- [x] WebSocket auto-reconnects on disconnection
- [x] Exponential backoff: 1s, 2s, 4s, 8s, 16s, max 30s
- [x] Connection status indicator visible in UI
- [x] After reconnect, dashboard state refreshes
- [x] After max retries, shows manual reconnect button
- [x] Cleanup on unmount (no leaked timers/sockets)
## Pre-submission checklist
- [x] Assigned to the linked issue (#344)
- [x] Starred the repo and following @Adit-Jain-srm
- [x] Single-concern change, conventional commit (`feat:`)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a connection status indicator for pipeline runs (Live, Reconnecting with attempt info, and Disconnected).
  - Included a “Reconnect” button when available.
  - Updated pipeline progress to follow WebSocket updates in real time, with a polling fallback only after reconnection attempts are exhausted.

- **Bug Fixes**
  - Improved pipeline completion/failure handling based on live connection updates.
  - Ensured WebSocket and polling are properly stopped when canceling or starting another run.

- **Tests**
  - Added automated coverage for WebSocket backoff/jitter and run-scoped WebSocket URL building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->