### PR TITLE
feat: add responsive mobile sidebar navigation

### DIFF
--- a/frontend/src/components/dashboard/AppShell.tsx
+++ b/frontend/src/components/dashboard/AppShell.tsx
@@ -35,6 +35,28 @@ export function AppShell({
   children,
 }: AppShellProps) {
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && mobileMenuOpen) {
+        setMobileMenuOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [mobileMenuOpen]);
+
+  useEffect(() => {
+    if (mobileMenuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileMenuOpen]);
 
   useEffect(() => {
     if (externalPaletteOpenPulse === undefined) return;
@@ -46,13 +68,23 @@ export function AppShell({
     <div className="relative min-h-screen bg-void text-slate-100">
       <NeuralCanvas />
       <div className="relative z-10 flex">
-        <Sidebar activeSection={activeSection} onSectionChange={onSectionChange} />
+        <Sidebar
+          activeSection={activeSection}
+          onSectionChange={(key) => {
+            onSectionChange(key);
+            setMobileMenuOpen(false);
+          }}
+          mobileMenuOpen={mobileMenuOpen}
+          onMobileMenuClose={() => setMobileMenuOpen(false)}
+        />
         <div className="flex min-w-0 flex-1 flex-col">
           <Topbar
             title={title}
             breadcrumb={breadcrumb}
             onOpenCommandPalette={() => setPaletteOpen(true)}
             apiStatus={apiStatus}
+            onOpenMobileMenu={() => setMobileMenuOpen(true)}
+            mobileMenuOpen={mobileMenuOpen}
           />
           <main id="main-content" tabIndex={-1} className="flex-1 overflow-x-hidden px-4 py-5 outline-none sm:px-6 sm:py-6">
             {children}

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   IconSparkle,
   IconTrend,
   IconWand,
+  IconX,
 } from "./icons";
 
 export type DashboardSectionKey =
@@ -74,22 +75,38 @@ export interface SidebarProps {
   activeSection: DashboardSectionKey;
   onSectionChange: (key: DashboardSectionKey) => void;
   collapsed?: boolean;
+  mobileMenuOpen?: boolean;
+  onMobileMenuClose?: () => void;
 }
 
 export function Sidebar({
   activeSection,
   onSectionChange,
   collapsed = false,
+  mobileMenuOpen = false,
+  onMobileMenuClose,
 }: SidebarProps) {
   return (
-    <aside
-      className={[
-        "sticky top-0 hidden h-screen shrink-0 border-r border-white/[0.05] bg-void/80 backdrop-blur-xl md:flex md:flex-col",
-        collapsed ? "w-[68px]" : "w-[232px]",
-        "transition-[width] duration-200",
-      ].join(" ")}
-    >
-      <div className="flex h-14 items-center gap-2 border-b border-white/[0.05] px-4">
+    <>
+      {/* Mobile Backdrop */}
+      {mobileMenuOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 backdrop-blur-sm transition-opacity md:hidden"
+          onClick={onMobileMenuClose}
+          aria-hidden="true"
+        />
+      )}
+      <aside
+        className={[
+          "fixed inset-y-0 left-0 z-40 flex h-full flex-col border-r border-white/[0.05] bg-void/95 backdrop-blur-xl transition-all duration-300 ease-in-out md:sticky md:top-0 md:h-screen md:shrink-0 md:bg-void/80",
+          mobileMenuOpen ? "translate-x-0 shadow-2xl" : "-translate-x-full md:translate-x-0 md:shadow-none",
+          collapsed ? "md:w-[68px]" : "md:w-[232px]",
+          "w-[260px]",
+        ].join(" ")}
+        aria-label="Sidebar navigation"
+      >
+        <div className="flex h-14 items-center justify-between gap-2 border-b border-white/[0.05] px-4">
+          <div className="flex items-center gap-2">
         <motion.span
           initial={{ scale: 0.85, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
@@ -99,13 +116,22 @@ export function Sidebar({
         >
           <IconShield size={14} />
         </motion.span>
-        {!collapsed && (
-          <div className="min-w-0">
-            <p className="text-sm font-semibold tracking-tight text-slate-100">NightmareNet</p>
-            <p className="text-[10px] uppercase tracking-widest text-slate-400">Sprint · 03</p>
+          {!collapsed && (
+            <div className="min-w-0">
+              <p className="text-sm font-semibold tracking-tight text-slate-100">NightmareNet</p>
+              <p className="text-[10px] uppercase tracking-widest text-slate-400">Sprint · 03</p>
+            </div>
+          )}
           </div>
-        )}
-      </div>
+          <button
+            type="button"
+            onClick={onMobileMenuClose}
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-slate-400 hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neural/50 md:hidden"
+            aria-label="Close sidebar"
+          >
+            <IconX size={20} />
+          </button>
+        </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">
         {NAV.map((group, gi) => (
@@ -124,7 +150,7 @@ export function Sidebar({
                       type="button"
                       onClick={() => onSectionChange(item.key)}
                       className={[
-                        "group relative flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] cursor-pointer",
+                        "group relative flex w-full items-center gap-2.5 rounded-md px-2 min-h-[44px] md:min-h-0 md:py-1.5 text-left text-[13px] cursor-pointer",
                         "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neural/50",
                         active
                           ? "bg-neural/[0.08] text-neural"
@@ -177,6 +203,7 @@ export function Sidebar({
           </div>
         )}
       </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/frontend/src/components/dashboard/Topbar.tsx
+++ b/frontend/src/components/dashboard/Topbar.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Badge } from "@/components/ui/Badge";
-import { IconBell, IconCommand, IconCpu, IconSearch } from "./icons";
+import { IconBell, IconCommand, IconCpu, IconSearch, IconMenu } from "./icons";
 
 export interface TopbarProps {
   title: string;
   breadcrumb?: { label: string; onClick?: () => void }[];
   onOpenCommandPalette: () => void;
   apiStatus?: "online" | "degraded" | "offline";
+  onOpenMobileMenu?: () => void;
+  mobileMenuOpen?: boolean;
 }
 
 const statusMap = {
@@ -21,11 +23,22 @@ export function Topbar({
   breadcrumb = [],
   onOpenCommandPalette,
   apiStatus = "online",
+  onOpenMobileMenu,
+  mobileMenuOpen = false,
 }: TopbarProps) {
   const status = statusMap[apiStatus];
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b border-white/[0.05] bg-void/80 px-4 backdrop-blur-xl sm:px-6">
       <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={onOpenMobileMenu}
+          className="mr-1 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-slate-400 hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neural/50 md:hidden"
+          aria-label="Open sidebar"
+          aria-expanded={mobileMenuOpen}
+        >
+          <IconMenu size={20} />
+        </button>
         <h1 className="truncate text-sm font-semibold text-slate-100">{title}</h1>
         {breadcrumb.length > 0 && (
           <nav className="hidden items-center gap-1 text-xs text-slate-400 md:flex" aria-label="Breadcrumb">

--- a/frontend/src/components/dashboard/icons.tsx
+++ b/frontend/src/components/dashboard/icons.tsx
@@ -248,3 +248,9 @@ export const IconKebab = (p: IconProps) => (
     <circle cx="12" cy="18.5" r="1.2" fill="currentColor" stroke="none" />
   </svg>
 );
+
+export const IconMenu = (p: IconProps) => (
+  <svg {...base(p)}>
+    <path d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+);


### PR DESCRIPTION
## Description

This PR makes the dashboard sidebar responsive on smaller screens.

On mobile devices, the sidebar is replaced with a hamburger menu that opens a slide-in navigation drawer. The desktop layout remains unchanged.

---

## 🔗 Related Issue

- Closes #320

---

## What I changed

- Added a hamburger menu for mobile screens.
- Added a slide-in sidebar with a backdrop.
- Added a close button and support for closing with the Escape key.
- Closed the drawer automatically after selecting a navigation item.
- Improved touch targets for mobile devices.
- Kept the existing desktop sidebar unchanged.

---

## Why this helps

- Makes navigation easier on phones and tablets.
- Prevents the sidebar from taking up too much screen space.
- Improves accessibility and overall mobile usability.
- Keeps the desktop experience exactly the same.

---

## Testing

- Ran `npm run lint` (only existing repository warnings).
- Ran `npm run build` successfully.
- Tested the sidebar on desktop and mobile screen sizes.
Verified the drawer opens, closes, and doesn't cause horizontal scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile navigation menu.
  * Added a menu button in the top bar and a close button within the sidebar.
  * Mobile navigation now supports backdrop dismissal, Escape-key closing, and automatic closure after selecting a section.
  * Prevented background scrolling while the mobile menu is open.
  * Improved mobile navigation tap targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->