### PR TITLE
feat(evaluation): add IBM ART integration adapter with PGD, FGSM, and C&W attacks

### DIFF
--- a/docs/tutorials/art-integration.md
+++ b/docs/tutorials/art-integration.md
@@ -1,0 +1,107 @@
+# ART Integration Tutorial
+
+This guide shows how to use IBM's [Adversarial Robustness Toolbox (ART)](https://github.com/Trusted-AI/adversarial-robustness-toolbox) with NightmareNet to evaluate model robustness using standardized adversarial attacks.
+
+## Installation
+
+Install NightmareNet with the `art` optional extra:
+
+```bash
+pip install 'nightmarenet[art]'
+```
+
+Or add it to your existing installation:
+
+```bash
+pip install adversarial-robustness-toolbox>=1.15.0
+```
+
+## Quick Start
+
+### 1. Wrap Your Model
+
+```python
+from nightmarenet.evaluation.art_adapter import NightmareNetARTClassifier
+
+# Wrap any torch.nn.Module as an ART classifier
+wrapper = NightmareNetARTClassifier(
+    model=your_pytorch_model,
+    nb_classes=10,
+    input_shape=(3, 32, 32),      # C, H, W
+    clip_values=(0.0, 1.0),       # input range
+)
+
+art_classifier = wrapper.classifier
+```
+
+### 2. Run a Single Attack
+
+```python
+import numpy as np
+from nightmarenet.evaluation.art_adapter import run_art_attack
+
+# Prepare test data (numpy arrays)
+x_test = np.random.rand(100, 3, 32, 32).astype(np.float32)
+y_test = np.random.randint(0, 10, 100)
+
+# Run PGD attack
+result = run_art_attack(
+    art_classifier,
+    attack_name="pgd",
+    x=x_test,
+    y=y_test,
+    eps=0.3,          # perturbation budget
+    max_iter=40,      # PGD iterations
+)
+
+print(f"Attack: {result.attack_name}")
+print(f"Success Rate: {result.success_rate:.1%}")
+print(f"Mean L2 Perturbation: {result.mean_perturbation:.4f}")
+print(f"Query Count: {result.query_count}")
+print(f"Time: {result.elapsed_seconds:.1f}s")
+```
+
+### 3. Run a Full Benchmark (PGD + FGSM + C&W)
+
+```python
+from nightmarenet.evaluation.art_adapter import run_art_benchmark
+
+results = run_art_benchmark(
+    art_classifier,
+    x=x_test,
+    y=y_test,
+    attacks=["pgd", "fgsm", "cw"],
+    eps=0.3,
+)
+
+for r in results:
+    print(f"{r.attack_name:>6s} | success={r.success_rate:.1%} | L2={r.mean_perturbation:.4f}")
+```
+
+## Supported Attacks
+
+| Key    | ART Class                    | Description                                      |
+|--------|------------------------------|--------------------------------------------------|
+| `pgd`  | `ProjectedGradientDescent`   | Iterative projected gradient descent (Madry et al.) |
+| `fgsm` | `FastGradientMethod`         | Single-step fast gradient sign method (Goodfellow et al.) |
+| `cw`   | `CarliniL2Method`            | Carlini & Wagner L2 attack                       |
+
+## Metrics
+
+Each `ARTAttackResult` contains:
+
+- **`success_rate`** — Fraction of correctly-classified samples where the attack changed the prediction.
+- **`mean_perturbation`** / **`median_perturbation`** — L2 norm of the adversarial perturbation.
+- **`query_count`** — Estimated number of forward-pass queries made by the attack.
+- **`elapsed_seconds`** — Wall-clock time for the attack.
+
+## Graceful Degradation
+
+If ART is not installed, importing the adapter raises a helpful error:
+
+```python
+>>> from nightmarenet.evaluation.art_adapter import NightmareNetARTClassifier
+>>> NightmareNetARTClassifier(model=m, nb_classes=10, input_shape=(3,32,32))
+ImportError: The Adversarial Robustness Toolbox (ART) is not installed.
+Install it with:  pip install 'nightmarenet[art]'
+```

--- a/nightmarenet/__init__.py
+++ b/nightmarenet/__init__.py
@@ -2,8 +2,19 @@
 
 __version__ = "0.2.0"
 
