### PR TITLE
fix: preserve failure categories and wire evaluation flow

### DIFF
--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -448,12 +448,13 @@ class Evaluator:
             if delta_auc is not None:
                 comparison["robustness_delta"] = delta_auc
 
-        failure_categories = (
-            trained_results.get("failure_categories")
-            or trained_results.get("robustness", {}).get("failure_categories")
-            or baseline_results.get("failure_categories")
-            or baseline_results.get("robustness", {}).get("failure_categories")
-        )
+        failure_categories = trained_results.get("failure_categories")
+        if failure_categories is None:
+            failure_categories = trained_results.get("robustness", {}).get("failure_categories")
+        if failure_categories is None:
+            failure_categories = baseline_results.get("failure_categories")
+        if failure_categories is None:
+            failure_categories = baseline_results.get("robustness", {}).get("failure_categories")
         if failure_categories is not None:
             comparison["failure_categories"] = failure_categories
 

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -72,11 +72,14 @@ def categorize_failures_by_distortion(
             or "unknown"
         )
 
-        is_fail = rec.get("is_failure")
-        if is_fail is None:
-            is_fail = rec.get("failed")
-        if is_fail is None:
-            is_fail = not rec.get("correct") if "correct" in rec else True
+        if "is_failure" in rec:
+            is_fail = rec["is_failure"]
+        elif "failed" in rec:
+            is_fail = rec["failed"]
+        elif "correct" in rec:
+            is_fail = not rec["correct"]
+        else:
+            is_fail = False
         is_fail = bool(is_fail)
 
         raw_delta = rec.get("confidence_delta")
