### PR TITLE
Infra: add GitHub security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+**Do NOT open a public issue for security vulnerabilities.**
+
+Instead, please email: **aditjain2005@gmail.com**
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Suggested fix (if you have one)
+
+We will acknowledge receipt within 48 hours and provide a timeline for a fix within 7 days. Critical vulnerabilities affecting production deployments will be patched within 72 hours.
+
+## Scope
+
+The following are in scope for security reports:
+- Authentication bypass in the API layer
+- Secrets exposure (API keys, tokens)
+- Remote code execution via distortion inputs
+- Dependency vulnerabilities with known exploits
+- CORS misconfiguration allowing credential theft
+
+The following are out of scope:
+- Denial of service via resource exhaustion (rate limiting exists)
+- Attacks requiring physical access to the machine
+- Social engineering attacks


### PR DESCRIPTION
## Summary

<!-- One-sentence description of what this PR does. Be specific. -->
Added `.github/SECURITY.md` so GitHub can automatically discover and display the repository's security policy.

## Motivation

<!-- Why is this change needed? What problem does it solve? -->
GitHub Security Advisory features look for security policies in `.github/SECURITY.md`. Adding this file improves vulnerability disclosure discoverability without changing the existing security process.

Closes #233 

## Changes

<!-- Bullet-point list of what changed. Include file paths for non-obvious changes. -->
- Added `.github/SECURITY.md`
- Copied the existing root `SECURITY.md` policy to keep security instructions consistent

-

## Acceptance Criteria

<!-- Copy the acceptance criteria from the linked issue as checkboxes.
     Check each box ONLY when your implementation satisfies it.
     If a criterion is not addressed in this PR, leave unchecked and explain why. -->

- [x] .github/SECURITY.md exists with vulnerability reporting instructions

- [x] GitHub "Security" tab shows the security policy

- [x] Root SECURITY.md preserved (not deleted)

- [x] Content is consistent between the files (no contradictions)


## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests
- [x] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [ ] No `from __future__ import annotations` added under `nightmarenet/api/`
- [ ] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

<!-- Required by CONTRIBUTING.md. Check one. -->

- [x] This PR is entirely human-written
- [ ] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [ ] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

<!-- Required by CONTRIBUTING.md for any frontend change. All three are needed. -->

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | |
| Desktop (light mode) | |
| Mobile (375px) | |

## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining supported versions, vulnerability reporting procedures, response timelines, and report scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->