### PR TITLE
feat: add ONNX and TorchScript model export support

### DIFF
--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -37,6 +37,7 @@ def cmd_train(args: argparse.Namespace) -> int:
 
     try:
         from nightmarenet.utils.logging_config import setup_logging_from_config
+
         setup_logging_from_config(config)
     except Exception as exc:
         print(f"Warning: logging initialization failed: {exc}", file=sys.stderr)
@@ -220,6 +221,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
         if isinstance(config, dict):
             try:
                 from nightmarenet.utils.logging_config import setup_logging_from_config
+
                 setup_logging_from_config(config)
             except Exception as exc:
                 print(f"Warning: logging initialization failed: {exc}", file=sys.stderr)
@@ -560,6 +562,90 @@ def cmd_pull(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_export(args: argparse.Namespace) -> int:
+    """Export a trained model to ONNX or TorchScript."""
+    import os
+
+    import torch
+
+    checkpoint_dir = args.checkpoint
+    output_path = args.output
+    fmt = args.format
+
+    if not os.path.exists(checkpoint_dir):
+        print(f"Error: checkpoint directory does not exist: {checkpoint_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        from transformers import AutoConfig, AutoTokenizer
+    except ImportError:
+        print("Error: transformers library is required to export models.", file=sys.stderr)
+        return 1
+
+    config_path = os.path.join(checkpoint_dir, "config.json")
+    if os.path.exists(config_path):
+        model_name_or_path = checkpoint_dir
+    else:
+        model_name_or_path = getattr(args, "model", None) or "distilbert-base-uncased"
+
+    try:
+        config = AutoConfig.from_pretrained(model_name_or_path)
+        tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+
+        task = getattr(args, "task", "seq_classification")
+        if task == "causal_lm":
+            from transformers import AutoModelForCausalLM
+
+            model = AutoModelForCausalLM.from_config(config)
+        elif task == "masked_lm":
+            from transformers import AutoModelForMaskedLM
+
+            model = AutoModelForMaskedLM.from_config(config)
+        else:
+            from transformers import AutoModelForSequenceClassification
+
+            model = AutoModelForSequenceClassification.from_config(config)
+    except Exception as e:
+        print(f"Error initializing model structure: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Loading weights from {checkpoint_dir}...")
+    from nightmarenet.distributed.checkpoint import load_model_weights
+
+    device = torch.device("cpu")
+
+    try:
+        load_model_weights(model, checkpoint_dir, device)
+    except Exception as e:
+        print(f"Error loading checkpoint weights: {e}", file=sys.stderr)
+        return 1
+
+    model.eval()
+
+    print("Generating dummy inputs...")
+    dummy_text = "The quick brown fox jumps over the lazy dog."
+    dummy_input = tokenizer(dummy_text, return_tensors="pt")
+
+    try:
+        if fmt == "onnx":
+            from nightmarenet.export import export_to_onnx
+
+            export_to_onnx(model, output_path, dummy_input)
+        elif fmt == "torchscript":
+            from nightmarenet.export import export_to_torchscript
+
+            export_to_torchscript(model, output_path, dummy_input)
+        else:
+            print(f"Error: Unknown format '{fmt}'", file=sys.stderr)
+            return 1
+    except Exception as e:
+        print(f"Export failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Successfully exported model to {output_path}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="nightmarenet",
@@ -700,6 +786,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target output directory vector to write weights artifacts into",
     )
 
+    # export command
+    export_parser = subparsers.add_parser(
+        "export", help="Export a model to ONNX or TorchScript for production deployment"
+    )
+    export_parser.add_argument(
+        "--format",
+        required=True,
+        choices=["onnx", "torchscript"],
+        help="Export format",
+    )
+    export_parser.add_argument(
+        "--checkpoint", required=True, help="Path to local trained checkpoint directory"
+    )
+    export_parser.add_argument("--output", required=True, help="Target output file path")
+    export_parser.add_argument(
+        "--model", help="Base model name/path (if checkpoint lacks config.json)"
+    )
+    export_parser.add_argument(
+        "--task",
+        default="seq_classification",
+        choices=["seq_classification", "causal_lm", "masked_lm"],
+        help="Model task architecture",
+    )
+
     return parser
 
 
@@ -733,6 +843,7 @@ def main(argv: Optional[list] = None) -> int:
         "transfer": cmd_transfer,
         "push": cmd_push,
         "pull": cmd_pull,
+        "export": cmd_export,
     }
 
     return commands[args.command](args)

--- a/nightmarenet/compression/distillation.py
+++ b/nightmarenet/compression/distillation.py
@@ -125,9 +125,7 @@ def run_distillation(
                 with torch.no_grad():
                     teacher_out = teacher(**adv_batch)
                     teacher_logits = (
-                        teacher_out.logits
-                        if hasattr(teacher_out, "logits")
-                        else teacher_out
+                        teacher_out.logits if hasattr(teacher_out, "logits") else teacher_out
                     )
 
                 # Student logits
@@ -137,9 +135,7 @@ def run_distillation(
                 else:
                     student_out = student(**adv_batch, labels=batch.get("input_ids"))
                 student_logits = (
-                    student_out.logits
-                    if hasattr(student_out, "logits")
-                    else student_out
+                    student_out.logits if hasattr(student_out, "logits") else student_out
                 )
                 task_loss = student_out.loss
 

--- a/nightmarenet/data/generator.py
+++ b/nightmarenet/data/generator.py
@@ -496,6 +496,7 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
         labels = item["labels"]
 
         from nightmarenet.distortions.registry import get_vision_registry
+
         registry = get_vision_registry()
 
         # Retrieve engines matching the current phase
@@ -504,6 +505,7 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
         if vision_config:
             for name, prob in vision_config.items():
                 import random
+
                 meta = registry.get_engine_metadata(name)
                 if meta.get("phase") == self.phase and random.random() < prob:
                     engines.append(name)

--- a/nightmarenet/data/loader.py
+++ b/nightmarenet/data/loader.py
@@ -254,9 +254,11 @@ def load_from_config(config: dict) -> Any:
         name = dataset_config.get("name", "cifar10").lower()
         max_samples = dataset_config.get("max_samples")
 
-        transform = transforms.Compose([
-            transforms.ToTensor(),
-        ])
+        transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+            ]
+        )
 
         if "cifar10" in name:
             try:
@@ -284,9 +286,7 @@ def load_from_config(config: dict) -> Any:
                     root=os.path.join(path, "val"), transform=transform
                 )
             else:
