### PR TITLE
feat: add DVC data versioning for reproducible experiments

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,4 @@
+/config.local
+/tmp
+/cache
+/local-remote

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = localremote
+['remote "localremote"']
+    url = local-remote

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .env/
 .venv/
 .venv312/
+.venv-dvc/
 
 # Secrets & environment
 .env
@@ -77,6 +78,15 @@ results/
 !results/gpu_benchmark.json
 checkpoints/
 logs/
+
+# DVC — large/managed data lives in cache/remote, not git
+.dvc/cache
+.dvc/tmp
+.dvc/local-remote/
+.dvc/config.local
+/data/raw/sst2_sample.csv
+/data/processed/sst2_sample.csv
+
 
 # Log files
 *.log

--- a/data/processed/.gitignore
+++ b/data/processed/.gitignore
@@ -1,0 +1,1 @@
+/sst2_sample.csv

--- a/data/raw/.gitignore
+++ b/data/raw/.gitignore
@@ -1,0 +1,1 @@
+/sst2_sample.csv

--- a/data/raw/sst2_sample.csv.dvc
+++ b/data/raw/sst2_sample.csv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 615e0aa7d38423a505ec0c65438118a0
+  size: 829
+  hash: md5
+  path: sst2_sample.csv

--- a/docs/data-versioning.md
+++ b/docs/data-versioning.md
@@ -1,0 +1,100 @@
+# Data versioning with DVC
+
+NightmareNet uses [DVC](https://dvc.org/) as an **optional** development tool to
+version datasets alongside code. DVC is not a runtime package dependency — install
+it only when you work on data or experiment reproducibility.
+
+## Why
+
+Loose dataset files have no lineage: if someone edits a CSV, prior experiments
+cannot be reproduced. DVC tracks content hashes (`.dvc` / `dvc.lock`) and can
+push/pull artifacts to a remote while git keeps only the small pointer files.
+
+## Setup
+
+```bash
+pip install dvc
+```
+
+This repo is already initialized (`.dvc/`, `dvc.yaml`, `dvc.lock`). The default
+remote is a **local filesystem** store at `.dvc/local-remote` (for testing). You
+can later point it at S3/GCS:
+
+```bash
+dvc remote add -d s3remote s3://your-bucket/nightmarenet
+```
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `data/raw/sst2_sample.csv.dvc` | Pointer for the SST-2-style sample dataset |
+| `data/raw/sst2_sample.csv` | Actual CSV (gitignored; restore via DVC or the prepare script) |
+| `data/processed/sst2_sample.csv` | Pipeline output from `dvc repro` (gitignored) |
+| `dvc.yaml` | Pipeline stages (data preparation) |
+| `dvc.lock` | Locked hashes for deps/outs |
+| `scripts/prepare_sst2_sample.py` | Deterministic SST-2-style sample generator |
+| `.dvc/config` | Remotes and DVC core settings |
+
+## Workflow
+
+### Pull existing data
+
+```bash
+dvc pull
+```
+
+Restores tracked files from the configured remote into `data/`.
+
+### Reproduce data preparation
+
+```bash
+dvc repro
+```
+
+Runs the `prepare_sst2` stage in `dvc.yaml`, which writes
+`data/processed/sst2_sample.csv` from `scripts/prepare_sst2_sample.py`.
+
+### Regenerate the raw sample locally
+
+If you do not have cache/remote data yet:
+
+```bash
+python scripts/prepare_sst2_sample.py --output data/raw/sst2_sample.csv
+```
+
+The script is deterministic so the content hash matches
+`data/raw/sst2_sample.csv.dvc`.
+
+### Share a new or updated dataset
+
+```bash
+# after changing or adding data
+dvc add data/raw/your_dataset.csv
+dvc push
+git add data/raw/your_dataset.csv.dvc data/raw/.gitignore dvc.lock
+git commit -m "data: update versioned dataset"
+```
+
+### Add a new preparation stage
+
+Edit `dvc.yaml`, then:
+
+```bash
+dvc repro
+git add dvc.yaml dvc.lock
+```
+
+## Pinning versions in experiments
+
+Commit the `.dvc` pointer (and `dvc.lock`) with the experiment config that used
+that data. Checking out that git commit and running `dvc pull` / `dvc repro`
+restores the same dataset bytes.
+
+## Notes
+
+- Do not commit large CSVs/parquets that DVC tracks — only `*.dvc`, `dvc.yaml`,
+  and `dvc.lock`.
+- The bundled SST-2 sample is a **tiny fixture** for tooling checks, not the
+  full GLUE SST-2 split used by training configs (`configs/benchmark_sst2*.yaml`
+  still load from HuggingFace).

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,15 @@
+schema: '2.0'
+stages:
+  prepare_sst2:
+    cmd: python scripts/prepare_sst2_sample.py --output 
+      data/processed/sst2_sample.csv
+    deps:
+    - path: scripts/prepare_sst2_sample.py
+      hash: md5
+      md5: 11d10b17ac520bfbfd09c117d19bf1b2
+      size: 2204
+    outs:
+    - path: data/processed/sst2_sample.csv
+      hash: md5
+      md5: 615e0aa7d38423a505ec0c65438118a0
+      size: 829

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,11 @@
+# DVC pipeline — data preparation for versioned experiment datasets.
+# Run: dvc repro
+# Requires: pip install dvc  (optional tool; not a package dependency)
+
+stages:
+  prepare_sst2:
+    cmd: python scripts/prepare_sst2_sample.py --output data/processed/sst2_sample.csv
+    deps:
+      - scripts/prepare_sst2_sample.py
+    outs:
+      - data/processed/sst2_sample.csv

--- a/scripts/prepare_sst2_sample.py
+++ b/scripts/prepare_sst2_sample.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Prepare a small SST-2-style sample dataset for DVC-tracked experiments.
+
+Generates a deterministic CSV with ``sentence`` / ``label`` columns matching
+the GLUE SST-2 schema. Intended for local reproducibility checks via
+``dvc repro``, not as a substitute for the full HuggingFace SST-2 split.
+"""
+
+import argparse
+import csv
+from pathlib import Path
+
+# Fixed fixtures so ``dvc repro`` is bit-stable across machines.
+_SAMPLES = [
+    ("a beautifully crafted piece of cinema", 1),
+    ("utterly boring and predictable from start to finish", 0),
+    ("an inspiring story with sharp performances", 1),
+    ("messy plotting ruins an otherwise decent cast", 0),
+    ("warm funny and surprisingly moving", 1),
+    ("a tedious slog with no payoff", 0),
+    ("smart writing elevates familiar material", 1),
+    ("loud empty and emotionally hollow", 0),
+    ("delightful entertainment for the whole family", 1),
+    ("confused tone and weak character work", 0),
+    ("a triumph of atmosphere and mood", 1),
+    ("forgettable fluff with lazy jokes", 0),
+    ("tense gripping and expertly paced", 1),
+    ("cliched dialogue sinks the drama", 0),
+    ("fresh ideas executed with confidence", 1),
+    ("overlong and self indulgent", 0),
+    ("charming performances light up the screen", 1),
+    ("style over substance in every frame", 0),
+    ("quietly powerful and deeply human", 1),
+    ("a misfire that never finds its footing", 0),
+]
+
+
+def prepare(output: Path) -> None:
+    """Write the SST-2-style sample CSV to ``output``."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["sentence", "label"])
+        writer.writerows(_SAMPLES)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/raw/sst2_sample.csv"),
+        help="Destination CSV path (default: data/raw/sst2_sample.csv)",
+    )
+    args = parser.parse_args()
+    prepare(args.output)
+    print(f"Wrote {len(_SAMPLES)} samples to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds optional DVC-based dataset versioning so experiment data can be pulled, reproduced, and shared without committing large files to git.

## Motivation
Datasets were loose files with no lineage. This wires DVC (optional tool, not a package dependency) for a small SST-2-style sample, a prepare pipeline, and a local filesystem remote for testing.
Closes #342

## Changes
- Init DVC (`.dvc/`, `.dvcignore`) with default local remote `.dvc/local-remote`
- Track `data/raw/sst2_sample.csv` via `data/raw/sst2_sample.csv.dvc`
- `dvc.yaml` / `dvc.lock` stage `prepare_sst2` → `data/processed/sst2_sample.csv`
- `scripts/prepare_sst2_sample.py` deterministic generator
- `docs/data-versioning.md` workflow docs
- `.gitignore` excludes DVC-managed CSVs and local remote/cache
## Before / After
| Before | After |
|--------|--------|
| No dataset versioning or lineage | `.dvc` pointer + `dvc.lock` hashes |
| No reproducible data prep | `dvc repro` runs `prepare_sst2` |
| Large data risk in git | CSVs gitignored; remote/cache for artifacts |
## Acceptance Criteria
- [x] `.dvc` file created for at least one dataset (SST-2 or similar test data)
- [x] `dvc.yaml` pipeline file defines data preparation steps
- [x] Remote storage configured (at minimum, local filesystem remote for testing)
- [x] `dvc repro` reproduces the data preparation step
- [x] Documentation in `docs/data-versioning.md` explaining the workflow
- [x] `.gitignore` updated to exclude large data files (tracked by DVC instead)
## Type
- [x] Infrastructure (CI/CD, Docker, tooling)
---
## Pre-submission Requirements
- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full
## Quality Checklist
- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [x] Commit messages follow Conventional Commits
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries in `nightmarenet/`
## Documentation
- [x] `docs/` updated (architecture, research, or API docs)
## AI Disclosure
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it
## Security Considerations
- [x] Not applicable (no security-sensitive changes)