@@ -528,9 +531,6 @@ def robustness_score(
     if strengths is None:
         strengths = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
-    failure_categories = categorize_failures_by_distortion(
-        failure_records, total_samples_per_distortion
-    )
 
     is_vision = tokenizer is None or not hasattr(base_dataset, "map")
 
@@ -775,6 +775,16 @@ def robustness_score(
     if _trapz_fn is None:
         _trapz_fn = np.trapz  # type: ignore[attr-defined]
     auc = float(_trapz_fn(inv_ppls, strengths))
+
+    failure_categories = {}
+    if failure_records:
+        failure_categories = categorize_failures_by_distortion(
+            failure_records, total_samples_per_distortion
+        )
+    elif export_failures and 'failures_data' in locals() and failures_data:
+        failure_categories = categorize_failures_by_distortion(
+            failures_data, total_samples_per_distortion
+        )
 
     res = {
         "metric": "robustness",

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -622,6 +622,16 @@ def robustness_score(
             _trapz_fn = np.trapz  # type: ignore[attr-defined]
         auc = float(_trapz_fn(accuracies, strengths))
 
+        failure_categories = {}
+        if failure_records:
+            failure_categories = categorize_failures_by_distortion(
+                failure_records, total_samples_per_distortion
+            )
+        elif export_failures and failures_data:
+            failure_categories = categorize_failures_by_distortion(
+                failures_data, total_samples_per_distortion
+            )
+
         res = {
             "metric": "robustness",
             "strengths": strengths,
@@ -781,7 +791,7 @@ def robustness_score(
         failure_categories = categorize_failures_by_distortion(
             failure_records, total_samples_per_distortion
         )
-    elif export_failures and 'failures_data' in locals() and failures_data:
+    elif export_failures and failures_data:
         failure_categories = categorize_failures_by_distortion(
             failures_data, total_samples_per_distortion
         )

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -773,6 +773,7 @@ def robustness_score(
                         "distortion_type": "text_distortion",
                         "distortion_strength": float(strength),
                         "seed": 42,
+                        "is_failure": int(orig_preds[i]) != int(dist_preds[i]),
                     }
                 )
 

--- a/tests/test_failure_categories.py
+++ b/tests/test_failure_categories.py
@@ -170,3 +170,64 @@ def test_markdown_rendering(tmp_path):
     empty_report = evaluator.generate_report(comparison_no_failures)
     assert "## Failure by Distortion Type" in empty_report
     assert "No failures detected across evaluated distortion types." in empty_report
+
+
+def test_empty_failure_categories():
+    """Test that an empty dict for failure categories is preserved and not overwritten by fallback."""
+    from nightmarenet.evaluation.evaluator import Evaluator
+    evaluator = Evaluator(model=None, tokenizer=None, config={})
+    trained = {"failure_categories": {}}
+    baseline = {"failure_categories": {"blur": {"count": 5}}}
+    result = evaluator.compare(baseline, trained)
+    assert result.get("failure_categories") == {}
+
+
+def test_missing_key_failure():
+    """Test that records without explicit failure flags default to False."""
+    from nightmarenet.evaluation.metrics import categorize_failures_by_distortion
+    sample = {"distortion_type": "blur", "confidence_delta": 0.1}
+    res = categorize_failures_by_distortion([sample])
+    # The count should be 0 because it's not a failure
+    assert res["blur"]["count"] == 0
+    assert res["blur"]["failure_rate"] == 0.0
+
+
+def test_auto_wiring():
+    """Test that failure_categories is populated in robustness_score."""
+    from nightmarenet.evaluation.metrics import robustness_score
+    from unittest.mock import MagicMock
+
+    class DummyDataset:
+        def map(self, *args, **kwargs): return self
+        def __iter__(self): yield {"text": "test"}
+        def __len__(self): return 1
+        column_names = ["text"]
+        
+    class MockTokenizer:
+        def __call__(self, text, **kwargs):
+            import torch
+            return {"input_ids": torch.tensor([[1, 2, 3]])}
+        pad_token_id = 0
+            
+    mock_model = MagicMock()
+    mock_model.return_value = type("Output", (), {})()
+    
+    data = [{"distortion_type": "blur", "is_failure": True, "confidence_delta": 0.5}]
+    
+    # We pass failure_records to trigger the block
+    try:
+        results = robustness_score(
+            model=mock_model,
+            base_dataset=DummyDataset(),
+            tokenizer=MockTokenizer(),
+            distortion_fn=lambda x, **kwargs: x,
+            strengths=[0.1],
+            export_failures=True,
+            failure_records=data,
+        )
+        assert "failure_categories" in results
+        assert results["failure_categories"]["blur"]["count"] == 1
+    except Exception as e:
+        # If model inference fails due to simplistic mocking, at least verify the wiring logic
+        # works by checking if failure_categories was accessed or the test reached this far
+        pass

--- a/tests/test_failure_categories.py
+++ b/tests/test_failure_categories.py
@@ -214,11 +214,11 @@ def test_auto_wiring():
 
     with patch("nightmarenet.evaluation.metrics.compute_perplexity") as mock_ppl, \
          patch("nightmarenet.evaluation.metrics.classification_metrics") as mock_cls:
-        
+
         # Mock responses to bypass actual inference
         mock_ppl.return_value = {"perplexity": 2.0, "per_sample_ppls": [2.0]}
-        # We need a failure, so orig_preds != dist_preds. Since it is called twice (clean, then distorted)
-        # we can just use side_effect to return different predictions.
+        # We need a failure, so orig_preds != dist_preds. Since it is called
+        # twice (clean, then distorted), we use side_effect to return different predictions.
         mock_cls.side_effect = [
             {"per_sample_preds": [0], "per_sample_confs": [0.9]},  # Clean dataset
             {"per_sample_preds": [1], "per_sample_confs": [0.4]}   # Distorted dataset

--- a/tests/test_failure_categories.py
+++ b/tests/test_failure_categories.py
@@ -200,6 +200,7 @@ def test_auto_wiring():
 
     class DummyDataset:
         def map(self, *args, **kwargs): return self
+        def set_format(self, *args, **kwargs): return self
         def __iter__(self): yield {"text": "test"}
         def __len__(self): return 1
         column_names = ["text"]

--- a/tests/test_failure_categories.py
+++ b/tests/test_failure_categories.py
@@ -173,7 +173,7 @@ def test_markdown_rendering(tmp_path):
 
 
 def test_empty_failure_categories():
-    """Test that an empty dict for failure categories is preserved and not overwritten by fallback."""
+    """Test that an empty dict for failure categories is preserved."""
     from nightmarenet.evaluation.evaluator import Evaluator
     evaluator = Evaluator(model=None, tokenizer=None, config={})
     trained = {"failure_categories": {}}
@@ -194,26 +194,27 @@ def test_missing_key_failure():
 
 def test_auto_wiring():
     """Test that failure_categories is populated in robustness_score."""
-    from nightmarenet.evaluation.metrics import robustness_score
     from unittest.mock import MagicMock
+
+    from nightmarenet.evaluation.metrics import robustness_score
 
     class DummyDataset:
         def map(self, *args, **kwargs): return self
         def __iter__(self): yield {"text": "test"}
         def __len__(self): return 1
         column_names = ["text"]
-        
+
     class MockTokenizer:
         def __call__(self, text, **kwargs):
             import torch
             return {"input_ids": torch.tensor([[1, 2, 3]])}
         pad_token_id = 0
-            
+
     mock_model = MagicMock()
     mock_model.return_value = type("Output", (), {})()
-    
+
     data = [{"distortion_type": "blur", "is_failure": True, "confidence_delta": 0.5}]
-    
+
     # We pass failure_records to trigger the block
     try:
         results = robustness_score(
@@ -227,7 +228,7 @@ def test_auto_wiring():
         )
         assert "failure_categories" in results
         assert results["failure_categories"]["blur"]["count"] == 1
-    except Exception as e:
+    except Exception:
         # If model inference fails due to simplistic mocking, at least verify the wiring logic
         # works by checking if failure_categories was accessed or the test reached this far
         pass

--- a/tests/test_failure_categories.py
+++ b/tests/test_failure_categories.py
@@ -194,7 +194,7 @@ def test_missing_key_failure():
 
 def test_auto_wiring():
     """Test that failure_categories is populated in robustness_score."""
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
 
     from nightmarenet.evaluation.metrics import robustness_score
 
@@ -211,12 +211,19 @@ def test_auto_wiring():
         pad_token_id = 0
 
     mock_model = MagicMock()
-    mock_model.return_value = type("Output", (), {})()
 
-    data = [{"distortion_type": "blur", "is_failure": True, "confidence_delta": 0.5}]
+    with patch("nightmarenet.evaluation.metrics.compute_perplexity") as mock_ppl, \
+         patch("nightmarenet.evaluation.metrics.classification_metrics") as mock_cls:
+        
+        # Mock responses to bypass actual inference
+        mock_ppl.return_value = {"perplexity": 2.0, "per_sample_ppls": [2.0]}
+        # We need a failure, so orig_preds != dist_preds. Since it is called twice (clean, then distorted)
+        # we can just use side_effect to return different predictions.
+        mock_cls.side_effect = [
+            {"per_sample_preds": [0], "per_sample_confs": [0.9]},  # Clean dataset
+            {"per_sample_preds": [1], "per_sample_confs": [0.4]}   # Distorted dataset
+        ]
 
-    # We pass failure_records to trigger the block
-    try:
         results = robustness_score(
             model=mock_model,
             base_dataset=DummyDataset(),
@@ -224,11 +231,8 @@ def test_auto_wiring():
             distortion_fn=lambda x, **kwargs: x,
             strengths=[0.1],
             export_failures=True,
-            failure_records=data,
+            failure_records=None,
         )
         assert "failure_categories" in results
-        assert results["failure_categories"]["blur"]["count"] == 1
-    except Exception:
-        # If model inference fails due to simplistic mocking, at least verify the wiring logic
-        # works by checking if failure_categories was accessed or the test reached this far
-        pass
+        # By default, metrics.py export logic uses "text_distortion" as distortion_type
+        assert results["failure_categories"]["text_distortion"]["count"] == 1


### PR DESCRIPTION
## Summary

<!-- One-sentence description of what this PR does. Be specific. -->

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

Closes #

## Changes

<!-- Bullet-point list of what changed. Include file paths for non-obvious changes. -->

-

## Acceptance Criteria

<!-- Copy the acceptance criteria from the linked issue as checkboxes.
     Check each box ONLY when your implementation satisfies it.
     If a criterion is not addressed in this PR, leave unchecked and explain why. -->

- [ ]

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [ ] I have **starred** this repository ⭐
- [ ] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [ ] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [ ] New functionality has corresponding tests
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [ ] No `from __future__ import annotations` added under `nightmarenet/api/`
- [ ] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [ ] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

<!-- Required by CONTRIBUTING.md. Check one. -->

- [ ] This PR is entirely human-written
- [ ] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [ ] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)

<!-- Required by CONTRIBUTING.md for any frontend change. All three are needed. -->

| View | Screenshot |
|------|-----------|
| Desktop (dark mode) | |
| Desktop (light mode) | |
| Mobile (375px) | |

## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>
Description

This PR fixes the failure categorization logic and integrates it into the standard evaluation pipeline.

Changes Made
Replaced the or-chain used to resolve failure_categories with explicit None checks to preserve empty dictionaries.
Updated failure detection logic so records without explicit failure indicators default to False instead of being treated as failures.
Wired failure_records from the per-sample export flow into robustness_score() when export_failures=True.
Enabled automatic generation of failure categories from exported per-sample evaluation data.
Added tests covering empty-dictionary preservation, default failure behavior, and automatic failure categorization.
Related Issue

Closes #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failure categorization to respect explicit failure flags and avoid defaulting missing fields to failures.
  * Ensured intentionally empty failure-category results are preserved during evaluations/comparisons.
  * Improved robustness reporting by correctly deriving and exporting failure categories only when relevant data is available.
* **Tests**
  * Added coverage for empty failure-category inputs, non-failure records missing explicit indicators, and end-to-end robustness reporting with exported distortion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->