-from nightmarenet.distortions.registry import get_registry as get_registry
-from nightmarenet.evaluation.evaluator import Evaluator as Evaluator
-from nightmarenet.pipeline import Pipeline as Pipeline
+try:
+    from nightmarenet.distortions.registry import get_registry as get_registry
+except ImportError:
+    get_registry = None  # type: ignore[assignment]
+
+try:
+    from nightmarenet.evaluation.evaluator import Evaluator as Evaluator
+except ImportError:
+    Evaluator = None  # type: ignore[assignment]
+
+try:
+    from nightmarenet.pipeline import Pipeline as Pipeline
+except ImportError:
+    Pipeline = None  # type: ignore[assignment]
 
 __all__ = ["Pipeline", "Evaluator", "get_registry", "__version__"]

--- a/nightmarenet/__init__.py
+++ b/nightmarenet/__init__.py
@@ -10,11 +10,11 @@ except ImportError:
 try:
     from nightmarenet.evaluation.evaluator import Evaluator as Evaluator
 except ImportError:
-    Evaluator = None  # type: ignore[assignment]
+    Evaluator = None  # type: ignore[assignment, misc]
 
 try:
     from nightmarenet.pipeline import Pipeline as Pipeline
 except ImportError:
-    Pipeline = None  # type: ignore[assignment]
+    Pipeline = None  # type: ignore[assignment, misc]
 
 __all__ = ["Pipeline", "Evaluator", "get_registry", "__version__"]

