### PR TITLE
feat: personalize dashboard sidebar ordering

### DIFF
--- a/frontend/src/components/dashboard/SettingsPanel.tsx
+++ b/frontend/src/components/dashboard/SettingsPanel.tsx
@@ -8,10 +8,10 @@ import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { useToast } from "@/components/ui/Toast";
 import { useSounds } from "@/lib/sounds";
-import { IconKey, IconSettings, IconShield, IconWand, IconBell } from "./icons";
+import { IconKey, IconSettings, IconShield, IconWand, IconBell, IconHome } from "./icons";
 import { testWebhook, getWebhooks, saveWebhooks } from "@/lib/api";
 
-type Tab = "keys" | "model" | "distortion" | "integrations" | "notifications";
+type Tab = "keys" | "model" | "distortion" | "integrations" | "notifications" | "preferences";
 
 const TABS: { key: Tab; label: string; icon: React.ReactNode }[] = [
   { key: "keys", label: "API Keys", icon: <IconKey size={12} /> },
@@ -19,6 +19,7 @@ const TABS: { key: Tab; label: string; icon: React.ReactNode }[] = [
   { key: "distortion", label: "Distortion", icon: <IconWand size={12} /> },
   { key: "integrations", label: "Integrations", icon: <IconSettings size={12} /> },
   { key: "notifications", label: "Notifications", icon: <IconBell size={12} /> },
+  { key: "preferences", label: "Preferences", icon: <IconHome size={12} /> },
 ];
 
 interface WebhookConfig {
@@ -450,6 +451,21 @@ export function SettingsPanel() {
               </Button>
             </div>
           )}
+        </div>
+      )}
+
+      {tab === "preferences" && (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-slate-400">Sidebar Layout</p>
+            <p className="text-[11px] text-slate-400 mb-3">Reset the personalized dashboard section ordering back to the default state. This removes custom ordering and visit statistics.</p>
+            <Button variant="danger" size="sm" onClick={() => {
+              window.dispatchEvent(new CustomEvent("reset-sidebar-prefs"));
+              toast.push({ title: "Sidebar layout reset", variant: "info" });
+            }}>
+              Reset to default order
+            </Button>
+          </div>
         </div>
       )}
     </Panel>

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { useEffect, useMemo } from "react";
+import { motion, Reorder } from "framer-motion";
+import { useVisitTracker } from "../../hooks/useVisitTracker";
 import {
   IconActivity,
   IconBeaker,
@@ -71,6 +73,9 @@ const NAV: NavGroup[] = [
   },
 ];
 
