### PR TITLE
fix(ci): harden release automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
             echo "::warning::RELEASE_PLEASE_TOKEN is not configured; release-please will use GITHUB_TOKEN, so a created tag will not trigger the downstream release workflow."
           fi
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,12 +8,22 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Warn when release token is unavailable
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "::warning::RELEASE_PLEASE_TOKEN is not configured; release-please will use GITHUB_TOKEN, so a created tag will not trigger the downstream release workflow."
+          fi
+
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,9 @@ jobs:
           path: dist/
 
       - name: Publish GitHub Release with assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: dist/*
-          generate_release_notes: true
           fail_on_unmatched_files: true
 
   publish:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,13 +29,30 @@ Tags look like `v0.2.1` (leading `v`).
    - updates `CHANGELOG.md`
    - updates `.release-please-manifest.json`
 4. Merge the Release PR.
-5. release-please creates the git tag and a GitHub Release with auto-generated notes.
+5. release-please creates the git tag and a GitHub Release while preserving the
+   curated changelog body.
 6. The tag triggers `.github/workflows/release.yml`, which:
    - builds the wheel and sdist
    - attaches them to the GitHub Release
    - publishes to PyPI (trusted publishing / `pypi` environment)
 
 No manual tagging is required for day-to-day releases after the bootstrap below.
+
+## Release token configuration
+
+Configure a fine-grained personal access token (PAT) in the repository settings
+as the `RELEASE_PLEASE_TOKEN` Actions secret. The token needs:
+
+- `Contents: write`, so release-please can create the release tag
+- `Pull requests: write`, so release-please can open and update the Release PR
+- `Issues: write`, so release-please can apply its Release PR labels
+
+When this secret is configured, release-please uses it to create the tag and the
+tag-triggered release workflow runs automatically. If the secret is unavailable,
+the workflow deliberately falls back to the default `GITHUB_TOKEN` and logs a
+warning. release-please can still open or update the Release PR, but a tag created
+with that fallback token will not trigger the downstream release workflow. In that
+case, a maintainer must push the release tag manually after reviewing the Release PR.
 
 ## Bootstrap: first release (`v0.2.1`)
 
@@ -49,7 +66,7 @@ git tag v0.2.1
 git push origin v0.2.1
 ```
 
-That runs `release.yml`: changelog/notes on the GitHub Release, wheel/sdist
+That runs `release.yml`: the curated changelog/notes on the GitHub Release, wheel/sdist
 assets, and PyPI publish (if the `pypi` environment is configured).
 
 Later releases should go through release-please only (do not hand-edit version


### PR DESCRIPTION
## Summary

Updates release automation so release-please can trigger downstream tag workflows when configured, while preserving its curated release notes.

## Motivation

The release-please workflow previously used the default `GITHUB_TOKEN`, lacked `issues: write`, and the release workflow used a mutable action tag with `generate_release_notes: true`. These settings could prevent downstream workflow execution, weaken supply-chain pinning, and overwrite release-please changelog content.

## Changes

- Added `issues: write` permission to `.github/workflows/release-please.yml`.
- Added `RELEASE_PLEASE_TOKEN` support with the maintainer-approved fallback to `github.token` and a warning when the secret is unavailable.
- Pinned `softprops/action-gh-release` to commit `c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda` (`v2.2.1`).
- Removed `generate_release_notes` so release-please's curated body is preserved.
- Documented PAT configuration, required permissions, fallback behavior, and manual tagging in `docs/releasing.md`.

## Acceptance Criteria

- [x] Release-please uses `RELEASE_PLEASE_TOKEN` when configured and falls back to `GITHUB_TOKEN` with a warning.
- [x] Release-please permissions include `contents: write`, `pull-requests: write`, and `issues: write`.
- [x] The GitHub Release action is pinned to a full commit SHA.
- [x] `generate_release_notes: true` was removed.
- [x] `RELEASE_PLEASE_TOKEN` configuration is documented.
- [ ] End-to-end confirmation that a release-please-created tag triggers `release.yml` requires maintainer-controlled GitHub secrets and workflow execution.

## Tests

- `git diff --check` passed.
- Workflow and documentation changes were reviewed statically.
- The repository's application test suite was not run because this PR changes only GitHub Actions configuration and release documentation.
- End-to-end tag-trigger verification remains maintainer-assisted and was not performed locally.

## Risks and follow-up

The configured fine-grained PAT must have repository `Contents: write`, `Pull requests: write`, and `Issues: write` permissions. If the secret is missing, release-please can still create or update its Release PR, but tags created with `GITHUB_TOKEN` will not trigger the downstream release workflow; a maintainer must push the tag manually.

This PR includes AI-assisted code understanding to speed up the process; the changes were manually reviewed and updated with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Improved automated release creation and publishing workflows.
  - Added a fallback token option and clearer warnings when release credentials are unavailable.
  - Release artifacts continue to be uploaded automatically from the distribution build.

- **Documentation**
  - Clarified release token requirements, permissions, and fallback behavior.
  - Documented manual tag-publishing steps when automated credentials are unavailable.
  - Updated first-release guidance for changelogs, packages, and publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->