--- a/nightmarenet/evaluation/art_adapter.py
+++ b/nightmarenet/evaluation/art_adapter.py
@@ -1,0 +1,305 @@
+"""IBM Adversarial Robustness Toolbox (ART) integration for NightmareNet.
+
+Provides an adapter layer that wraps NightmareNet models as ART
+``PyTorchClassifier`` instances, enabling standardized adversarial
+attacks (PGD, FGSM, C&W) and comparable robustness metrics.
+
+Install the optional dependency with::
+
+    pip install 'nightmarenet[art]'
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Supported attack registry
+# ---------------------------------------------------------------------------
+
+SUPPORTED_ATTACKS: Dict[str, str] = {
+    "pgd": "ProjectedGradientDescent",
+    "fgsm": "FastGradientMethod",
+    "cw": "CarliniL2Method",
+}
+
+# ---------------------------------------------------------------------------
+# Import guard
+# ---------------------------------------------------------------------------
+
+
+def _check_art_available() -> None:
+    """Raise ``ImportError`` with install instructions if ART is missing."""
+    try:
+        import art  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "The Adversarial Robustness Toolbox (ART) is not installed. "
+            "Install it with:  pip install 'nightmarenet[art]'"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ARTAttackResult:
+    """Container for the outcome of a single ART attack run.
+
+    Attributes:
+        attack_name: Human-readable attack identifier (e.g. ``"pgd"``).
+        success_rate: Fraction of samples where the attack changed the prediction.
+        mean_perturbation: Mean L2 perturbation magnitude across all adversarial examples.
+        median_perturbation: Median L2 perturbation magnitude.
+        query_count: Total forward-pass queries made by the attack.
+        elapsed_seconds: Wall-clock time taken for the attack.
+        adversarial_examples: The generated adversarial inputs (numpy array).
+        original_predictions: Model predictions on clean inputs.
+        adversarial_predictions: Model predictions on adversarial inputs.
+    """
+
+    attack_name: str
+    success_rate: float
+    mean_perturbation: float
+    median_perturbation: float
+    query_count: int
+    elapsed_seconds: float
+    adversarial_examples: Optional[Any] = field(default=None, repr=False)
+    original_predictions: Optional[Any] = field(default=None, repr=False)
+    adversarial_predictions: Optional[Any] = field(default=None, repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Adapter class
+# ---------------------------------------------------------------------------
+
+
+class NightmareNetARTClassifier:
+    """Wrapper that adapts a ``torch.nn.Module`` into an ART ``PyTorchClassifier``.
+
+    Example::
+
+        from nightmarenet.evaluation.art_adapter import NightmareNetARTClassifier
+
+        wrapper = NightmareNetARTClassifier(
+            model=my_torch_model,
+            nb_classes=10,
+            input_shape=(3, 32, 32),
+        )
+        art_classifier = wrapper.classifier  # ready for ART attacks
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        nb_classes: int,
+        input_shape: Tuple[int, ...],
+        clip_values: Tuple[float, float] = (0.0, 1.0),
+        loss: Optional[Any] = None,
+        optimizer: Optional[Any] = None,
+        device_type: str = "cpu",
+    ) -> None:
+        _check_art_available()
+
+        import torch
+        from art.estimators.classification import PyTorchClassifier
+
+        if loss is None:
+            loss = torch.nn.CrossEntropyLoss()
+
+        self._model = model
+        self.classifier = PyTorchClassifier(
+            model=model,
+            loss=loss,
+            optimizer=optimizer,
+            input_shape=input_shape,
+            nb_classes=nb_classes,
+            clip_values=clip_values,
+            device_type=device_type,
+        )
+        logger.info(
+            "Wrapped model as ART PyTorchClassifier (classes=%d, shape=%s)",
+            nb_classes,
+            input_shape,
+        )
+
+    @classmethod
+    def from_nightmarenet_model(
+        cls,
+        model: Any,
+        nb_classes: int,
+        input_shape: Tuple[int, ...],
+        **kwargs: Any,
+    ) -> "NightmareNetARTClassifier":
+        """Factory constructor for convenience."""
+        return cls(model=model, nb_classes=nb_classes, input_shape=input_shape, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Attack runners
+# ---------------------------------------------------------------------------
+
+
+def _build_attack(classifier: Any, attack_name: str, **kwargs: Any) -> Any:
+    """Instantiate an ART attack object by name."""
+    name = attack_name.lower()
+    if name not in SUPPORTED_ATTACKS:
+        raise ValueError(
+            f"Unsupported attack: {attack_name!r}. "
+            f"Supported: {list(SUPPORTED_ATTACKS.keys())}"
+        )
+
+    _check_art_available()
+
+    if name == "pgd":
+        from art.attacks.evasion import ProjectedGradientDescent
+
+        return ProjectedGradientDescent(
+            estimator=classifier,
+            eps=kwargs.get("eps", 0.3),
+            eps_step=kwargs.get("eps_step", 0.01),
+            max_iter=kwargs.get("max_iter", 40),
+            targeted=kwargs.get("targeted", False),
+            batch_size=kwargs.get("batch_size", 32),
+        )
+    elif name == "fgsm":
+        from art.attacks.evasion import FastGradientMethod
+
+        return FastGradientMethod(
+            estimator=classifier,
+            eps=kwargs.get("eps", 0.3),
+            targeted=kwargs.get("targeted", False),
+            batch_size=kwargs.get("batch_size", 32),
+        )
+    elif name == "cw":
+        from art.attacks.evasion import CarliniL2Method
+
+        return CarliniL2Method(
+            classifier=classifier,
+            confidence=kwargs.get("confidence", 0.0),
+            max_iter=kwargs.get("max_iter", 10),
+            batch_size=kwargs.get("batch_size", 32),
+            learning_rate=kwargs.get("learning_rate", 0.01),
+        )
+
+    # Should not reach here due to the check above, but satisfy type checkers.
+    raise ValueError(f"Unsupported attack: {attack_name!r}")  # pragma: no cover
+
+
+def run_art_attack(
+    classifier: Any,
+    attack_name: str,
+    x: Any,
+    y: Any,
+    **attack_kwargs: Any,
+) -> ARTAttackResult:
+    """Run a single ART attack against a wrapped model.
+
+    Args:
+        classifier: An ART-compatible classifier (e.g. from ``NightmareNetARTClassifier.classifier``).
+        attack_name: One of ``"pgd"``, ``"fgsm"``, ``"cw"``.
+        x: Clean input samples as a numpy array of shape ``(N, *input_shape)``.
+        y: True labels as a numpy array of shape ``(N,)`` or one-hot ``(N, C)``.
+        **attack_kwargs: Extra keyword arguments forwarded to the ART attack constructor.
+
+    Returns:
+        An ``ARTAttackResult`` with metrics and adversarial examples.
+    """
+    _check_art_available()
+
+    x = np.asarray(x, dtype=np.float32)
+    y = np.asarray(y)
+
+    attack = _build_attack(classifier, attack_name, **attack_kwargs)
+
+    # Run the attack
+    t0 = time.perf_counter()
+    x_adv = attack.generate(x=x)
+    elapsed = time.perf_counter() - t0
+
+    # Predictions
+    original_preds = np.argmax(classifier.predict(x), axis=1)
+    adversarial_preds = np.argmax(classifier.predict(x_adv), axis=1)
+
+    # True labels (handle one-hot)
+    if y.ndim > 1:
+        true_labels = np.argmax(y, axis=1)
+    else:
+        true_labels = y
+
+    # Success rate = fraction where adversarial prediction differs from original correct prediction
+    correctly_classified = original_preds == true_labels
+    if correctly_classified.sum() == 0:
+        success_rate = 0.0
+    else:
+        flipped = adversarial_preds[correctly_classified] != true_labels[correctly_classified]
+        success_rate = float(flipped.mean())
+
+    # Perturbation magnitudes (L2)
+    diff = (x_adv - x).reshape(len(x), -1)
+    l2_norms = np.linalg.norm(diff, axis=1)
+
+    # Query count heuristic — ART does not expose this directly.
+    # PGD: max_iter forward + backward per sample; FGSM: 1; C&W: max_iter.
+    name = attack_name.lower()
+    max_iter = attack_kwargs.get("max_iter", 40 if name == "pgd" else (10 if name == "cw" else 1))
+    query_count = int(len(x) * max_iter)
+
+    return ARTAttackResult(
+        attack_name=attack_name.lower(),
+        success_rate=round(success_rate, 4),
+        mean_perturbation=round(float(np.mean(l2_norms)), 6),
+        median_perturbation=round(float(np.median(l2_norms)), 6),
+        query_count=query_count,
+        elapsed_seconds=round(elapsed, 3),
+        adversarial_examples=x_adv,
+        original_predictions=original_preds,
+        adversarial_predictions=adversarial_preds,
+    )
+
+
+def run_art_benchmark(
+    classifier: Any,
+    x: Any,
+    y: Any,
+    attacks: Optional[Sequence[str]] = None,
+    **attack_kwargs: Any,
+) -> List[ARTAttackResult]:
+    """Run multiple ART attacks and return aggregated results.
+
+    Args:
+        classifier: ART-compatible classifier.
+        x: Clean input samples.
+        y: True labels.
+        attacks: Attack names to run. Defaults to ``["pgd", "fgsm", "cw"]``.
+        **attack_kwargs: Extra keyword arguments forwarded to each attack constructor.
+
+    Returns:
+        List of ``ARTAttackResult``, one per attack.
+    """
+    if attacks is None:
+        attacks = list(SUPPORTED_ATTACKS.keys())
+
+    results: List[ARTAttackResult] = []
+    for attack_name in attacks:
+        logger.info("Running ART attack: %s", attack_name)
+        result = run_art_attack(classifier, attack_name, x, y, **attack_kwargs)
+        logger.info(
+            "  %s — success_rate=%.2f%%, mean_L2=%.4f, time=%.1fs",
+            result.attack_name,
+            result.success_rate * 100,
+            result.mean_perturbation,
+            result.elapsed_seconds,
+        )
+        results.append(result)
+
+    return results

--- a/nightmarenet/evaluation/art_adapter.py
+++ b/nightmarenet/evaluation/art_adapter.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -139,7 +139,7 @@ class NightmareNetARTClassifier:
         nb_classes: int,
         input_shape: Tuple[int, ...],
         **kwargs: Any,
-    ) -> "NightmareNetARTClassifier":
+    ) -> NightmareNetARTClassifier:
         """Factory constructor for convenience."""
         return cls(model=model, nb_classes=nb_classes, input_shape=input_shape, **kwargs)
 
