### PR TITLE
feat: export per-sample robustness evaluation failures

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -87,6 +87,9 @@ compression:
 
 # Evaluation configuration
 evaluation:
+  export_failures: false
+  failure_export_format: "json"
+  failure_threshold: 0.20
   metrics:
     - "recall"
     - "generalization"

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -203,7 +203,21 @@ class Evaluator:
                     max_length=model_config.get("max_length", 128),
                     batch_size=self.config.get("training", {}).get("batch_size", 8),
                     device=self.device,
+                    export_failures=self.eval_config.get("export_failures", False),
                 )
+                if self.eval_config.get("export_failures", False):
+                    failures = results["robustness"].get("per_sample_data")
+                    if failures:
+                        from nightmarenet.evaluation.failure_export import save_failure_report
+
+                        format = self.eval_config.get("failure_export_format", "json")
+                        threshold = self.eval_config.get("failure_threshold", 0.20)
+                        saved_path = save_failure_report(
+                            failures, self.output_dir, format, threshold
+                        )
+                        if saved_path:
+                            logger.info("Saved failure report to %s", saved_path)
+
                 if self.tracker:
                     self._log_eval(
                         "robustness",

--- a/nightmarenet/evaluation/failure_export.py
+++ b/nightmarenet/evaluation/failure_export.py
@@ -1,0 +1,84 @@
+"""Module for exporting robustness evaluation failures."""
+
+import csv
+import json
+import logging
+import os
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def export_failures_json(failures: list[dict], filepath: str) -> None:
+    """Export failures to a JSON file.
+
+    Args:
+        failures: List of failure dictionaries.
+        filepath: Path to the output JSON file.
+    """
+    try:
+        with open(filepath, "w") as f:
+            json.dump(failures, f, indent=2, default=str)
+        logger.info("Exported %d failures to %s", len(failures), filepath)
+    except Exception as e:
+        logger.error("Failed to export JSON failures to %s: %s", filepath, e)
+
+
+def export_failures_csv(failures: list[dict], filepath: str) -> None:
+    """Export failures to a CSV file.
+
+    Args:
+        failures: List of failure dictionaries.
+        filepath: Path to the output CSV file.
+    """
+    if not failures:
+        return
+
+    try:
+        keys = list(failures[0].keys())
+        with open(filepath, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=keys)
+            writer.writeheader()
+            writer.writerows(failures)
+        logger.info("Exported %d failures to %s", len(failures), filepath)
+    except Exception as e:
+        logger.error("Failed to export CSV failures to %s: %s", filepath, e)
+
+
+def save_failure_report(
+    failures: list[dict], output_dir: str, format: str = "json", threshold: float = 0.20
+) -> str:
+    """Filter and save failure report.
+
+    Args:
+        failures: List of all per-sample data collected during robustness evaluation.
+        output_dir: Directory to save the failure report.
+        format: Export format ('json' or 'csv').
+        threshold: Confidence drop threshold for failure definition.
+
+    Returns:
+        The path to the saved report, or empty string if no failures.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    failed_samples = []
+    for sample in failures:
+        prediction_changed = sample.get("original_prediction") != sample.get("distorted_prediction")
+        confidence_drop = sample.get("confidence_drop", 0.0)
+
+        if prediction_changed or confidence_drop > threshold:
+            failed_samples.append(sample)
+
+    if not failed_samples:
+        logger.info("No failures detected. Skipping export.")
+        return ""
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filepath = os.path.join(output_dir, f"{timestamp}_failures.{format}")
+
+    if format.lower() == "csv":
+        export_failures_csv(failed_samples, filepath)
+    else:
+        export_failures_json(failed_samples, filepath)
+
+    return filepath

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -325,6 +325,7 @@ def robustness_score(
     max_length: int = 128,
     batch_size: int = 8,
     device="cpu",
+    export_failures: bool = False,
 ) -> dict:
     """Compute robustness score under increasing distortion strengths.
 
@@ -351,6 +352,28 @@ def robustness_score(
     is_vision = tokenizer is None or not hasattr(base_dataset, "map")
     if is_vision:
         accuracies = []
+        failures_data = []
+        orig_preds = []
+        orig_confs = []
+
+        if export_failures:
+
+            class DummyGenerator0:
+                def __init__(self, strength, seed, config):
+                    self.strength = strength
+                    self.seed = seed
+                    self.config = config
+                    self.target_model = model
+
+            from nightmarenet.data.generator import DistortedVisionDataset
+
+            dummy_gen_0 = DummyGenerator0(0.0, seed=42, config={})
+            clean_ds = DistortedVisionDataset(base_dataset, dummy_gen_0, phase="dream")
+            clean_dl = DataLoader(clean_ds, batch_size=batch_size, shuffle=False)
+            clean_metrics = classification_metrics(model, clean_dl, device, return_per_sample=True)
+            orig_preds = clean_metrics.get("per_sample_preds", [])
+            orig_confs = clean_metrics.get("per_sample_confs", [])
+
         for strength in strengths:
 
             class DummyGenerator:
@@ -366,9 +389,34 @@ def robustness_score(
             distorted_ds = DistortedVisionDataset(base_dataset, dummy_gen, phase="dream")
             dataloader = DataLoader(distorted_ds, batch_size=batch_size, shuffle=False)
 
-            metrics = classification_metrics(model, dataloader, device)
+            metrics = classification_metrics(
+                model, dataloader, device, return_per_sample=export_failures
+            )
             acc = metrics.get("accuracy", 0.0)
             accuracies.append(acc)
+
+            if export_failures:
+                dist_preds = metrics.get("per_sample_preds", [])
+                dist_confs = metrics.get("per_sample_confs", [])
+                for i in range(len(orig_preds)):
+                    if i >= len(dist_preds):
+                        break
+                    failures_data.append(
+                        {
+                            "sample_index": i,
+                            "original_input": "<vision_input>",
+                            "distorted_input": "<vision_distorted>",
+                            "original_prediction": int(orig_preds[i]),
+                            "distorted_prediction": int(dist_preds[i]),
+                            "original_confidence": float(orig_confs[i]),
+                            "distorted_confidence": float(dist_confs[i]),
+                            "confidence_drop": float(orig_confs[i] - dist_confs[i]),
+                            "distortion_type": "vision_distortion",
+                            "distortion_strength": float(strength),
+                            "seed": 42,
+                        }
+                    )
+
             logger.info("Robustness - Strength %.1f: Accuracy = %.4f", strength, acc)
 
         _trapz_fn = getattr(np, "trapezoid", None)
@@ -376,14 +424,44 @@ def robustness_score(
             _trapz_fn = np.trapz  # type: ignore[attr-defined]
         auc = float(_trapz_fn(accuracies, strengths))
 
-        return {
+        res = {
             "metric": "robustness",
             "strengths": strengths,
             "accuracies": accuracies,
             "auc_robustness": _safe_float(auc),
         }
+        if export_failures:
+            res["per_sample_data"] = failures_data
+        return res
 
     perplexities = []
+    failures_data = []
+
+    orig_preds = []
+    orig_confs = []
+    orig_texts = []
+
+    if export_failures:
+        # Run classification on clean dataset to get original preds
+        def _get_preds(dataset):
+            def tok_fn(examples):
+                return tokenizer(
+                    examples[text_column],
+                    truncation=True,
+                    padding="max_length",
+                    max_length=max_length,
+                    return_tensors="pt",
+                )
+
+            tok_ds = dataset.map(tok_fn, batched=True, remove_columns=dataset.column_names)
+            tok_ds.set_format("torch")
+            dl = DataLoader(tok_ds, batch_size=batch_size, shuffle=False)
+            return classification_metrics(model, dl, device, return_per_sample=True)
+
+        clean_metrics = _get_preds(base_dataset)
+        orig_preds = clean_metrics.get("per_sample_preds", [])
+        orig_confs = clean_metrics.get("per_sample_confs", [])
+        orig_texts = [x[text_column] for x in base_dataset]
 
     for strength in strengths:
         # Apply distortion at this strength
@@ -408,10 +486,36 @@ def robustness_score(
             remove_columns=distorted.column_names,
         )
         tokenized.set_format("torch")
-        dataloader = DataLoader(tokenized, batch_size=batch_size)
+        dataloader = DataLoader(tokenized, batch_size=batch_size, shuffle=False)
 
         ppl = compute_perplexity(model, dataloader, device)
         perplexities.append(ppl)
+
+        if export_failures:
+            dist_metrics = classification_metrics(model, dataloader, device, return_per_sample=True)
+            dist_preds = dist_metrics.get("per_sample_preds", [])
+            dist_confs = dist_metrics.get("per_sample_confs", [])
+            dist_texts = [x[text_column] for x in distorted]
+
+            for i in range(len(orig_preds)):
+                if i >= len(dist_preds):
+                    break
+                failures_data.append(
+                    {
+                        "sample_index": i,
+                        "original_input": orig_texts[i],
+                        "distorted_input": dist_texts[i],
+                        "original_prediction": int(orig_preds[i]),
+                        "distorted_prediction": int(dist_preds[i]),
+                        "original_confidence": float(orig_confs[i]),
+                        "distorted_confidence": float(dist_confs[i]),
+                        "confidence_drop": float(orig_confs[i] - dist_confs[i]),
+                        "distortion_type": "text_distortion",
+                        "distortion_strength": float(strength),
+                        "seed": 42,
+                    }
+                )
+
         logger.info("Robustness - Strength %.1f: Perplexity = %.2f", strength, ppl)
 
     # Compute AUC using trapezoidal rule (normalized)
@@ -422,12 +526,15 @@ def robustness_score(
         _trapz_fn = np.trapz  # type: ignore[attr-defined]
     auc = float(_trapz_fn(inv_ppls, strengths))
 
-    return {
+    res = {
         "metric": "robustness",
         "strengths": strengths,
         "perplexities": [_safe_float(p, default=float("inf")) for p in perplexities],
         "auc_robustness": _safe_float(auc),
     }
+    if export_failures:
+        res["per_sample_data"] = failures_data
+    return res
 
 
 def hallucination_rate(
@@ -516,6 +623,7 @@ def classification_metrics(
     model,
     dataloader: DataLoader,
     device="cpu",
+    return_per_sample: bool = False,
 ) -> dict:
     """Compute classification metrics (accuracy, F1, per-class stats).
 
@@ -532,6 +640,7 @@ def classification_metrics(
     model.eval()
     all_preds = []
     all_labels = []
+    all_confs = []
 
     try:
         with torch.no_grad():
@@ -539,10 +648,23 @@ def classification_metrics(
                 batch = {k: v.to(device) for k, v in batch.items()}
                 outputs = model(**batch)
                 logits = outputs.logits if hasattr(outputs, "logits") else outputs
-                preds = logits.argmax(dim=-1).cpu().numpy()
-                labels = batch["labels"].cpu().numpy()
+
+                probs = torch.softmax(logits, dim=-1)
+                confs, preds = probs.max(dim=-1)
+
+                preds = preds.cpu().numpy()
+                confs = confs.cpu().numpy()
+
+                if "labels" in batch:
+                    labels = batch["labels"].cpu().numpy()
+                    all_labels.extend(labels.tolist())
+                else:
+                    # Dummy labels if not present
+                    all_labels.extend([0] * len(preds))
+
                 all_preds.extend(preds.tolist())
-                all_labels.extend(labels.tolist())
+                if return_per_sample:
+                    all_confs.extend(confs.tolist())
     except Exception as e:
         logger.warning("Error during classification metrics computation: %s", e)
         return {
@@ -558,7 +680,7 @@ def classification_metrics(
         all_labels, all_preds, zero_division=0
     )
 
-    return {
+    res = {
         "metric": "classification",
         "accuracy": _safe_float(accuracy),
         "f1_weighted": _safe_float(f1_weighted),
@@ -567,3 +689,7 @@ def classification_metrics(
         "f1_per_class": [_safe_float(f) for f in f1_per_class],
         "support_per_class": support.tolist(),
     }
+    if return_per_sample:
+        res["per_sample_preds"] = all_preds
+        res["per_sample_confs"] = all_confs
+    return res

--- a/tests/test_failure_export.py
+++ b/tests/test_failure_export.py
@@ -1,0 +1,155 @@
+import csv
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from nightmarenet.evaluation.failure_export import (
+    export_failures_csv,
+    export_failures_json,
+    save_failure_report,
+)
+
+
+@pytest.fixture
+def sample_failures():
+    return [
+        {
+            "sample_index": 0,
+            "original_input": "clean text 0",
+            "distorted_input": "distorted text 0",
+            "original_prediction": 1,
+            "distorted_prediction": 1,
+            "original_confidence": 0.9,
+            "distorted_confidence": 0.8,
+            "confidence_drop": 0.1,
+            "distortion_type": "text_distortion",
+            "distortion_strength": 0.5,
+            "seed": 42,
+        },
+        {
+            "sample_index": 1,
+            "original_input": "clean text 1",
+            "distorted_input": "distorted text 1",
+            "original_prediction": 1,
+            "distorted_prediction": 0,
+            "original_confidence": 0.95,
+            "distorted_confidence": 0.6,
+            "confidence_drop": 0.35,
+            "distortion_type": "text_distortion",
+            "distortion_strength": 0.5,
+            "seed": 42,
+        },
+        {
+            "sample_index": 2,
+            "original_input": "clean text 2",
+            "distorted_input": "distorted text 2",
+            "original_prediction": 0,
+            "distorted_prediction": 0,
+            "original_confidence": 0.8,
+            "distorted_confidence": 0.4,
+            "confidence_drop": 0.4,
+            "distortion_type": "text_distortion",
+            "distortion_strength": 0.5,
+            "seed": 42,
+        },
+    ]
+
+
+def test_export_disabled(tmp_path):
+    # Testing that save_failure_report returns empty string if no failures matched
+    filepath = save_failure_report([], str(tmp_path))
+    assert filepath == ""
+
+
+def test_json_export(tmp_path, sample_failures):
+    filepath = tmp_path / "test_failures.json"
+    export_failures_json(sample_failures, str(filepath))
+
+    assert filepath.exists()
+    with open(filepath) as f:
+        data = json.load(f)
+    assert len(data) == 3
+    assert data[1]["sample_index"] == 1
+
+
+def test_csv_export(tmp_path, sample_failures):
+    filepath = tmp_path / "test_failures.csv"
+    export_failures_csv(sample_failures, str(filepath))
+
+    assert filepath.exists()
+    with open(filepath) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert rows[1]["sample_index"] == "1"
+
+
+def test_threshold_filtering(tmp_path, sample_failures):
+    # sample 0: drop 0.1 (not exported if threshold is 0.2)
+    # sample 2: drop 0.4, prediction not changed (exported due to drop > 0.2)
+    filepath = save_failure_report(sample_failures, str(tmp_path), format="json", threshold=0.2)
+    assert filepath != ""
+
+    with open(filepath) as f:
+        data = json.load(f)
+
+    assert len(data) == 2
+    indices = [d["sample_index"] for d in data]
+    assert 1 in indices  # prediction changed
+    assert 2 in indices  # confidence drop > threshold
+    assert 0 not in indices  # neither
+
+
+def test_prediction_change_detection(tmp_path, sample_failures):
+    # sample 1 has prediction change. even if threshold is very high, it should be exported
+    filepath = save_failure_report(sample_failures, str(tmp_path), format="json", threshold=0.99)
+    assert filepath != ""
+
+    with open(filepath) as f:
+        data = json.load(f)
+
+    assert len(data) == 1
+    assert data[0]["sample_index"] == 1
+
+
+def test_expected_keys(tmp_path, sample_failures):
+    filepath = save_failure_report(sample_failures, str(tmp_path), format="json", threshold=0.0)
+    assert filepath != ""
+
+    with open(filepath) as f:
+        data = json.load(f)
+
+    expected_keys = {
+        "sample_index",
+        "original_input",
+        "distorted_input",
+        "original_prediction",
+        "distorted_prediction",
+        "original_confidence",
+        "distorted_confidence",
+        "confidence_drop",
+        "distortion_type",
+        "distortion_strength",
+        "seed",
+    }
+    assert set(data[0].keys()) == expected_keys
+
+
+def test_empty_failures(tmp_path):
+    filepath = tmp_path / "empty.csv"
+    export_failures_csv([], str(filepath))
+    # csv exporter returns early if empty
+    assert not filepath.exists()
+
+
+@mock.patch("nightmarenet.evaluation.failure_export.datetime")
+def test_output_file_created(mock_datetime, tmp_path, sample_failures):
+    mock_datetime.now.return_value.strftime.return_value = "20260101_120000"
+
+    filepath = save_failure_report(sample_failures, str(tmp_path), format="csv", threshold=0.2)
+
+    assert "20260101_120000_failures.csv" in filepath
+    assert os.path.exists(filepath)


### PR DESCRIPTION
## Summary

Add configurable per-sample robustness failure export with JSON/CSV support while preserving existing evaluation behavior when the feature is disabled.

## Motivation

Current robustness evaluation only reports aggregate metrics, making it difficult to inspect which samples contributed to robustness degradation. This change adds optional per-sample failure export to simplify debugging and failure analysis without affecting existing workflows.

Closes #375

## Changes

- Added configurable per-sample failure export settings in `configs/default.yaml`
- Added `nightmarenet/evaluation/failure_export.py` for JSON/CSV export logic
- Extended robustness evaluation to collect per-sample failure information when enabled
- Updated `nightmarenet/evaluation/evaluator.py` to trigger failure export after robustness evaluation
- Added `tests/test_failure_export.py` covering export, filtering, and output generation

## Acceptance Criteria

- [x] Evaluation generates per-sample results alongside aggregate metrics
- [x] Failed samples are exported to JSON or CSV
- [x] Failure records include the required metadata and confidence information
- [x] Export format is configurable
- [x] Only failures are exported
- [x] Existing evaluation behavior remains unchanged when export is disabled
- [x] `evaluation.export_failures` enables the feature
- [x] Added tests covering the export functionality

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [ ] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [x] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [x] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [x] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see SECURITY.md — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

N/A

## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

The implementation is intentionally opt-in. Existing robustness evaluation behavior remains unchanged unless `evaluation.export_failures` is enabled. The export logic is isolated in a dedicated module to keep the evaluation pipeline modular and easier to extend for future failure analysis features.

</details>