### PR TITLE
infra: extend mypy strict mode to optimization and data modules (#445)

### DIFF
--- a/nightmarenet/data/adaption.py
+++ b/nightmarenet/data/adaption.py
@@ -22,22 +22,22 @@ logger = logging.getLogger(__name__)
 try:
     from adaption import Adaption
 except ImportError:
-    Adaption = None  # type: ignore[assignment, misc]
+    Adaption = None
 
 try:
     from adaption import AsyncAdaption
 except ImportError:
-    AsyncAdaption = None  # type: ignore[assignment, misc]
+    AsyncAdaption = None
 
 try:
     from adaption import DatasetTimeout
 except ImportError:
-    DatasetTimeout = None  # type: ignore[assignment, misc]
+    DatasetTimeout = None
 
 try:
     from datasets import Dataset as HFDataset
 except ImportError:
-    HFDataset = None  # type: ignore[assignment, misc]
+    HFDataset = None
 
 __all__ = ["Adaption", "AsyncAdaption", "AdaptionOptimizer"]
 

--- a/nightmarenet/data/generator.py
+++ b/nightmarenet/data/generator.py
@@ -45,15 +45,15 @@ class DreamDatasetGenerator:
         self,
         strength: float = 0.25,
         text_column: str = "text",
-        config: Optional[dict] = None,
+        config: Optional[dict[str, Any]] = None,
         seed: int = 42,
-    ):
+    ) -> None:
         self.strength = validate_strength(strength, "strength")
         self.text_column = text_column
         self.config = config or {}
         self.seed = seed
 
-    def _distort(self, example: dict) -> dict:
+    def _distort(self, example: dict[str, Any]) -> dict[str, Any]:
         """Apply dream-level distortions to a single example."""
         text = example[self.text_column]
         if not text or not text.strip():
@@ -92,7 +92,7 @@ class DreamDatasetGenerator:
 
         return {**example, self.text_column: result}
 
-    def generate(self, dataset):
+    def generate(self, dataset: Any) -> Any:
         """Generate a dream dataset by applying mild distortions.
 
         Args:
@@ -191,7 +191,7 @@ class NightmareDatasetGenerator:
         self,
         strength: float = 0.8,
         text_column: str = "text",
-        config: Optional[dict] = None,
+        config: Optional[dict[str, Any]] = None,
         seed: int = 42,
         strength_schedule: str = "uniform",
         strength_min: float = 0.3,
@@ -199,7 +199,7 @@ class NightmareDatasetGenerator:
         target_model: Optional[Any] = None,
         target_tokenizer: Optional[Any] = None,
         cycle_id: int = 0,
-    ):
+    ) -> None:
         self.strength = validate_strength(strength, "strength")
         self.text_column = text_column
         self.config = config or {}
@@ -230,7 +230,7 @@ class NightmareDatasetGenerator:
     def uses_gradient_learned(self) -> bool:
         """Return whether model-aware learned distortion is enabled."""
         adversarial = self.config.get("adversarial", {})
-        return (
+        return bool(
             adversarial.get("learned", 0.0) > 0.0
             and adversarial.get("learned_strategy", "attention") == "gradient"
         )
@@ -285,7 +285,7 @@ class NightmareDatasetGenerator:
 
         return strengths
 
-    def _distort(self, example: dict, strength: Optional[float] = None) -> dict:
+    def _distort(self, example: dict[str, Any], strength: Optional[float] = None) -> dict[str, Any]:
         """Apply nightmare-level distortions to a single example.
 
         Args:
@@ -345,7 +345,7 @@ class NightmareDatasetGenerator:
 
         return {**example, self.text_column: result}
 
-    def generate(self, dataset):
+    def generate(self, dataset: Any) -> Any:
         """Generate a nightmare dataset by applying extreme distortions.
 
         Args:
@@ -404,7 +404,7 @@ class NightmareDatasetGenerator:
         else:
             strengths = self._compute_strengths(len(dataset))
 
-            def _distort_with_strength(example, idx):
+            def _distort_with_strength(example: dict[str, Any], idx: int) -> dict[str, Any]:
                 return self._distort(example, strength=strengths[idx])
 
             nightmare_data = dataset.map(
@@ -445,7 +445,7 @@ class NightmareDatasetGenerator:
 
 
 def create_generators_from_config(
-    config: dict,
+    config: dict[str, Any],
 ) -> tuple[DreamDatasetGenerator, NightmareDatasetGenerator]:
     """Create dream and nightmare generators from a config dictionary.
 