@@ -205,7 +205,8 @@ def run_art_attack(
     """Run a single ART attack against a wrapped model.
 
     Args:
-        classifier: An ART-compatible classifier (e.g. from ``NightmareNetARTClassifier.classifier``).
+        classifier: An ART-compatible classifier (e.g. from
+            ``NightmareNetARTClassifier.classifier``).
         attack_name: One of ``"pgd"``, ``"fgsm"``, ``"cw"``.
         x: Clean input samples as a numpy array of shape ``(N, *input_shape)``.
         y: True labels as a numpy array of shape ``(N,)`` or one-hot ``(N, C)``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ export = [
     "onnx>=1.14.0",
     "onnxruntime>=1.16.0"
 ]
+art = [
+    "adversarial-robustness-toolbox>=1.15.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/Adit-Jain-srm/NightmareNet"

--- a/tests/test_art_adapter.py
+++ b/tests/test_art_adapter.py
@@ -1,0 +1,288 @@
+"""Tests for the IBM ART adapter module.
+
+Tests use mock objects so ART and PyTorch are NOT required to run the
+import-guard and validation tests. Tests that exercise actual ART
+functionality are skipped when ART is not installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Detect whether ART is available for integration tests
+# ---------------------------------------------------------------------------
+try:
+    import art  # noqa: F401
+
+    HAS_ART = True
+except ImportError:
+    HAS_ART = False
+
+try:
+    import torch  # noqa: F401
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+
+# ---------------------------------------------------------------------------
+# Import-guard tests (always run, even without ART)
+# ---------------------------------------------------------------------------
+
+
+class TestARTImportGuard:
+    """Verify graceful errors when ART is not installed."""
+
+    def test_check_art_available_raises_with_install_hint(self):
+        """Importing the guard with ART missing should raise ImportError with install hint."""
+        with patch.dict("sys.modules", {"art": None}):
+            # Re-import to get fresh state
+            from nightmarenet.evaluation.art_adapter import _check_art_available
+
+            with pytest.raises(ImportError, match="pip install 'nightmarenet\\[art\\]'"):
+                _check_art_available()
+
+    def test_supported_attacks_dictionary_contains_expected_keys(self):
+        from nightmarenet.evaluation.art_adapter import SUPPORTED_ATTACKS
+
+        assert "pgd" in SUPPORTED_ATTACKS
+        assert "fgsm" in SUPPORTED_ATTACKS
+        assert "cw" in SUPPORTED_ATTACKS
+
+    def test_art_attack_result_dataclass_fields(self):
+        from nightmarenet.evaluation.art_adapter import ARTAttackResult
+
+        field_names = {f.name for f in fields(ARTAttackResult)}
+        assert "attack_name" in field_names
+        assert "success_rate" in field_names
+        assert "mean_perturbation" in field_names
+        assert "median_perturbation" in field_names
+        assert "query_count" in field_names
+        assert "elapsed_seconds" in field_names
+        assert "adversarial_examples" in field_names
+
+    def test_invalid_attack_name_raises_value_error(self):
+        from nightmarenet.evaluation.art_adapter import _build_attack
+
+        with pytest.raises(ValueError, match="Unsupported attack"):
+            _build_attack(MagicMock(), "nonexistent_attack")
+
+
+# ---------------------------------------------------------------------------
+# Mock-based functional tests (no real ART needed)
+# ---------------------------------------------------------------------------
+
+
+class TestARTAdapterMocked:
+    """Tests using mocked ART modules to verify adapter logic."""
+
+    def test_run_art_attack_returns_valid_result(self):
+        """Verify run_art_attack returns correct ARTAttackResult with mocked attack."""
+        from nightmarenet.evaluation.art_adapter import ARTAttackResult
+
+        # Mock the entire ART import chain
+        mock_art = MagicMock()
+        mock_pgd_class = MagicMock()
+
+        n_samples = 10
+        n_classes = 3
+        input_shape = (3, 4, 4)
+        x = np.random.rand(n_samples, *input_shape).astype(np.float32)
+        y = np.eye(n_classes)[np.random.randint(0, n_classes, n_samples)]
+
+        # Mock attack.generate returns slightly perturbed inputs
+        x_adv = x + np.random.normal(0, 0.01, x.shape).astype(np.float32)
+        mock_pgd_instance = MagicMock()
+        mock_pgd_instance.generate.return_value = x_adv
+        mock_pgd_class.return_value = mock_pgd_instance
+
+        # Mock classifier.predict returns valid logits
+        mock_classifier = MagicMock()
+        clean_logits = np.random.rand(n_samples, n_classes).astype(np.float32)
+        adv_logits = np.random.rand(n_samples, n_classes).astype(np.float32)
+        mock_classifier.predict.side_effect = [clean_logits, adv_logits]
+
+        with patch.dict("sys.modules", {"art": mock_art}):
+            with patch(
+                "nightmarenet.evaluation.art_adapter._build_attack",
+                return_value=mock_pgd_instance,
+            ):
+                from nightmarenet.evaluation.art_adapter import run_art_attack
+
+                result = run_art_attack(mock_classifier, "pgd", x, y)
+
+        assert isinstance(result, ARTAttackResult)
+        assert result.attack_name == "pgd"
+        assert 0.0 <= result.success_rate <= 1.0
+        assert result.mean_perturbation >= 0.0
+        assert result.median_perturbation >= 0.0
+        assert result.query_count > 0
+        assert result.elapsed_seconds >= 0.0
+        assert result.adversarial_examples is not None
+
+    def test_run_art_benchmark_returns_list_of_results(self):
+        """Verify run_art_benchmark returns one result per attack."""
+        from nightmarenet.evaluation.art_adapter import ARTAttackResult
+
+        mock_art = MagicMock()
+
+        n_samples = 5
+        n_classes = 2
+        input_shape = (1, 8, 8)
+        x = np.random.rand(n_samples, *input_shape).astype(np.float32)
+        y = np.eye(n_classes)[np.random.randint(0, n_classes, n_samples)]
+
+        mock_attack_instance = MagicMock()
+        mock_attack_instance.generate.return_value = x + 0.01
+
+        mock_classifier = MagicMock()
+        # predict is called twice per attack (clean + adversarial) * 3 attacks = 6 calls
+        logits = np.random.rand(n_samples, n_classes).astype(np.float32)
+        mock_classifier.predict.return_value = logits
+
+        with patch.dict("sys.modules", {"art": mock_art}):
+            with patch(
+                "nightmarenet.evaluation.art_adapter._build_attack",
+                return_value=mock_attack_instance,
+            ):
+                from nightmarenet.evaluation.art_adapter import run_art_benchmark
+
+                results = run_art_benchmark(
+                    mock_classifier, x, y, attacks=["pgd", "fgsm", "cw"]
+                )
+
+        assert len(results) == 3
+        assert all(isinstance(r, ARTAttackResult) for r in results)
+        attack_names = [r.attack_name for r in results]
+        assert "pgd" in attack_names
+        assert "fgsm" in attack_names
+        assert "cw" in attack_names
+
+    def test_run_art_attack_with_integer_labels(self):
+        """Verify integer (non-one-hot) labels are handled correctly."""
+        mock_art = MagicMock()
+
+        n_samples = 8
+        n_classes = 4
+        input_shape = (3, 4, 4)
+        x = np.random.rand(n_samples, *input_shape).astype(np.float32)
+        y = np.random.randint(0, n_classes, n_samples)
+
+        mock_attack_instance = MagicMock()
+        mock_attack_instance.generate.return_value = x + 0.01
+
+        mock_classifier = MagicMock()
+        logits = np.random.rand(n_samples, n_classes).astype(np.float32)
+        mock_classifier.predict.return_value = logits
+
+        with patch.dict("sys.modules", {"art": mock_art}):
+            with patch(
+                "nightmarenet.evaluation.art_adapter._build_attack",
+                return_value=mock_attack_instance,
+            ):
+                from nightmarenet.evaluation.art_adapter import run_art_attack
+
+                result = run_art_attack(mock_classifier, "fgsm", x, y)
+
+        assert result.attack_name == "fgsm"
+        assert 0.0 <= result.success_rate <= 1.0
+
+    def test_run_art_attack_zero_correct_predictions(self):
+        """When the model classifies nothing correctly, success_rate should be 0."""
+        mock_art = MagicMock()
+
+        n_samples = 5
+        n_classes = 3
+        input_shape = (1, 4, 4)
+        x = np.random.rand(n_samples, *input_shape).astype(np.float32)
+        y = np.zeros(n_samples, dtype=int)  # all label 0
+
+        mock_attack_instance = MagicMock()
+        mock_attack_instance.generate.return_value = x
+
+        mock_classifier = MagicMock()
+        # Predict class 1 for everything (never matches label 0)
+        wrong_logits = np.zeros((n_samples, n_classes), dtype=np.float32)
+        wrong_logits[:, 1] = 1.0
+        mock_classifier.predict.return_value = wrong_logits
+
+        with patch.dict("sys.modules", {"art": mock_art}):
+            with patch(
+                "nightmarenet.evaluation.art_adapter._build_attack",
+                return_value=mock_attack_instance,
+            ):
+                from nightmarenet.evaluation.art_adapter import run_art_attack
+
+                result = run_art_attack(mock_classifier, "pgd", x, y)
+
+        assert result.success_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (skipped when ART / torch not installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_ART or not HAS_TORCH, reason="ART and/or PyTorch not installed")
+class TestARTAdapterIntegration:
+    """Integration tests that use real ART + PyTorch."""
+
+    def _make_simple_model(self):
+        """Create a tiny linear classifier for testing."""
+        import torch
+
+        model = torch.nn.Sequential(
+            torch.nn.Flatten(),
+            torch.nn.Linear(3 * 4 * 4, 3),
+        )
+        model.eval()
+        return model
+
+    def test_nightmarenet_art_classifier_wraps_model(self):
+        from nightmarenet.evaluation.art_adapter import NightmareNetARTClassifier
+
+        model = self._make_simple_model()
+        wrapper = NightmareNetARTClassifier(
+            model=model,
+            nb_classes=3,
+            input_shape=(3, 4, 4),
+        )
+        assert wrapper.classifier is not None
+
+    def test_from_nightmarenet_model_factory(self):
+        from nightmarenet.evaluation.art_adapter import NightmareNetARTClassifier
+
+        model = self._make_simple_model()
+        wrapper = NightmareNetARTClassifier.from_nightmarenet_model(
+            model=model,
+            nb_classes=3,
+            input_shape=(3, 4, 4),
+        )
+        assert wrapper.classifier is not None
+
+    def test_run_fgsm_attack(self):
+        from nightmarenet.evaluation.art_adapter import (
+            NightmareNetARTClassifier,
+            run_art_attack,
+        )
+
+        model = self._make_simple_model()
+        wrapper = NightmareNetARTClassifier(
+            model=model, nb_classes=3, input_shape=(3, 4, 4)
+        )
+
+        x = np.random.rand(8, 3, 4, 4).astype(np.float32)
+        y = np.random.randint(0, 3, 8)
+
+        result = run_art_attack(wrapper.classifier, "fgsm", x, y, eps=0.1)
+
+        assert result.attack_name == "fgsm"
+        assert 0.0 <= result.success_rate <= 1.0
+        assert result.mean_perturbation >= 0.0
+        assert result.adversarial_examples.shape == x.shape


### PR DESCRIPTION
## Summary

Adds an adapter layer that wraps NightmareNet models as ART `PyTorchClassifier` instances, enabling standardized adversarial attacks (PGD, FGSM, C&W) with industry-standard robustness metrics.

## Motivation

NightmareNet evaluates robustness using custom distortions but doesn't integrate with IBM's Adversarial Robustness Toolbox (ART) — the industry standard for adversarial ML evaluation. This makes results incomparable with published research.

Closes #339

## Changes

- `pyproject.toml`: Added `art = ["adversarial-robustness-toolbox>=1.15.0"]` optional dependency.
- `nightmarenet/evaluation/art_adapter.py` [NEW]: ART adapter module with:
  - `NightmareNetARTClassifier` — wraps `torch.nn.Module` as `art.estimators.classification.PyTorchClassifier`.
  - `run_art_attack()` — runs a single attack (pgd/fgsm/cw) with standardized metrics.
  - `run_art_benchmark()` — runs multiple attacks and returns aggregated results.
  - `ARTAttackResult` dataclass with: `success_rate`, `mean_perturbation`, `median_perturbation`, `query_count`, `elapsed_seconds`.
  - `_check_art_available()` — graceful error with install instructions when ART is missing.
- `tests/test_art_adapter.py` [NEW]: 11 tests (8 mock-based, 3 integration skipped without ART/torch) covering import guard, result dataclass, attack validation, mocked attack runs, benchmark aggregation, integer labels, and zero-accuracy edge case.
- `docs/tutorials/art-integration.md` [NEW]: Usage guide with installation, quick-start, and metrics explanation.
- `nightmarenet/__init__.py`: Guarded optional imports for environments without PyTorch.

## Acceptance Criteria

- [x] ART listed as optional dependency in `pyproject.toml`
- [x] Adapter wraps NightmareNet model as `art.estimators.classification.PyTorchClassifier`
- [x] At least 3 ART attacks runnable against NightmareNet models (PGD, FGSM, C&W)
- [x] Results include standard metrics: attack success rate, perturbation magnitude, query count
- [x] Test with mock model verifies adapter works correctly
- [x] Graceful error when ART not installed (helpful message pointing to install command)

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `pytest tests/` — all tests pass (8 passed, 3 skipped)
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries in `nightmarenet/`

## Documentation

- [x] Docstrings added/updated (Google style, public APIs only)
- [x] `docs/` updated (`docs/tutorials/art-integration.md`)

## AI Disclosure

- [ ] This PR is entirely human-written
- [x] This PR includes AI-assisted code — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [x] No secrets, keys, or credentials in code or comments
- [x] CORS / auth / rate limiting behavior unchanged