+const ALL_ITEMS = NAV.flatMap((g) => g.items);
+const VALID_KEYS = ALL_ITEMS.map((i) => i.key);
+
 export interface SidebarProps {
   activeSection: DashboardSectionKey;
   onSectionChange: (key: DashboardSectionKey) => void;
@@ -86,6 +91,45 @@ export function Sidebar({
   mobileMenuOpen = false,
   onMobileMenuClose,
 }: SidebarProps) {
+  const { isLoaded, totalVisits, visitCounts, customOrder, registerVisit, setCustomOrder } =
+    useVisitTracker(VALID_KEYS);
+
+  useEffect(() => {
+    if (isLoaded) {
+      registerVisit(activeSection);
+    }
+  }, [activeSection, isLoaded, registerVisit]);
+
+  const displayItems = useMemo(() => {
+    if (customOrder.length > 0) {
+      const itemMap = new Map(ALL_ITEMS.map((item) => [item.key, item]));
+      const result = [];
+      for (const key of customOrder) {
+        if (itemMap.has(key)) {
+          result.push(itemMap.get(key)!);
+          itemMap.delete(key);
+        }
+      }
+      for (const item of ALL_ITEMS) {
+        if (itemMap.has(item.key)) {
+          result.push(item);
+        }
+      }
+      return result;
+    }
+
+    if (totalVisits >= 10) {
+      return [...ALL_ITEMS].sort((a, b) => {
+        const countA = visitCounts[a.key] || 0;
+        const countB = visitCounts[b.key] || 0;
+        if (countB !== countA) return countB - countA;
+        return ALL_ITEMS.indexOf(a) - ALL_ITEMS.indexOf(b);
+      });
+    }
+
+    return null;
+  }, [customOrder, totalVisits, visitCounts]);
+
   return (
     <>
       {/* Mobile Backdrop */}
@@ -134,18 +178,29 @@ export function Sidebar({
         </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">
-        {NAV.map((group, gi) => (
-          <div key={group.label} className={gi > 0 ? "mt-4" : ""}>
+        {displayItems ? (
+          <div className="mt-2">
             {!collapsed && (
-              <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-widest text-slate-300">
-                {group.label}
-              </p>
+              <div className="mb-2 px-2 flex items-center justify-between">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-300">
+                  Your Top Views
+                </p>
+              </div>
             )}
-            <ul className="space-y-0.5">
-              {group.items.map((item) => {
+            <Reorder.Group
+              axis="y"
+              values={displayItems}
+              onReorder={(newItems) => setCustomOrder(newItems.map((i) => i.key))}
+              className="space-y-0.5"
+            >
+              {displayItems.map((item) => {
                 const active = activeSection === item.key;
                 return (
-                  <li key={item.key}>
+                  <Reorder.Item
+                    key={item.key}
+                    value={item.key}
+                    className="relative"
+                  >
                     <button
                       type="button"
                       onClick={() => onSectionChange(item.key)}
@@ -177,12 +232,62 @@ export function Sidebar({
                         </>
                       )}
                     </button>
-                  </li>
+                  </Reorder.Item>
                 );
               })}
-            </ul>
+            </Reorder.Group>
           </div>
-        ))}
+        ) : (
+          NAV.map((group, gi) => (
+            <div key={group.label} className={gi > 0 ? "mt-4" : ""}>
+              {!collapsed && (
+                <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-widest text-slate-300">
+                  {group.label}
+                </p>
+              )}
+              <ul className="space-y-0.5">
+                {group.items.map((item) => {
+                  const active = activeSection === item.key;
+                  return (
+                    <li key={item.key}>
+                      <button
+                        type="button"
+                        onClick={() => onSectionChange(item.key)}
+                        className={[
+                          "group relative flex w-full items-center gap-2.5 rounded-md px-2 min-h-[44px] md:min-h-0 md:py-1.5 text-left text-[13px] cursor-pointer",
+                          "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neural/50",
+                          active
+                            ? "bg-neural/[0.08] text-neural"
+                            : "text-slate-400 hover:bg-white/[0.04] hover:text-slate-200",
+                        ].join(" ")}
+                        aria-current={active ? "page" : undefined}
+                        title={collapsed ? item.label : undefined}
+                      >
+                        {active && (
+                          <motion.span
+                            layoutId="sidebar-active"
+                            className="absolute left-0 top-1.5 h-5 w-0.5 rounded-r bg-neural shadow-[0_0_8px_var(--color-neural)]"
+                          />
+                        )}
+                        <span className="flex h-5 w-5 items-center justify-center">{item.icon}</span>
+                        {!collapsed && (
+                          <>
+                            <span className="flex-1 truncate">{item.label}</span>
+                            {item.badge && (
+                              <span className="rounded-full bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-mono text-slate-400">
+                                {item.badge}
+                              </span>
+                            )}
+                          </>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))
+        )}
       </nav>
 
       <div className="border-t border-white/[0.05] px-2 py-3">

--- a/frontend/src/hooks/useVisitTracker.test.ts
+++ b/frontend/src/hooks/useVisitTracker.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVisitTracker } from "./useVisitTracker";
+import { getSidebarPrefs, clearSidebarPrefs } from "../lib/storage";
+
+describe("useVisitTracker", () => {
+  const VALID_KEYS = ["home", "settings", "profile"];
+
+  beforeEach(() => {
+    localStorage.clear();
+    clearSidebarPrefs();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should initialize with default state", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    expect(result.current.isLoaded).toBe(true);
+    expect(result.current.totalVisits).toBe(0);
+    expect(result.current.visitCounts).toEqual({});
+    expect(result.current.customOrder).toEqual([]);
+  });
+
+  it("should track valid visits", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    act(() => {
+      result.current.registerVisit("home");
+    });
+
+    expect(result.current.visitCounts["home"]).toBe(1);
+    expect(result.current.totalVisits).toBe(1);
+
+    act(() => {
+      result.current.registerVisit("home");
+      result.current.registerVisit("settings");
+    });
+
+    expect(result.current.visitCounts["home"]).toBe(2);
+    expect(result.current.visitCounts["settings"]).toBe(1);
+    expect(result.current.totalVisits).toBe(3);
+  });
+
+  it("should ignore invalid visits", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    act(() => {
+      result.current.registerVisit("invalid-route");
+    });
+
+    expect(result.current.visitCounts["invalid-route"]).toBeUndefined();
+    expect(result.current.totalVisits).toBe(0);
+  });
+
+  it("should support setting custom order", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    act(() => {
+      result.current.setCustomOrder(["settings", "home", "profile"]);
+    });
+
+    expect(result.current.customOrder).toEqual(["settings", "home", "profile"]);
+  });
+
+  it("should reset state to defaults", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    act(() => {
+      result.current.registerVisit("home");
+      result.current.setCustomOrder(["profile", "home", "settings"]);
+    });
+
+    expect(result.current.totalVisits).toBe(1);
+    expect(result.current.customOrder.length).toBe(3);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.totalVisits).toBe(0);
+    expect(result.current.customOrder).toEqual([]);
+    expect(result.current.visitCounts).toEqual({});
+  });
+
+  it("should handle custom reset event", () => {
+    const { result } = renderHook(() => useVisitTracker(VALID_KEYS));
+
+    act(() => {
+      result.current.registerVisit("home");
+    });
+
+    expect(result.current.totalVisits).toBe(1);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("reset-sidebar-prefs"));
+    });
+
+    expect(result.current.totalVisits).toBe(0);
+  });
+
+  it("storage migration should handle empty or invalid data gracefully", () => {
+    localStorage.setItem("nightmare_sidebar_prefs", JSON.stringify({ invalid: "data" }));
+    const prefs = getSidebarPrefs();
+    expect(prefs.version).toBe(1);
+    expect(prefs.visitCounts).toEqual({});
+    expect(prefs.customOrder).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/useVisitTracker.ts
+++ b/frontend/src/hooks/useVisitTracker.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { getSidebarPrefs, saveSidebarPrefs, clearSidebarPrefs, SidebarPrefs } from "../lib/storage";
+
+export function useVisitTracker<T extends string>(validKeys: readonly T[]) {
+  const [prefs, setPrefs] = useState<SidebarPrefs>({
+    version: 1,
+    visitCounts: {},
+    customOrder: [],
+  });
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setPrefs(getSidebarPrefs());
+    setIsLoaded(true);
+  }, []);
+
+  const totalVisits = useMemo(() => {
+    return Object.values(prefs.visitCounts).reduce((acc, curr) => acc + curr, 0);
+  }, [prefs.visitCounts]);
+
+  const registerVisit = useCallback(
+    (key: T) => {
+      if (!(validKeys as readonly string[]).includes(key)) return;
+      
+      setPrefs((prev) => {
+        const newCounts = { ...prev.visitCounts };
+        newCounts[key] = (newCounts[key] || 0) + 1;
+        const next = { ...prev, visitCounts: newCounts };
+        saveSidebarPrefs(next);
+        return next;
+      });
+    },
+    [validKeys]
+  );
+
+  const setCustomOrder = useCallback((keys: T[]) => {
+    setPrefs((prev) => {
+      const next = { ...prev, customOrder: keys };
+      saveSidebarPrefs(next);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    clearSidebarPrefs();
+    setPrefs({
+      version: 1,
+      visitCounts: {},
+      customOrder: [],
+    });
+  }, []);
+
+  useEffect(() => {
+    const handleReset = () => reset();
+    window.addEventListener("reset-sidebar-prefs", handleReset);
+    return () => window.removeEventListener("reset-sidebar-prefs", handleReset);
+  }, [reset]);
+
+  const customOrder = useMemo(() => {
+    return prefs.customOrder.filter((k): k is T => (validKeys as readonly string[]).includes(k));
+  }, [prefs.customOrder, validKeys]);
+
+  const visitCounts = useMemo(() => {
+    const counts = {} as Record<T, number>;
+    for (const [k, v] of Object.entries(prefs.visitCounts)) {
+      if ((validKeys as readonly string[]).includes(k)) {
+        counts[k as T] = v;
+      }
+    }
+    return counts;
+  }, [prefs.visitCounts, validKeys]);
+
+  return {
+    isLoaded,
+    totalVisits,
+    visitCounts,
+    customOrder,
+    registerVisit,
+    setCustomOrder,
+    reset,
+  };
+}

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,0 +1,75 @@
+/**
+ * Storage schema and utilities for NightmareNet frontend.
+ */
+
+export interface SidebarPrefsV1 {
+  version: 1;
+  visitCounts: Record<string, number>;
+  customOrder: string[];
+}
+
+export type SidebarPrefs = SidebarPrefsV1;
+
+const SIDEBAR_PREFS_KEY = "nightmare_sidebar_prefs";
+const CURRENT_VERSION = 1;
+
+function defaultSidebarPrefs(): SidebarPrefs {
+  return {
+    version: CURRENT_VERSION,
+    visitCounts: {},
+    customOrder: [],
+  };
+}
+
+/**
+ * Migration logic for future schema updates.
+ */
+function migrateSidebarPrefs(data: unknown): SidebarPrefs {
+  if (!data || typeof data !== "object") {
+    return defaultSidebarPrefs();
+  }
+
+  const record = data as Record<string, unknown>;
+
+  // Future migrations can be added here
+  // if (record.version === 1) {
+  //   record = migrateV1ToV2(record);
+  // }
+
+  // Fallback if version is unknown
+  if (record.version !== CURRENT_VERSION) {
+    return defaultSidebarPrefs();
+  }
+
+  return record as unknown as SidebarPrefs;
+}
+
+export function getSidebarPrefs(): SidebarPrefs {
+  if (typeof window === "undefined") {
+    return defaultSidebarPrefs();
+  }
+  
+  try {
+    const raw = localStorage.getItem(SIDEBAR_PREFS_KEY);
+    if (!raw) return defaultSidebarPrefs();
+    const parsed = JSON.parse(raw);
+    return migrateSidebarPrefs(parsed);
+  } catch (err) {
+    console.error("Failed to parse sidebar prefs:", err);
+    return defaultSidebarPrefs();
+  }
+}
+
+export function saveSidebarPrefs(prefs: SidebarPrefs): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(SIDEBAR_PREFS_KEY, JSON.stringify(prefs));
+  } catch (err) {
+    console.error("Failed to save sidebar prefs:", err);
+  }
+}
+
+export function clearSidebarPrefs(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(SIDEBAR_PREFS_KEY);
+}


### PR DESCRIPTION
## Summary

Add personalized dashboard sidebar ordering based on visit frequency with persistent manual drag-and-drop customization and reset support.

## Motivation

The dashboard sidebar currently uses a fixed order, requiring frequent users to repeatedly navigate through less-used sections. This change personalizes the sidebar based on usage while allowing users to override the order manually.

- Closes #321

## Changes

- Added a versioned localStorage utility for storing sidebar preferences.
- Added a `useVisitTracker` hook to track sidebar visit frequency.
- Implemented automatic sidebar ordering after 10+ total visits.
- Added persistent drag-and-drop sidebar reordering.
- Added a "Reset to default order" option in the settings panel.
- Added unit tests covering visit tracking and ordering behavior.

## Acceptance Criteria

- [x] Visit frequency tracked per sidebar item in localStorage
- [x] After 10+ total visits, sidebar reorders by frequency
- [x] Manual drag-to-reorder overrides automatic ordering
- [x] "Reset to default order" option available
- [x] First-time users see the default sidebar order
- [x] localStorage versioned to support future schema changes

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors *(not applicable for this frontend PR)*
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors *(not run)*
- [ ] `pytest tests/` — all tests pass *(frontend uses Vitest)*
- [x] New functionality has corresponding tests
- [x] Commit messages follow Conventional Commits
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (feature is self-contained)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [x] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see SECURITY.md

## Screenshots (if UI/UX change)

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | *(attach screenshot)* |
| Desktop (light mode) | *(attach screenshot)* |
| Mobile (375px) | *(attach screenshot)* |

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

The implementation keeps the default sidebar experience for new users while progressively personalizing navigation after sufficient usage. Manual drag-and-drop ordering always takes precedence over automatic ordering and persists across sessions. Invalid or stale localStorage entries are filtered during hydration to maintain type safety and support future schema migrations.

</details>