### PR TITLE
infra: publish api and worker images to GHCR on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: api
+            dockerfile: docker/Dockerfile.api
+          - image: worker
+            dockerfile: docker/Dockerfile.worker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image name
+        id: meta_name
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "image=ghcr.io/${OWNER}/nightmarenet-${{ matrix.image }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.meta_name.outputs.image }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=min

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ When `model.type: "image_classification"` is specified, text-specific configurat
 
 The open-source version of NightmareNet currently supports running the **API** and **Frontend** locally. The `db`, `redis`, and `worker` services are included for future hosted functionality and are disabled by default.
 
+### Pre-built images (GHCR)
+
+Release tags publish multi-arch images to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/adit-jain-srm/nightmarenet-api:latest
+docker pull ghcr.io/adit-jain-srm/nightmarenet-worker:latest
+```
+
+Images are also tagged with the release version (e.g. `v0.2.1`) and a short commit SHA (`sha-<hash>`).
 
 ### Local Development Setup (Recommended)
 To run both the FastAPI backend and Next.js frontend concurrently in your local environment, use the unified setup command:


### PR DESCRIPTION
## Summary
Docker images were only built in CI, never published. This adds a release-tag workflow that pushes the api and worker images to GHCR (amd64 + arm64) and documents how to pull them.

Closes #348
## Before / After
**Before:** users had to `docker build` locally.
**After:** `v*` tags publish `ghcr.io/adit-jain-srm/nightmarenet-{api,worker}` with `latest`, version, and `sha-*` tags.

## Acceptance criteria (from #348)
- [x] Docker images published to GHCR on release tags
- [x] Images tagged: `latest`, version tag, `sha-<hash>`
- [x] Both `api` and `worker` images published
- [x] Multi-platform: linux/amd64 and linux/arm64
- [x] README updated with pull commands
- [x] Image size: existing multi-stage Dockerfiles already exclude build deps from runtime (no Dockerfile changes needed)

## Pre-submission checklist
- [x] Assigned to the linked issue (#348)
- [x] Starred the repo and following @Adit-Jain-srm
- [x] Single-concern change, conventional commit (`infra:` / scope matches issue)
- [x] No breaking changes