@@ -479,18 +479,23 @@ def create_generators_from_config(
     return dream_gen, nightmare_gen
 
 
-class DistortedVisionDataset(torch.utils.data.Dataset):
-    def __init__(self, dataset, generator, phase="dream"):
-        self.dataset = dataset
-        self.generator = generator
-        self.phase = phase
-        self._cached_strengths = None
-        self._cached_strengths_len = None
+class DistortedVisionDataset(torch.utils.data.Dataset):  # type: ignore[misc]
+    def __init__(
+        self,
+        dataset: Any,
+        generator: Any,
+        phase: str = "dream",
+    ) -> None:
+        self.dataset: Any = dataset
+        self.generator: DreamDatasetGenerator | NightmareDatasetGenerator = generator
+        self.phase: str = phase
+        self._cached_strengths: Optional[list[float]] = None
+        self._cached_strengths_len: Optional[int] = None
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.dataset)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> dict[str, Any]:
         item = self.dataset[idx]
         pixel_values = item["pixel_values"]
         labels = item["labels"]
@@ -500,7 +505,7 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
         registry = get_vision_registry()
 
         # Retrieve engines matching the current phase
-        engines = []
+        engines: list[str] = []
         vision_config = self.generator.config.get("vision", {})
         if vision_config:
             for name, prob in vision_config.items():
@@ -520,7 +525,10 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
         if self.phase == "nightmare" and sched != "uniform":
             ds_len = len(self.dataset)
             if self._cached_strengths is None or self._cached_strengths_len != ds_len:
-                self._cached_strengths = self.generator._compute_strengths(ds_len)
+                if hasattr(self.generator, "_compute_strengths"):
+                    self._cached_strengths = self.generator._compute_strengths(ds_len)
+                else:
+                    self._cached_strengths = [actual_strength] * ds_len
                 self._cached_strengths_len = ds_len
             if idx < len(self._cached_strengths):
                 actual_strength = self._cached_strengths[idx]
@@ -530,7 +538,7 @@ class DistortedVisionDataset(torch.utils.data.Dataset):
             if name in ["vision_fgsm", "vision_pgd"]:
                 fn = registry._engines.get(name)
                 if fn is not None and hasattr(fn, "__self__"):
-                    fn.__self__.model = self.generator.target_model
+                    fn.__self__.model = getattr(self.generator, "target_model", None)
             distorted = registry.apply(
                 name, distorted, strength=actual_strength, seed=self.generator.seed
             )

--- a/nightmarenet/data/loader.py
+++ b/nightmarenet/data/loader.py
@@ -7,7 +7,7 @@ datasets and returning raw, dream, and nightmare splits.
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import torch
 from datasets import IterableDataset, load_dataset
@@ -42,7 +42,7 @@ class DatasetWrapper:
         max_samples: Optional[int] = None,
         seed: int = 42,
         streaming: bool = False,
-    ):
+    ) -> None:
         self.dataset_name = dataset_name
         self.subset = subset
         self.text_column = text_column
@@ -156,7 +156,7 @@ class DatasetWrapper:
         )
         return self
 
-    def _load_streaming(self, raw) -> DatasetWrapper:
+    def _load_streaming(self, raw: Any) -> DatasetWrapper:
         """Load dataset in streaming mode, returning IterableDatasets."""
         if "train" in raw:
             self._train_dataset = raw["train"]
@@ -199,14 +199,14 @@ class DatasetWrapper:
         return self
 
     @property
-    def train_data(self):
+    def train_data(self) -> Any:
         """Return the training dataset (Dataset or IterableDataset)."""
         if self._train_dataset is None:
             raise RuntimeError("Dataset not loaded. Call .load() first.")
         return self._train_dataset
 
     @property
-    def test_data(self):
+    def test_data(self) -> Any:
         """Return the test dataset (Dataset or IterableDataset)."""
         if self._test_dataset is None:
             raise RuntimeError("Dataset not loaded. Call .load() first.")
@@ -230,10 +230,10 @@ class DatasetWrapper:
                 "get_texts() is not supported for streaming datasets. "
                 "Iterate over the dataset directly instead."
             )
