### PR TITLE
fix: replace library print/console.log with proper logging

### DIFF
--- a/frontend/src/components/dashboard/AuditTrail.tsx
+++ b/frontend/src/components/dashboard/AuditTrail.tsx
@@ -124,7 +124,6 @@ export function AuditTrail() {
                 description: "Configure retention and webhooks in Settings.",
                 variant: "info",
               });
-              console.log("[AuditTrail] empty-state secondary: open settings requested");
             },
           }}
         />

--- a/frontend/src/components/dashboard/BenchmarkSuite.tsx
+++ b/frontend/src/components/dashboard/BenchmarkSuite.tsx
@@ -93,7 +93,7 @@ export function BenchmarkSuite() {
           icon={<IconBenchmark size={18} />}
           title="No benchmarks available"
           description="Your benchmark suite is empty. Create or configure benchmarks to begin testing."
-          primary={{ label: "Configure Benchmarks", onClick: () => console.log("[BenchmarkSuite] empty-state primary") }}
+          primary={{ label: "Configure Benchmarks", onClick: () => {} }}
         />
       ) : (
         <ul className="space-y-2">

--- a/frontend/src/components/dashboard/ModelComparison.tsx
+++ b/frontend/src/components/dashboard/ModelComparison.tsx
@@ -129,7 +129,7 @@ export function ModelComparison() {
           icon={<IconTrend size={18} />}
           title="Insufficient models"
           description="Model comparison requires at least two models. Add another model to compare performance."
-          primary={{ label: "Add Model", onClick: () => console.log("[ModelComparison] empty-state primary") }}
+          primary={{ label: "Add Model", onClick: () => {} }}
         />
       ) : (
         <>

--- a/frontend/src/components/dashboard/RobustnessRadar.tsx
+++ b/frontend/src/components/dashboard/RobustnessRadar.tsx
@@ -63,7 +63,7 @@ export function RobustnessRadar() {
           icon={<IconRadar size={18} />}
           title="No evaluation data"
           description="There are currently no robustness metrics to display. Run an evaluation to generate radar data."
-          primary={{ label: "Run Evaluation", onClick: () => console.log("[RobustnessRadar] empty-state primary") }}
+          primary={{ label: "Run Evaluation", onClick: () => {} }}
         />
       ) : (
         <>

--- a/frontend/src/components/dashboard/RunDetail.tsx
+++ b/frontend/src/components/dashboard/RunDetail.tsx
@@ -206,7 +206,6 @@ function ReRunMenu({ config }: { config: RunConfig }) {
     // TODO: wire to POST /api/v1/pipeline/create with this mutated config.
     // For now the queue surface lives only client-side so reviewers can
     // exercise the UX without an active training cluster.
-    console.log("[RunDetail] re-run requested", { preset: preset.id, config: next });
     setOpen(false);
   };
 

--- a/nightmarenet/distortions/testing.py
+++ b/nightmarenet/distortions/testing.py
@@ -30,11 +30,10 @@ def validate_distortion_plugin(engine_cls: type) -> List[str]:
 
         failures = validate_distortion_plugin(MyDistortion)
         if failures:
-            print("Validation failed:")
             for f in failures:
-                print(f"  - {f}")
+                logger.warning("Validation failed: %s", f)
         else:
-            print("Plugin is valid!")
+            logger.info("Plugin is valid!")
     """
     return validate_base_distortion(engine_cls)
 
@@ -57,6 +56,6 @@ def validate_distortion_function(fn) -> List[str]:
 
         failures = validate_distortion_function(my_distortion)
         if not failures:
-            print("Function is valid!")
+            logger.info("Function is valid!")
     """
     return validate_distortion_contract(fn)

--- a/nightmarenet/hub/core.py
+++ b/nightmarenet/hub/core.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -5,6 +6,8 @@ from typing import Any, Dict, Optional
 import yaml
 
 from nightmarenet.hub.utils import require_hf_hub
+
+logger = logging.getLogger(__name__)
 
 
 def _generate_model_card(repo_id: str, metadata: Dict[str, Any]) -> str:
@@ -92,10 +95,10 @@ def push_model(model_dir: str, repo_id: str, metadata_path: Optional[str] = None
     with open(card_path, "w", encoding="utf-8") as f:
         f.write(card_content)
 
-    print(f"Pushing to Hub '{model_dir}' : '{repo_id}'...")
+    logger.info("Pushing to Hub '%s' : '%s'...", model_dir, repo_id)
     api.create_repo(repo_id=repo_id, exist_ok=True, repo_type="model")
     api.upload_folder(folder_path=str(src_path), repo_id=repo_id, repo_type="model")
-    print("✓ Pushing to Hub completed successfully.")
+    logger.info("Pushing to Hub completed successfully.")
 
 
 @require_hf_hub
@@ -108,7 +111,7 @@ def pull_model(repo_id: str, target_dir: str) -> None:
     dest_path = Path(target_dir)
     dest_path.mkdir(parents=True, exist_ok=True)
 
-    print(f"Downloading model... '{repo_id}'")
+    logger.info("Downloading model... '%s'", repo_id)
     token = os.getenv("HF_TOKEN")
     snapshot_download(repo_id=repo_id, local_dir=str(dest_path), token=token)
-    print(f"✓ Model successfully downloaded to: {target_dir}")
+    logger.info("Model successfully downloaded to: %s", target_dir)

--- a/nightmarenet/training/callbacks.py
+++ b/nightmarenet/training/callbacks.py
@@ -65,7 +65,7 @@ class CallbackManager:
 
     Usage:
         mgr = CallbackManager()
-        mgr.on(EventType.STEP, lambda e: print(e.progress_pct))
+        mgr.on(EventType.STEP, my_handler)
         mgr.emit(TrainingEvent(event_type=EventType.STEP, phase="wake", step=10, total_steps=100))
     """
 


### PR DESCRIPTION
## Summary
Library code was using `print()` / unguarded `console.log` instead of proper logging. This swaps the hub helpers to a module logger, updates docstring examples, and removes the leftover frontend debug logs (leaving ExperimentList for #314 and cli.py for #326).
Closes #350
## Before / After
**Before:** `print()` in hub push/pull + docstring examples; stray `console.log` in a few dashboard panels.
**After:** hub uses `logging.getLogger(__name__)`; those frontend logs are gone.
## Acceptance criteria (from #350)
- [x] Zero `print()` in `nightmarenet/` library code (excluding `cli.py`)
- [x] Affected Python file (`hub/core.py`) uses `logger = logging.getLogger(__name__)`
- [x] Zero unguarded `console.log` in `frontend/src/` production paths (excluding ExperimentList / #314)
- [x] No test assertions depended on print output
## Pre-submission checklist
- [x] Assigned to the linked issue (#350)
- [x] Starred the repo and following @Adit-Jain-srm
- [x] Single-concern change, conventional commit (`fix:`)
- [x] No breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed unintended console messages from dashboard empty-state actions and re-run controls.
  - Empty-state actions now behave quietly when functionality is not yet available.
  - Audit settings continues to display its informational notification.

- **Improvements**
  - Operational and validation messages now use structured logging, improving visibility and consistency.
  - Updated the callback usage example to demonstrate a named handler instead of an inline print statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->