### PR TITLE
[Bug]: Fix dead code after return in robustness_score() — failure ranking now executes

### DIFF
--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -631,8 +631,6 @@ def robustness_score(
         }
         if export_failures:
             res["per_sample_data"] = failures_data
-        return res
-
         ranked_failures = rank_failures(all_failures)
         res["top_failures"] = ranked_failures[:10]
         res["delta_distribution"] = build_delta_distribution(ranked_failures)
@@ -785,8 +783,6 @@ def robustness_score(
     }
     if export_failures:
         res["per_sample_data"] = failures_data
-    return res
-
     ranked_failures = rank_failures(all_failures)
     res["top_failures"] = ranked_failures[:10]
     res["delta_distribution"] = build_delta_distribution(ranked_failures)


### PR DESCRIPTION
## Description

Fixes unreachable failure-ranking code in `robustness_score()` that prevented `top_failures`, `delta_distribution`, and `confidence_deltas` from ever being populated in evaluation responses.

### Problem

Two blocks of dead code existed after `return res` in both the vision and text branches of `metrics.py`:

- **Lines 634–640 (vision branch)**: `rank_failures()` and `build_delta_distribution()` called after `return res` — never executed.
- **Lines 788–794 (text branch)**: Same pattern — dead code after `return res`.

This meant the confidence delta analysis feature in evaluation reports silently produced empty fields.

### Fix

Moved the `rank_failures()` and `build_delta_distribution()` calls to execute **before** the `return res` statement in both branches. The ranking logic now runs as intended on the `all_failures` data that was already being collected.

### Changes

| File | Change |
|------|--------|
| `nightmarenet/evaluation/metrics.py` (vision branch, L634–640) | Move ranking before `return res` |
| `nightmarenet/evaluation/metrics.py` (text branch, L788–794) | Same fix for text code path |

### Verification

- [x] `top_failures` is now populated in robustness responses
- [x] `delta_distribution` is now populated with severity buckets
- [x] `confidence_deltas` list is now included in responses
- [x] Ruff lint passes on changed files
- [x] Existing test suite unaffected (no API contract change)

Closes #481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Robustness evaluations now include failure rankings and detailed metrics.
  * Added top failures, delta distributions, and confidence changes to evaluation results across supported evaluation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->