-        return dataset[self.text_column]
+        return cast(list[str], dataset[self.text_column])
 
 
-def load_from_config(config: dict) -> Any:
+def load_from_config(config: dict[str, Any]) -> Any:
     """Create and load a DatasetWrapper or VisionDatasetWrapper from a config dictionary.
 
     Args:
@@ -322,17 +322,17 @@ def load_from_config(config: dict) -> Any:
     ).load()
 
 
-class VisionItemWrapper(torch.utils.data.Dataset):
-    def __init__(self, dataset):
-        self.dataset = dataset
+class VisionItemWrapper(torch.utils.data.Dataset):  # type: ignore[misc]
+    def __init__(self, dataset: Any) -> None:
+        self.dataset: Any = dataset
         from torchvision.transforms.functional import to_tensor
 
         self._to_tensor = to_tensor
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.dataset)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: Any) -> dict[str, Any]:
         img, label = self.dataset[idx]
         if not isinstance(img, torch.Tensor):
             img = self._to_tensor(img)
@@ -340,14 +340,14 @@ class VisionItemWrapper(torch.utils.data.Dataset):
 
 
 class VisionDatasetWrapper:
-    def __init__(self, train_data, test_data):
+    def __init__(self, train_data: Any, test_data: Any) -> None:
         self._train_data = VisionItemWrapper(train_data)
         self._test_data = VisionItemWrapper(test_data)
 
     @property
-    def train_data(self):
+    def train_data(self) -> VisionItemWrapper:
         return self._train_data
 
     @property
-    def test_data(self):
+    def test_data(self) -> VisionItemWrapper:
         return self._test_data

--- a/nightmarenet/optimization/hpo.py
+++ b/nightmarenet/optimization/hpo.py
@@ -24,7 +24,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def _set_nested(config: dict, dotted_key: str, value: Any) -> None:
+def _set_nested(config: dict[str, Any], dotted_key: str, value: Any) -> None:
     """Set a value in a nested dictionary using dotted key notation."""
     keys = dotted_key.split(".")
     current = config
@@ -38,14 +38,14 @@ def _set_nested(config: dict, dotted_key: str, value: Any) -> None:
 class HyperparameterOptimizer:
     """Manages Optuna hyperparameter optimization for the NightmareNet pipeline."""
 
-    def __init__(self, config_path: str):
+    def __init__(self, config_path: str) -> None:
         if not OPTUNA_AVAILABLE:
             raise ImportError(
                 "Optuna is required for HPO. Install it with: pip install 'nightmarenet[hpo]'"
             )
         self.config_path = config_path
-        self.base_config = load_config(config_path)
-        self.hpo_config = self.base_config.get("hpo", {})
+        self.base_config: dict[str, Any] = load_config(config_path)
+        self.hpo_config: dict[str, Any] = self.base_config.get("hpo", {})
 
         self.study_name = self.hpo_config.get("study_name", "nightmarenet-optimization")
         # Default to a local SQLite database if storage is not configured.
@@ -67,9 +67,9 @@ class HyperparameterOptimizer:
             load_if_exists=True,
         )
 
-    def _suggest_parameters(self, trial: optuna.Trial) -> dict:
+    def _suggest_parameters(self, trial: optuna.Trial) -> dict[str, Any]:
         """Parse search space from config and suggest parameters."""
-        trial_params = {}
+        trial_params: dict[str, Any] = {}
         for param_key, param_def in self.search_space.items():
             param_type = param_def.get("type")
             if param_type == "float":
@@ -104,7 +104,7 @@ class HyperparameterOptimizer:
         pruned_flag = [False]
         pipeline = None
 
-        def on_event(metrics: dict) -> None:
+        def on_event(metrics: dict[str, Any]) -> None:
             if not self.pruning_enabled:
                 return
 

--- a/nightmarenet/phases/prepare.py
+++ b/nightmarenet/phases/prepare.py
@@ -115,8 +115,8 @@ class PreparePhase(Phase):
                     )
                     nightmare_gen.set_cycle(0)
 
-                dream_data = dream_gen.generate(dream_base)  # type: ignore[no-untyped-call]
-                nightmare_data = nightmare_gen.generate(nightmare_base)  # type: ignore[no-untyped-call]
+                dream_data = dream_gen.generate(dream_base)
+                nightmare_data = nightmare_gen.generate(nightmare_base)
 
                 if not uses_gradient_learned:
                     context.callback_manager = CallbackManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,8 @@ module = [
     "nightmarenet.compliance.*",
     "nightmarenet.hub.*",
     "nightmarenet.evaluation.certification",
+    "nightmarenet.optimization.*",
+    "nightmarenet.data.*",
 ]
 disallow_any_generics = true
 disallow_subclassing_any = true


### PR DESCRIPTION
### Description
This PR resolves #445 by extending strict type checking overrides in `mypy` configuration to cover the `nightmarenet.optimization.*` and `nightmarenet.data.*` packages, fixing all resulting typing issues, and clean up suppressions in `prepare.py`.

### Changes Made
- **Configuration**: Added strict overrides for `nightmarenet.optimization.*` and `nightmarenet.data.*` to `pyproject.toml`.
- **Optimization Module**: Annotated `hpo.py` config fields, constructors, return type helpers, and nested callbacks.
- **Data Module**:
  - Typed `generator.py` (generators, wrappers, and dataset types) and updated properties to return explicit types.
  - Typed `loader.py` wrappers (`VisionItemWrapper`, `VisionDatasetWrapper`) and cast lists for strict return types.
  - Removed unused `# type: ignore` overrides in `adaption.py`.
- **Phases Module**: Removed `# type: ignore[no-untyped-call]` comments in `prepare.py` since the generators are now fully typed.

### Verification Results
- Ran `mypy nightmarenet/` successfully with 0 errors.
- Ran `ruff check .` with 0 warnings/errors.
- Ran `pytest` with all 891 tests successfully passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset distortion compatibility when optional generator capabilities or target models are unavailable.
  * Ensured distortion strength checks consistently produce reliable boolean results.

* **Refactor**
  * Improved type coverage across dataset loading, generation, vision wrappers, and hyperparameter optimization.
  * Strengthened configuration and dataset handling without changing expected workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->