-                logger.warning(
-                    "ImageNet subset path %s not found. Falling back to FakeData.", path
-                )
+                logger.warning("ImageNet subset path %s not found. Falling back to FakeData.", path)
                 train_dataset = datasets.FakeData(
                     size=100, image_size=(3, 224, 224), num_classes=1000, transform=transform
                 )
@@ -314,8 +314,7 @@ def load_from_config(config: dict) -> Any:
     dataset_config = config.get("dataset", {})
     return DatasetWrapper(
         dataset_name=dataset_config.get("name", "wikitext"),
-        subset=dataset_config.get("config")
-            or dataset_config.get("subset", "wikitext-2-raw-v1"),
+        subset=dataset_config.get("config") or dataset_config.get("subset", "wikitext-2-raw-v1"),
         text_column=dataset_config.get("text_column", "text"),
         max_samples=dataset_config.get("max_samples"),
         seed=config.get("seed", 42),
@@ -327,6 +326,7 @@ class VisionItemWrapper(torch.utils.data.Dataset):
     def __init__(self, dataset):
         self.dataset = dataset
         from torchvision.transforms.functional import to_tensor
+
         self._to_tensor = to_tensor
 
     def __len__(self):

--- a/nightmarenet/distortions/vision/nightmare.py
+++ b/nightmarenet/distortions/vision/nightmare.py
@@ -34,8 +34,7 @@ class PixelPerturbation(ImageDistortion):
         # Generate uniform random noise in [-eps, eps]
         if gen is not None:
             noise = (
-                torch.rand(image.shape, generator=gen, device=image.device, dtype=image.dtype)
-                * 2.0
+                torch.rand(image.shape, generator=gen, device=image.device, dtype=image.dtype) * 2.0
                 - 1.0
             ) * eps
         else:

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -101,6 +101,7 @@ def quick_robustness_score(
                     self.target_model = model
 
             from nightmarenet.data.generator import DistortedVisionDataset
+
             dummy_gen = DummyGenerator(strength, seed=42, config={})
             distorted_ds = DistortedVisionDataset(subset, dummy_gen, phase="dream")
             dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)
@@ -351,6 +352,7 @@ def robustness_score(
     if is_vision:
         accuracies = []
         for strength in strengths:
+
             class DummyGenerator:
                 def __init__(self, strength, seed, config):
                     self.strength = strength
@@ -359,6 +361,7 @@ def robustness_score(
                     self.target_model = model
 
             from nightmarenet.data.generator import DistortedVisionDataset
+
             dummy_gen = DummyGenerator(strength, seed=42, config={})
             distorted_ds = DistortedVisionDataset(base_dataset, dummy_gen, phase="dream")
             dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)

--- a/nightmarenet/export/__init__.py
+++ b/nightmarenet/export/__init__.py
@@ -1,0 +1,6 @@
+"""Model export module for ONNX and TorchScript."""
+
+from .onnx_export import export_to_onnx
+from .torchscript_export import export_to_torchscript
+
+__all__ = ["export_to_onnx", "export_to_torchscript"]

--- a/nightmarenet/export/onnx_export.py
+++ b/nightmarenet/export/onnx_export.py
@@ -6,6 +6,8 @@ from importlib.util import find_spec
 
 import torch
 
+from nightmarenet.export.utils import unwrap_output
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,19 +58,13 @@ def export_to_onnx(
 
         def forward(self, *args, **kwargs):
             out = self.m(*args, **kwargs)
-            if hasattr(out, "logits"):
-                return out.logits
-            if isinstance(out, dict):
-                return out[list(out.keys())[0]]
-            if isinstance(out, tuple):
-                return out[0]
-            return out
+            return unwrap_output(out)
 
     wrapped_model = ONNXWrapper(model)
     wrapped_model.eval()
 
     try:
-        logger.info(f"Exporting model to {output_path} (opset={opset})")
+        logger.info("Exporting model to %s (opset=%s)", output_path, opset)
         torch.onnx.export(
             wrapped_model,
             tuple(dummy_input.values()),
@@ -81,7 +77,7 @@ def export_to_onnx(
             dynamic_axes=dynamic_axes,
         )
     except Exception as e:
-        logger.error(f"Failed to export ONNX model: {e}")
+        logger.error("Failed to export ONNX model: %s", e)
         raise RuntimeError(f"ONNX export failed: {e}") from e
 
     try:
@@ -89,7 +85,7 @@ def export_to_onnx(
         onnx.checker.check_model(onnx_model)
         logger.info("ONNX checker validation passed.")
     except Exception as e:
-        logger.error(f"ONNX validation failed: {e}")
+        logger.error("ONNX validation failed: %s", e)
         raise RuntimeError(f"ONNX validation failed: {e}") from e
 
     logger.info("Running output validation...")
@@ -104,7 +100,7 @@ def export_to_onnx(
         pt_out = pt_outs.cpu().numpy()
 
     max_diff = np.max(np.abs(pt_out - ort_out))
-    logger.info(f"Maximum absolute difference: {max_diff}")
+    logger.info("Maximum absolute difference: %s", max_diff)
 
     if max_diff >= 1e-5:
         raise RuntimeError(f"Output tolerance exceeded. Max diff: {max_diff}")

--- a/nightmarenet/export/onnx_export.py
+++ b/nightmarenet/export/onnx_export.py
@@ -1,0 +1,112 @@
+"""ONNX export functionality."""
+
+import logging
+import os
+from importlib.util import find_spec
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def check_dependencies() -> None:
+    missing = []
+
+    if find_spec("onnx") is None:
+        missing.append("onnx")
+
+    if find_spec("onnxruntime") is None:
+        missing.append("onnxruntime")
+
+    if missing:
+        raise ImportError(
+            "Optional export dependencies are missing. "
+            "Install them with: pip install 'nightmarenet[export]' "
+            f"(missing: {', '.join(missing)})"
+        )
+
+
+def export_to_onnx(
+    model: torch.nn.Module, output_path: str, dummy_input: dict, opset: int = 14
+) -> None:
+    """Export a PyTorch model to ONNX format."""
+    check_dependencies()
+
+    import numpy as np
+    import onnx
+    import onnxruntime
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+
+    model.eval()
+
+    dynamic_axes = {}
+    for key in dummy_input.keys():
+        dynamic_axes[key] = {0: "batch_size", 1: "sequence_length"}
+
+    input_names = list(dummy_input.keys())
+    output_names = ["output"]
+    dynamic_axes["output"] = {0: "batch_size", 1: "sequence_length"}
+
+    # Optional wrapper to extract tensor from dict/dataclass output
+    class ONNXWrapper(torch.nn.Module):
+        def __init__(self, m):
+            super().__init__()
+            self.m = m
+
+        def forward(self, *args, **kwargs):
+            out = self.m(*args, **kwargs)
+            if hasattr(out, "logits"):
+                return out.logits
+            if isinstance(out, dict):
+                return out[list(out.keys())[0]]
+            if isinstance(out, tuple):
+                return out[0]
+            return out
+
+    wrapped_model = ONNXWrapper(model)
+    wrapped_model.eval()
+
+    try:
+        logger.info(f"Exporting model to {output_path} (opset={opset})")
+        torch.onnx.export(
+            wrapped_model,
+            tuple(dummy_input.values()),
+            output_path,
+            export_params=True,
+            opset_version=opset,
+            do_constant_folding=True,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+        )
+    except Exception as e:
+        logger.error(f"Failed to export ONNX model: {e}")
+        raise RuntimeError(f"ONNX export failed: {e}") from e
+
+    try:
+        onnx_model = onnx.load(output_path)
+        onnx.checker.check_model(onnx_model)
+        logger.info("ONNX checker validation passed.")
+    except Exception as e:
+        logger.error(f"ONNX validation failed: {e}")
+        raise RuntimeError(f"ONNX validation failed: {e}") from e
+
+    logger.info("Running output validation...")
+    ort_session = onnxruntime.InferenceSession(output_path)
+    ort_inputs = {k: v.cpu().numpy() for k, v in dummy_input.items()}
+
+    ort_outs = ort_session.run(None, ort_inputs)
+    ort_out = ort_outs[0]
+
+    with torch.no_grad():
+        pt_outs = wrapped_model(*tuple(dummy_input.values()))
+        pt_out = pt_outs.cpu().numpy()
+
+    max_diff = np.max(np.abs(pt_out - ort_out))
+    logger.info(f"Maximum absolute difference: {max_diff}")
+
+    if max_diff >= 1e-5:
+        raise RuntimeError(f"Output tolerance exceeded. Max diff: {max_diff}")
+
+    logger.info("ONNX export and validation completed successfully.")

--- a/nightmarenet/export/torchscript_export.py
+++ b/nightmarenet/export/torchscript_export.py
@@ -3,7 +3,10 @@
 import logging
 import os
 
+import numpy as np
 import torch
+
+from nightmarenet.export.utils import unwrap_output
 
 logger = logging.getLogger(__name__)
 
@@ -31,24 +34,18 @@ def export_to_torchscript(model: torch.nn.Module, output_path: str, dummy_input:
             else:
                 out = self.m(*args)
 
-            if hasattr(out, "logits"):
-                return out.logits
-            if isinstance(out, dict):
-                return out[list(out.keys())[0]]
-            if isinstance(out, tuple):
-                return out[0]
-            return out
+            return unwrap_output(out)
 
     wrapped_model = TraceWrapper(model)
     wrapped_model.eval()
     inputs_tuple = tuple(dummy_input.values())
 
     try:
-        logger.info(f"Tracing model for TorchScript export to {output_path}")
+        logger.info("Tracing model for TorchScript export to %s", output_path)
         traced_model = torch.jit.trace(wrapped_model, inputs_tuple, strict=False)
         traced_model.save(output_path)
     except Exception as e:
-        logger.error(f"Failed to export TorchScript model: {e}")
+        logger.error("Failed to export TorchScript model: %s", e)
         raise RuntimeError(f"TorchScript export failed: {e}") from e
 
     logger.info("Running output validation...")
@@ -65,10 +62,8 @@ def export_to_torchscript(model: torch.nn.Module, output_path: str, dummy_input:
         pt_outs = wrapped_model(*inputs_tuple)
         pt_out = pt_outs.cpu().numpy()
 
-    import numpy as np
-
     max_diff = np.max(np.abs(pt_out - ts_out))
-    logger.info(f"Maximum absolute difference: {max_diff}")
+    logger.info("Maximum absolute difference: %s", max_diff)
 
     if max_diff >= 1e-5:
         raise RuntimeError(f"Output tolerance exceeded. Max diff: {max_diff}")

--- a/nightmarenet/export/torchscript_export.py
+++ b/nightmarenet/export/torchscript_export.py
@@ -1,0 +1,76 @@
+"""TorchScript export functionality."""
+
+import logging
+import os
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def export_to_torchscript(model: torch.nn.Module, output_path: str, dummy_input: dict) -> None:
+    """Export a PyTorch model to TorchScript format using tracing."""
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+
+    model.eval()
+
+    class TraceWrapper(torch.nn.Module):
+        def __init__(self, m):
+            super().__init__()
+            self.m = m
+
+        def forward(self, *args):
+            # Try to pass as kwargs if we can infer keys from dummy_input
+            # otherwise pass as positional args
+            if len(args) == len(dummy_input):
+                kwargs = dict(zip(dummy_input.keys(), args))
+                try:
+                    out = self.m(**kwargs)
+                except Exception:
+                    out = self.m(*args)
+            else:
+                out = self.m(*args)
+
+            if hasattr(out, "logits"):
+                return out.logits
+            if isinstance(out, dict):
+                return out[list(out.keys())[0]]
+            if isinstance(out, tuple):
+                return out[0]
+            return out
+
+    wrapped_model = TraceWrapper(model)
+    wrapped_model.eval()
+    inputs_tuple = tuple(dummy_input.values())
+
+    try:
+        logger.info(f"Tracing model for TorchScript export to {output_path}")
+        traced_model = torch.jit.trace(wrapped_model, inputs_tuple, strict=False)
+        traced_model.save(output_path)
+    except Exception as e:
+        logger.error(f"Failed to export TorchScript model: {e}")
+        raise RuntimeError(f"TorchScript export failed: {e}") from e
+
+    logger.info("Running output validation...")
+    loaded_model = torch.jit.load(output_path)
+    loaded_model.eval()
+
+    with torch.no_grad():
+        ts_out = loaded_model(*inputs_tuple)
+        if isinstance(ts_out, tuple):
+            ts_out = ts_out[0].cpu().numpy()
+        else:
+            ts_out = ts_out.cpu().numpy()
+
+        pt_outs = wrapped_model(*inputs_tuple)
+        pt_out = pt_outs.cpu().numpy()
+
+    import numpy as np
+
+    max_diff = np.max(np.abs(pt_out - ts_out))
+    logger.info(f"Maximum absolute difference: {max_diff}")
+
+    if max_diff >= 1e-5:
+        raise RuntimeError(f"Output tolerance exceeded. Max diff: {max_diff}")
+
+    logger.info("TorchScript export and validation completed successfully.")

--- a/nightmarenet/export/utils.py
+++ b/nightmarenet/export/utils.py
@@ -1,0 +1,14 @@
+"""Shared utilities for model export."""
+
+from typing import Any
+
+
+def unwrap_output(out: Any) -> Any:
+    """Unwrap model output to extract the main tensor."""
+    if hasattr(out, "logits"):
+        return out.logits
+    if isinstance(out, dict):
+        return out[list(out.keys())[0]]
+    if isinstance(out, tuple):
+        return out[0]
+    return out

--- a/nightmarenet/phases/ingest.py
+++ b/nightmarenet/phases/ingest.py
@@ -63,6 +63,7 @@ class IngestPhase(Phase):
                 model_type = context.config.get("model", {}).get("type", "")
                 if model_type == "image_classification":
                     from nightmarenet.data.loader import load_from_config
+
                     wrapper = load_from_config(context.config)
                     context.dataset = wrapper.train_data
                     context.eval_dataset = wrapper.test_data

--- a/nightmarenet/pipeline_runner.py
+++ b/nightmarenet/pipeline_runner.py
@@ -88,9 +88,7 @@ class PipelineRunner:
 
         # Persist initial run state
         _persist_run_state(self.id, self.pipeline.config, "running", self._start_time)
-        parent_context = (
-            otel_context.get_current() if otel_context is not None else None
-        )
+        parent_context = otel_context.get_current() if otel_context is not None else None
 
         def _run() -> None:
             token = None
@@ -165,9 +163,7 @@ class PipelineRunner:
                 if token is not None:
                     otel_context.detach(token)
 
-        self._thread = threading.Thread(
-            target=_run, daemon=True, name=f"pipeline-{self.id}"
-        )
+        self._thread = threading.Thread(target=_run, daemon=True, name=f"pipeline-{self.id}")
         self._thread.start()
         logger.info("Pipeline %s started.", self.id)
         return self.id
@@ -308,9 +304,7 @@ def _get_runs_dir() -> Path:
     return runs_dir
 
 
-def _persist_run_state(
-    run_id: str, config: dict, status: str, timestamp: float
-) -> None:
+def _persist_run_state(run_id: str, config: dict, status: str, timestamp: float) -> None:
     """Persist initial run state to disk."""
     runs_dir = _get_runs_dir()
     run_file = runs_dir / f"{run_id}.json"

--- a/nightmarenet/training/trainer.py
+++ b/nightmarenet/training/trainer.py
@@ -57,10 +57,12 @@ _MODEL_TYPE_MAP = {
     "seq_classification": AutoModelForSequenceClassification,
 }
 
+
 @dataclass
 class ModelOutput:
     loss: Optional[torch.Tensor]
     logits: torch.Tensor
+
 
 class VisionModelWrapper(torch.nn.Module):
     def __init__(self, base_model, criterion=None):
@@ -202,15 +204,14 @@ class Trainer:
             )
             if self.model_type == "image_classification":
                 import torchvision.models as torchvision_models
+
                 model_creator = None
                 for name in dir(torchvision_models):
                     if name.lower() == model_name.lower():
                         model_creator = getattr(torchvision_models, name)
                         break
                 if model_creator is None:
-                    raise ValueError(
-                        f"Unknown torchvision model name '{model_name}'."
-                    )
+                    raise ValueError(f"Unknown torchvision model name '{model_name}'.")
                 num_classes = self.model_config.get("num_labels", 10)
                 try:
                     base_model = model_creator(num_classes=num_classes)

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -50,6 +50,7 @@ def _find_closest_key(key: str, candidates: list[str], max_distance: int = 2) ->
 
     return closest if min_dist <= max_distance else None
 
+
 # Default configuration with all supported keys and their default values.
 DEFAULT_CONFIG: dict[str, Any] = {
     "model": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ ai = [
 hub = [
     "huggingface_hub>=0.20.0"
 ]
+export = [
+    "onnx>=1.14.0",
+    "onnxruntime>=1.16.0"
+]
 
 [project.urls]
 Homepage = "https://github.com/Adit-Jain-srm/NightmareNet"

--- a/tests/test_distortion_modules.py
+++ b/tests/test_distortion_modules.py
@@ -3,6 +3,7 @@
 Verifies that the DRY refactor (importing distort() from dream.py/nightmare.py
 instead of inline logic) produces correct results.
 """
+
 import nightmarenet.distortions.nightmare as nightmare_module
 from nightmarenet.distortions.dream import distort as dream_distort
 from nightmarenet.distortions.nightmare import distort as nightmare_distort

--- a/tests/test_distributed_native.py
+++ b/tests/test_distributed_native.py
@@ -108,6 +108,7 @@ def test_apply_phase_strategy(mock_logger):
 # DDP Wrapper Tests
 # ============================================================================
 
+
 @mock.patch("nightmarenet.distributed.ddp_wrapper.dist")
 @mock.patch("nightmarenet.distributed.ddp_wrapper.torch.cuda")
 def test_ddp_wrapper_setup_with_torchrun(mock_cuda, mock_dist, monkeypatch):
@@ -168,9 +169,7 @@ def test_ddp_wrapper_wrap_model(mock_torch, mock_dist, monkeypatch):
 
     monkeypatch.setenv("LOCAL_RANK", "0")
     with mock.patch.object(model, "to", return_value=model) as mock_to:
-        with mock.patch(
-            "nightmarenet.distributed.ddp_wrapper.DistributedDataParallel"
-        ) as mock_ddp:
+        with mock.patch("nightmarenet.distributed.ddp_wrapper.DistributedDataParallel") as mock_ddp:
             mock_ddp.return_value = "wrapped_model"
             result = wrapper.wrap_model(model)
             assert result == "wrapped_model"
@@ -209,6 +208,7 @@ def test_ddp_wrapper_teardown(mock_dist):
 # ============================================================================
 # Strategy Tests
 # ============================================================================
+
 
 def test_unwrap_model_simple():
     """Test unwrapping a simple model."""
@@ -275,6 +275,7 @@ def test_strategy_ddp_not_initialized_fallback(mock_logger):
 # Checkpoint Edge Case Tests
 # ============================================================================
 
+
 def test_checkpoint_missing_directory(tmp_path):
     """Test loading from a non-existent checkpoint directory."""
     with pytest.raises(FileNotFoundError, match="not found"):
@@ -329,12 +330,14 @@ def test_checkpoint_missing_model_weights(tmp_path):
     checkpoint_dir.mkdir()
     (checkpoint_dir / ".complete").write_text("complete")
     (checkpoint_dir / "metadata.json").write_text(
-        json.dumps({
-            "version": nightmarenet.__version__,
-            "cycle": 1,
-            "phase": "wake",
-            "config_hash": "abc",
-        })
+        json.dumps(
+            {
+                "version": nightmarenet.__version__,
+                "cycle": 1,
+                "phase": "wake",
+                "config_hash": "abc",
+            }
+        )
     )
 
     with pytest.raises(ValueError, match="does not contain any valid model weights"):
@@ -347,12 +350,14 @@ def test_checkpoint_missing_optimizer_state(tmp_path):
     checkpoint_dir.mkdir()
     (checkpoint_dir / ".complete").write_text("complete")
     (checkpoint_dir / "metadata.json").write_text(
-        json.dumps({
-            "version": nightmarenet.__version__,
-            "cycle": 1,
-            "phase": "wake",
-            "config_hash": "abc",
-        })
+        json.dumps(
+            {
+                "version": nightmarenet.__version__,
+                "cycle": 1,
+                "phase": "wake",
+                "config_hash": "abc",
+            }
+        )
     )
     (checkpoint_dir / "model.pt").write_text("dummy")
 
@@ -376,7 +381,7 @@ def test_checkpoint_checksum_mismatch(tmp_path):
         "cycle": 1,
         "phase": "wake",
         "config_hash": "abc",
-        "file_hashes": {"model.pt": "wrong_hash"}
+        "file_hashes": {"model.pt": "wrong_hash"},
     }
     (checkpoint_dir / "metadata.json").write_text(json.dumps(metadata))
     (checkpoint_dir / "optimizer.pt").write_text("dummy")
@@ -403,7 +408,7 @@ def test_checkpoint_save_overwrites_existing(tmp_path):
         model=model,
         optimizer=optimizer,
         config=config,
-        metrics={"loss": 0.5}
+        metrics={"loss": 0.5},
     )
 
     # Second save (should overwrite)
@@ -414,7 +419,7 @@ def test_checkpoint_save_overwrites_existing(tmp_path):
         model=model,
         optimizer=optimizer,
         config=config,
-        metrics={"loss": 0.3}
+        metrics={"loss": 0.3},
     )
 
     assert target_dir1 == target_dir2
@@ -429,6 +434,7 @@ def test_checkpoint_save_overwrites_existing(tmp_path):
 # ============================================================================
 # Version Compatibility Tests
 # ============================================================================
+
 
 def test_version_compatibility_same():
     """Test version compatibility with identical versions."""
@@ -461,6 +467,7 @@ def test_version_compatibility_invalid_format():
 # ============================================================================
 # Config Hash Determinism Tests
 # ============================================================================
+
 
 def test_config_hash_determinism():
     """Test that config hash is deterministic across calls."""
@@ -498,6 +505,7 @@ def test_config_hash_nested_order_independence():
 # ============================================================================
 # Device Pool Tests
 # ============================================================================
+
 
 def test_device_pool_override():
     """Test device pool with explicit device override."""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
-import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -35,84 +35,94 @@ class DummyHFModel(nn.Module):
         return Output(self.linear(x))
 
 
-class TestModelExport(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.output_dir = self.temp_dir.name
-        self.model = DummyModel()
-        self.hf_model = DummyHFModel()
-        self.dummy_input = {
-            "input_ids": torch.randint(0, 100, (2, 10)),
-            "attention_mask": torch.ones(2, 10, dtype=torch.long),
-        }
+@pytest.fixture
+def export_context():
+    temp_dir = tempfile.TemporaryDirectory()
+    output_dir = temp_dir.name
+    model = DummyModel()
+    hf_model = DummyHFModel()
+    dummy_input = {
+        "input_ids": torch.randint(0, 100, (2, 10)),
+        "attention_mask": torch.ones(2, 10, dtype=torch.long),
+    }
 
-    def tearDown(self):
-        self.temp_dir.cleanup()
+    yield {
+        "output_dir": output_dir,
+        "model": model,
+        "hf_model": hf_model,
+        "dummy_input": dummy_input,
+    }
 
-    def test_export_to_onnx(self):
-        from importlib.util import find_spec
+    temp_dir.cleanup()
 
-        if find_spec("onnx") is None or find_spec("onnxruntime") is None:
-            self.skipTest("ONNX optional dependencies not installed.")
 
-        output_path = os.path.join(self.output_dir, "model.onnx")
-        export_to_onnx(self.model, output_path, self.dummy_input)
-        self.assertTrue(os.path.exists(output_path))
+def test_export_to_onnx(export_context):
+    from importlib.util import find_spec
 
-    def test_export_to_onnx_hf(self):
-        from importlib.util import find_spec
+    if find_spec("onnx") is None or find_spec("onnxruntime") is None:
+        pytest.skip("ONNX optional dependencies not installed.")
 
-        if find_spec("onnx") is None or find_spec("onnxruntime") is None:
-            self.skipTest("ONNX optional dependencies not installed.")
+    output_path = os.path.join(export_context["output_dir"], "model.onnx")
+    export_to_onnx(export_context["model"], output_path, export_context["dummy_input"])
+    assert os.path.exists(output_path)
 
-        output_path = os.path.join(self.output_dir, "model_hf.onnx")
-        export_to_onnx(self.hf_model, output_path, self.dummy_input)
-        self.assertTrue(os.path.exists(output_path))
 
-    def test_export_to_torchscript(self):
-        output_path = os.path.join(self.output_dir, "model.pt")
-        export_to_torchscript(self.model, output_path, self.dummy_input)
-        self.assertTrue(os.path.exists(output_path))
+def test_export_to_onnx_hf(export_context):
+    from importlib.util import find_spec
 
-    def test_export_to_torchscript_hf(self):
-        output_path = os.path.join(self.output_dir, "model_hf.pt")
-        export_to_torchscript(self.hf_model, output_path, self.dummy_input)
-        self.assertTrue(os.path.exists(output_path))
+    if find_spec("onnx") is None or find_spec("onnxruntime") is None:
+        pytest.skip("ONNX optional dependencies not installed.")
 
-    @patch("nightmarenet.export.export_to_onnx")
-    @patch("nightmarenet.distributed.checkpoint.load_model_weights")
-    @patch("transformers.AutoModelForSequenceClassification.from_config")
-    @patch("transformers.AutoTokenizer.from_pretrained")
-    @patch("transformers.AutoConfig.from_pretrained")
-    def test_cli_export_onnx(self, mock_config, mock_tokenizer, mock_model, mock_load, mock_export):
-        import argparse
+    output_path = os.path.join(export_context["output_dir"], "model_hf.onnx")
+    export_to_onnx(export_context["hf_model"], output_path, export_context["dummy_input"])
+    assert os.path.exists(output_path)
 
-        from nightmarenet.cli import cmd_export
 
-        args = argparse.Namespace(
-            command="export",
-            format="onnx",
-            checkpoint="/tmp/dummy_checkpoint",
-            output="/tmp/dummy_output.onnx",
-            model="distilbert-base-uncased",
-            task="seq_classification",
-        )
+def test_export_to_torchscript(export_context):
+    output_path = os.path.join(export_context["output_dir"], "model.pt")
+    export_to_torchscript(export_context["model"], output_path, export_context["dummy_input"])
+    assert os.path.exists(output_path)
 
-        # We need os.path.exists to return True for checkpoint_dir
-        with patch("os.path.exists") as mock_exists:
 
-            def side_effect(path):
-                if path == "/tmp/dummy_checkpoint":
-                    return True
-                return False
+def test_export_to_torchscript_hf(export_context):
+    output_path = os.path.join(export_context["output_dir"], "model_hf.pt")
+    export_to_torchscript(export_context["hf_model"], output_path, export_context["dummy_input"])
+    assert os.path.exists(output_path)
 
-            mock_exists.side_effect = side_effect
 
-            mock_tokenizer_instance = MagicMock()
-            mock_tokenizer_instance.return_value = {"input_ids": torch.tensor([[1]])}
-            mock_tokenizer.return_value = mock_tokenizer_instance
+@patch("nightmarenet.export.export_to_onnx")
+@patch("nightmarenet.distributed.checkpoint.load_model_weights")
+@patch("transformers.AutoModelForSequenceClassification.from_config")
+@patch("transformers.AutoTokenizer.from_pretrained")
+@patch("transformers.AutoConfig.from_pretrained")
+def test_cli_export_onnx(mock_config, mock_tokenizer, mock_model, mock_load, mock_export):
+    import argparse
 
-            ret = cmd_export(args)
-            self.assertEqual(ret, 0)
-            mock_export.assert_called_once()
-            mock_load.assert_called_once()
+    from nightmarenet.cli import cmd_export
+
+    args = argparse.Namespace(
+        command="export",
+        format="onnx",
+        checkpoint="/tmp/dummy_checkpoint",
+        output="/tmp/dummy_output.onnx",
+        model="distilbert-base-uncased",
+        task="seq_classification",
+    )
+
+    with patch("os.path.exists") as mock_exists:
+
+        def side_effect(path):
+            if path == "/tmp/dummy_checkpoint":
+                return True
+            return False
+
+        mock_exists.side_effect = side_effect
+
+        mock_tokenizer_instance = MagicMock()
+        mock_tokenizer_instance.return_value = {"input_ids": torch.tensor([[1]])}
+        mock_tokenizer.return_value = mock_tokenizer_instance
+
+        ret = cmd_export(args)
+        assert ret == 0
+        mock_export.assert_called_once()
+        mock_load.assert_called_once()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,118 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+
+from nightmarenet.export.onnx_export import export_to_onnx
+from nightmarenet.export.torchscript_export import export_to_torchscript
+
+
+class DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 2)
+
+    def forward(self, input_ids, attention_mask=None):
+        # Dummy computation using the input_ids directly
+        x = input_ids.float()
+        return self.linear(x)
+
+
+class DummyHFModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 2)
+
+    def forward(self, input_ids, attention_mask=None):
+        class Output:
+            def __init__(self, logits):
+                self.logits = logits
+
+        x = input_ids.float()
+        return Output(self.linear(x))
+
+
+class TestModelExport(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.output_dir = self.temp_dir.name
+        self.model = DummyModel()
+        self.hf_model = DummyHFModel()
+        self.dummy_input = {
+            "input_ids": torch.randint(0, 100, (2, 10)),
+            "attention_mask": torch.ones(2, 10, dtype=torch.long),
+        }
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_export_to_onnx(self):
+        from importlib.util import find_spec
+
+        if find_spec("onnx") is None or find_spec("onnxruntime") is None:
+            self.skipTest("ONNX optional dependencies not installed.")
+
+        output_path = os.path.join(self.output_dir, "model.onnx")
+        export_to_onnx(self.model, output_path, self.dummy_input)
+        self.assertTrue(os.path.exists(output_path))
+
+    def test_export_to_onnx_hf(self):
+        from importlib.util import find_spec
+
+        if find_spec("onnx") is None or find_spec("onnxruntime") is None:
+            self.skipTest("ONNX optional dependencies not installed.")
+
+        output_path = os.path.join(self.output_dir, "model_hf.onnx")
+        export_to_onnx(self.hf_model, output_path, self.dummy_input)
+        self.assertTrue(os.path.exists(output_path))
+
+    def test_export_to_torchscript(self):
+        output_path = os.path.join(self.output_dir, "model.pt")
+        export_to_torchscript(self.model, output_path, self.dummy_input)
+        self.assertTrue(os.path.exists(output_path))
+
+    def test_export_to_torchscript_hf(self):
+        output_path = os.path.join(self.output_dir, "model_hf.pt")
+        export_to_torchscript(self.hf_model, output_path, self.dummy_input)
+        self.assertTrue(os.path.exists(output_path))
+
+    @patch("nightmarenet.export.export_to_onnx")
+    @patch("nightmarenet.distributed.checkpoint.load_model_weights")
+    @patch("transformers.AutoModelForSequenceClassification.from_config")
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoConfig.from_pretrained")
+    def test_cli_export_onnx(self, mock_config, mock_tokenizer, mock_model, mock_load, mock_export):
+        import argparse
+
+        from nightmarenet.cli import cmd_export
+
+        args = argparse.Namespace(
+            command="export",
+            format="onnx",
+            checkpoint="/tmp/dummy_checkpoint",
+            output="/tmp/dummy_output.onnx",
+            model="distilbert-base-uncased",
+            task="seq_classification",
+        )
+
+        # We need os.path.exists to return True for checkpoint_dir
+        with patch("os.path.exists") as mock_exists:
+
+            def side_effect(path):
+                if path == "/tmp/dummy_checkpoint":
+                    return True
+                return False
+
+            mock_exists.side_effect = side_effect
+
+            mock_tokenizer_instance = MagicMock()
+            mock_tokenizer_instance.return_value = {"input_ids": torch.tensor([[1]])}
+            mock_tokenizer.return_value = mock_tokenizer_instance
+
+            ret = cmd_export(args)
+            self.assertEqual(ret, 0)
+            mock_export.assert_called_once()
+            mock_load.assert_called_once()

--- a/tests/test_vision_pipeline.py
+++ b/tests/test_vision_pipeline.py
@@ -50,6 +50,7 @@ def test_full_vision_pipeline_cycle():
 
     # 1. Ingest (mock CIFAR-10 download to force fallback to FakeData immediately)
     from unittest.mock import patch
+
     side_effect = Exception("Mock network download failure")
     with patch("torchvision.datasets.CIFAR10", side_effect=side_effect):
         pipe.ingest()


### PR DESCRIPTION
## Description

This PR adds support for exporting trained NightmareNet models to ONNX and TorchScript formats, making them easier to use in production environments outside of Python.

The export functionality is available through a new `nightmarenet export` CLI command and reuses the existing checkpoint loading flow. ONNX exports are validated after generation, and both ONNX and TorchScript exports are checked against the original PyTorch model to ensure their outputs remain consistent.

---

## Related Issue

Closes #341

---

## What I changed

- Added a new `nightmarenet export` CLI command.
- Implemented ONNX export with dynamic batch and sequence dimensions.
- Implemented TorchScript export using tracing.
- Reused the existing checkpoint loading utilities instead of duplicating logic.
- Added optional `export` dependencies for `onnx` and `onnxruntime`.
- Added tests covering CLI integration, model export, and output validation.

---

## Why this helps

- Makes trained models easier to deploy with ONNX Runtime, Triton, and TorchScript-based inference.
- Keeps ONNX dependencies optional so they don't affect users who don't need export support.
- Verifies that exported models produce outputs consistent with the original PyTorch model.
- Provides automated test coverage for the export workflow.

---

## Testing

- Ran `pytest tests/test_export.py -v`
- Result: **3 passed, 2 skipped** (ONNX tests skipped when optional dependencies are not installed)
- Verified TorchScript export and CLI functionality.