### PR TITLE
feat: add frontend error boundaries and offline state

### DIFF
--- a/frontend/src/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+
+function HealthyChild() {
+  return <p>Dashboard content</p>;
+}
+
+function ThrowingChild(): never {
+  throw new Error("Panel failed");
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("renders its children when no error is thrown", () => {
+    render(
+      <ErrorBoundary>
+        <HealthyChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Dashboard content")).toBeInTheDocument();
+  });
+
+  it("catches child errors and displays recovery controls", () => {
+    render(
+      <ErrorBoundary fallbackTitle="Experiment panel unavailable">
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Experiment panel unavailable",
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Report this issue" }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/Adit-Jain-srm/NightmareNet/issues/new/choose",
+    );
+  });
+
+  it("invokes the reset callback when Retry is selected", () => {
+    const onReset = vi.fn();
+
+    render(
+      <ErrorBoundary onReset={onReset}>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it("reports the captured error through onError", () => {
+    const onError = vi.fn();
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ message: "Panel failed" }),
+    );
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { ThemeProvider } from "@/lib/theme";
 import SkipLink from "@/components/a11y/SkipLink";
+import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { OfflineBanner } from "@/components/ui/OfflineBanner";
 import "./globals.css";
 
 export const viewport: Viewport = {
@@ -69,6 +71,12 @@ export default function RootLayout({
         className="scanlines min-h-full flex flex-col bg-void text-text font-sans"
         suppressHydrationWarning
       >
+      <OfflineBanner />
+
+  <ErrorBoundary
+    fallbackTitle="NightmareNet encountered an unexpected error"
+    fallbackMessage="The application could not continue. Retry the page content or report the problem."
+  >
         <Script
           id="theme-initializer"
           strategy="beforeInteractive"
@@ -98,6 +106,7 @@ export default function RootLayout({
         <ThemeProvider>
           {children}
         </ThemeProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/frontend/src/components/dashboard/DashboardRoot.tsx
+++ b/frontend/src/components/dashboard/DashboardRoot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { AnimatePresence, motion } from "framer-motion";
 import { AppShell } from "./AppShell";
 import type { DashboardSectionKey } from "./Sidebar";
@@ -157,12 +158,23 @@ function DashboardRootInner() {
             </>
           )}
 
+          <ErrorBoundary
+  fallbackTitle="Experiments unavailable"
+  fallbackMessage="The experiment list failed to render. Retry this panel or report the issue."
+>
+
           {section === "experiments" && (
             <motion.div variants={fadeIn}>
               <ExperimentList onSectionChange={navigate} />
             </motion.div>
           )}
 
+          </ErrorBoundary>
+
+          <ErrorBoundary
+  fallbackTitle="Run details unavailable"
+  fallbackMessage="The selected run details failed to render. Retry this panel or report the issue."
+>
           {section === "run-detail" && (
             <>
               <motion.div variants={fadeIn}>
@@ -179,17 +191,25 @@ function DashboardRootInner() {
             </>
           )}
 
+          </ErrorBoundary>
+
           {section === "phases" && (
             <motion.div variants={fadeIn}>
               <PhaseVisualizer activePhase={1} />
             </motion.div>
           )}
 
+          <ErrorBoundary
+  fallbackTitle="Live metrics unavailable"
+  fallbackMessage="Live metrics failed to render. Other dashboard panels remain available."
+>
           {section === "metrics" && (
             <motion.div variants={fadeIn}>
               <LiveMetrics />
             </motion.div>
           )}
+
+          </ErrorBoundary>
 
           {section === "robustness" && (
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Component,
+  type ErrorInfo,
+  type ReactNode,
+} from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallbackTitle?: string;
+  fallbackMessage?: string;
+  reportHref?: string;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    if (process.env.NODE_ENV !== "test") {
+      console.error("NightmareNet UI error:", error, errorInfo);
+    }
+
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    const {
+      fallbackTitle = "This section could not be loaded",
+      fallbackMessage = "An unexpected error occurred. You can retry this section without refreshing the whole application.",
+      reportHref = "https://github.com/Adit-Jain-srm/NightmareNet/issues/new/choose",
+    } = this.props;
+
+    return (
+      <section
+        role="alert"
+        aria-live="assertive"
+        className="rounded-2xl border border-red-400/30 bg-red-950/20 p-6 text-left shadow-lg"
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">
+          Recovery mode
+        </p>
+
+        <h2 className="mt-2 text-xl font-semibold text-white">
+          {fallbackTitle}
+        </h2>
+
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+          {fallbackMessage}
+        </p>
+
+        {process.env.NODE_ENV === "development" && (
+          <details className="mt-4 rounded-lg border border-white/10 bg-black/20 p-3">
+            <summary className="cursor-pointer text-sm font-medium text-slate-200">
+              Technical details
+            </summary>
+            <pre className="mt-3 overflow-x-auto whitespace-pre-wrap text-xs text-red-200">
+              {error.message}
+            </pre>
+          </details>
+        )}
+
+        <div className="mt-5 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded-lg bg-white px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Retry
+          </button>
+
+          <Link
+            href={reportHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Report this issue
+          </Link>
+        </div>
+      </section>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/ui/OfflineBanner.tsx
+++ b/frontend/src/components/ui/OfflineBanner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function OfflineBanner() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    const updateNetworkState = () => {
+      setIsOnline(navigator.onLine);
+    };
+
+    updateNetworkState();
+
+    window.addEventListener("online", updateNetworkState);
+    window.addEventListener("offline", updateNetworkState);
+
+    return () => {
+      window.removeEventListener("online", updateNetworkState);
+      window.removeEventListener("offline", updateNetworkState);
+    };
+  }, []);
+
+  if (isOnline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="sticky top-0 z-[100] border-b border-amber-300/40 bg-amber-950 px-4 py-3 text-center text-sm font-medium text-amber-100 shadow-lg"
+    >
+      You are offline. Live metrics and API-backed actions may be unavailable
+      until your connection returns.
+    </div>
+  );
+}
+
+export default OfflineBanner;


### PR DESCRIPTION
## Description

Adds resilient frontend error handling and offline-state feedback so a runtime failure no longer results in a blank page or crashes unrelated dashboard panels.

## Related Issue

Closes #240

## Changes

- Added a reusable class-based `ErrorBoundary` component.
- Added accessible fallback UI with:
  - Clear error messaging
  - Retry/reset action
  - Link to report an issue
  - Development-only technical details
- Wrapped the root application content with a top-level boundary.
- Wrapped `ExperimentList`, `RunDetail`, and `LiveMetrics` independently.
- Added an offline banner based on `navigator.onLine` and browser `online`/`offline` events.
- Added focused unit tests proving errors are caught and recovery controls render.

## Validation

- [x] `npm test`
- [x] `npm run build`
- [x] `npm run test:a11y -- --project=chromium`
- [x] Manual root fallback verification
- [x] Manual isolated panel fallback verification
- [x] Manual browser offline/online verification
- [ ] Screenshots attached

## Screenshots
<img width="1398" height="474" alt="Screenshot 2026-07-20 191726" src="https://github.com/user-attachments/assets/e0f86061-7037-4f64-916f-093ec9d8f0c8" />
<img width="1368" height="850" alt="Screenshot 2026-07-20 191739" src="https://github.com/user-attachments/assets/17467694-d110-4512-b0f2-89e99a2548f4" />
<img width="1358" height="847" alt="Screenshot 2026-07-20 191748" src="https://github.com/user-attachments/assets/15e18783-ef07-4c6c-a791-54abef5e011e" />
<img width="1315" height="851" alt="Screenshot 2026-07-20 191813" src="https://github.com/user-attachments/assets/999ab30c-1a41-43bc-8c64-58f4ca9895b0" />
<img width="1376" height="847" alt="Screenshot 2026-07-20 191843" src="https://github.com/user-attachments/assets/efb5419d-f5a6-4329-afd8-11cf223080ff" />


## Acceptance Criteria

- [x] `ErrorBoundary` exists under `frontend/src/components/ui/`
- [x] Root layout is wrapped with a top-level boundary
- [x] `ExperimentList`, `RunDetail`, and `LiveMetrics` have individual boundaries
- [x] Fallback includes an error message and retry button
- [x] Offline banner appears while disconnected
- [x] `ErrorBoundary.test.tsx` proves thrown errors are caught

## Scope

No service worker, PWA cache, API retry layer, or unrelated dashboard refactor was introduced.

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [ ] I have **starred** this repository ⭐
- [ ] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [ ] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)


## Security Considerations


- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

