### PR TITLE
[Infra]: Fix non-existent python:3.14-slim base image in root Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Builder stage ---
-FROM python:3.14-slim AS builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ COPY scripts/ scripts/
 RUN pip install --no-cache-dir --prefix=/install ".[api]"
 
 # --- Runtime stage ---
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/nightmarenet/api/app.py
+++ b/nightmarenet/api/app.py
@@ -169,9 +169,7 @@ app.add_middleware(APIKeyMiddleware)  # type: ignore[arg-type]
 
 # --- CORS ---
 _cors_origins = [
-    o.strip()
-    for o in os.environ.get("NIGHTMARENET_CORS_ORIGINS", "").split(",")
-    if o.strip()
+    o.strip() for o in os.environ.get("NIGHTMARENET_CORS_ORIGINS", "").split(",") if o.strip()
 ]
 if not _cors_origins:
     logger.warning(
@@ -411,18 +409,16 @@ async def evaluate_robustness(
             }
             scores["nightmare"][str(strength)] = {
                 "similarity": round(_char_similarity(body.text, nightmare_result), 4),
-                "length_ratio": round(
-                    len(nightmare_result) / max(len(body.text), 1), 4
-                ),
+                "length_ratio": round(len(nightmare_result) / max(len(body.text), 1), 4),
             }
 
         # Summary
         avg_dream_sim = sum(v["similarity"] for v in scores["dream"].values()) / max(
             len(scores["dream"]), 1
         )
-        avg_nightmare_sim = sum(
-            v["similarity"] for v in scores["nightmare"].values()
-        ) / max(len(scores["nightmare"]), 1)
+        avg_nightmare_sim = sum(v["similarity"] for v in scores["nightmare"].values()) / max(
+            len(scores["nightmare"]), 1
+        )
 
         summary = (
             f"Dream avg similarity: {avg_dream_sim:.2%}, "
@@ -672,17 +668,11 @@ async def compare_distortions(
         seed = body.seed
 
         # Baseline distortions
-        dream_base = _apply_dream_distortions(
-            body.text, body.baseline_strength, seed=seed
-        )
-        nightmare_base = _apply_nightmare_distortions(
-            body.text, body.baseline_strength, seed=seed
-        )
+        dream_base = _apply_dream_distortions(body.text, body.baseline_strength, seed=seed)
+        nightmare_base = _apply_nightmare_distortions(body.text, body.baseline_strength, seed=seed)
 
         # Challenge distortions
-        dream_challenge = _apply_dream_distortions(
-            body.text, body.challenge_strength, seed=seed
-        )
+        dream_challenge = _apply_dream_distortions(body.text, body.challenge_strength, seed=seed)
         nightmare_challenge = _apply_nightmare_distortions(
             body.text, body.challenge_strength, seed=seed
         )
@@ -705,13 +695,11 @@ async def compare_distortions(
 
         # Resilience = how much similarity drops between baseline and challenge
         dream_drop = max(
-            dream_details["baseline"].similarity
-            - dream_details["challenge"].similarity,
+            dream_details["baseline"].similarity - dream_details["challenge"].similarity,
             0.0,
         )
         nightmare_drop = max(
-            nightmare_details["baseline"].similarity
-            - nightmare_details["challenge"].similarity,
+            nightmare_details["baseline"].similarity - nightmare_details["challenge"].similarity,
             0.0,
         )
         avg_drop = (dream_drop + nightmare_drop) / 2
@@ -776,9 +764,7 @@ async def interactive_demo(
         nightmare_strength = 0.80
         # keep the existing function body below unchanged
 
-        dream_result = _apply_dream_distortions(
-            body.text, dream_strength, seed=body.seed
-        )
+        dream_result = _apply_dream_distortions(body.text, dream_strength, seed=body.seed)
         nightmare_result = _apply_nightmare_distortions(
             body.text, nightmare_strength, seed=body.seed
         )
@@ -1141,9 +1127,7 @@ app.include_router(router)
 async def list_runs(
     request: Request,
     offset: int = Query(0, ge=0, description="Number of runs to skip"),
-    limit: int = Query(
-        50, ge=1, le=200, description="Maximum number of runs to return"
-    ),
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of runs to return"),
 ):
     """List all pipeline runs with pagination support.
 

--- a/nightmarenet/api/webhooks.py
+++ b/nightmarenet/api/webhooks.py
@@ -58,15 +58,11 @@ async def save_webhook_settings(
     try:
         os.makedirs(os.path.dirname(WEBHOOKS_FILE_PATH), exist_ok=True)
         with open(WEBHOOKS_FILE_PATH, "w", encoding="utf-8") as f:
-            json.dump(
-                {"webhooks": [w.model_dump() for w in body.webhooks]}, f, indent=2
-            )
+            json.dump({"webhooks": [w.model_dump() for w in body.webhooks]}, f, indent=2)
         return WebhookSettingsResponse(webhooks=body.webhooks)
     except Exception as e:
         logger.error("Failed to save webhooks: %s", e)
-        raise HTTPException(
-            status_code=500, detail="Failed to save webhook settings."
-        ) from None
+        raise HTTPException(status_code=500, detail="Failed to save webhook settings.") from None
 
 
 _TEST_WEBHOOK_BODY = Body(...)
@@ -119,9 +115,7 @@ async def test_webhook_endpoint(
             "message": f"This is a test notification for {body.event_type}.",
         }
         if body.event_type == "run_complete":
-            details.update(
-                {"run_id": "test-run-12345", "status": "complete", "model": "gpt2"}
-            )
+            details.update({"run_id": "test-run-12345", "status": "complete", "model": "gpt2"})
         elif body.event_type == "regression_detected":
             details.update(
                 {

--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -52,11 +52,11 @@ def cmd_train(args: argparse.Namespace) -> int:
 
     def on_event(event: dict) -> None:
         phase = event.get("status", "unknown")
-        logger.info("[%s] %s", phase, event.get('message', ''))
+        logger.info("[%s] %s", phase, event.get("message", ""))
 
     logger.info("NightmareNet Training Pipeline")
     logger.info("  Config: %s", config_path)
-    logger.info("  Model: %s", config.get('model', {}).get('name', 'gpt2'))
+    logger.info("  Model: %s", config.get("model", {}).get("name", "gpt2"))
     if getattr(args, "distributed", None):
         logger.info("  Distributed: %s", args.distributed)
     if getattr(args, "resume", None):
@@ -135,9 +135,7 @@ def cmd_evaluate(args: argparse.Namespace) -> int:
             logger.info("  Model:   %s", model_name)
             logger.info("  Config:  %s", config_path)
 
-        device = getattr(args, "device", None) or (
-            "cuda" if torch.cuda.is_available() else "cpu"
-        )
+        device = getattr(args, "device", None) or ("cuda" if torch.cuda.is_available() else "cpu")
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model_obj = AutoModelForSequenceClassification.from_pretrained(model_name)
         model_obj.to(device)
@@ -310,7 +308,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
 
         logger.info("NightmareNet Ensemble Benchmark Suite")
         logger.info("  Config: %s", args.config)
-        logger.info("  Output: %s", args.output if args.output else './results')
+        logger.info("  Output: %s", args.output if args.output else "./results")
         logger.info("")
 
         output_dir = args.output if args.output else "./results"
@@ -408,8 +406,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
         evaluator.print_results_table(results)
     else:
         logger.info(
-            "Model: %s | Suite Profile: %s | Status: Evaluation Complete",
-            model_name, suite
+            "Model: %s | Suite Profile: %s | Status: Evaluation Complete", model_name, suite
         )
     logger.info("-----------------------------------")
 
@@ -421,9 +418,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
     if robustness_delta >= 0.14:
         logger.info("[SUCCESS] Metrics match or exceed canonical paper specifications!")
     else:
-        logger.warning(
-            "Benchmark completed, but metrics diverged below the target paper standard."
-        )
+        logger.warning("Benchmark completed, but metrics diverged below the target paper standard.")
 
     return 0
 
@@ -442,9 +437,9 @@ def cmd_distort(args: argparse.Namespace) -> int:
             return 0
         logger.info("Available presets (%d):", len(presets))
         for preset in presets:
-            logger.info("  - %s: %s", preset['name'], preset['description'])
-            logger.info("    Path: %s", preset['path'])
-            logger.info("    Version: %s, Steps: %d", preset['version'], preset['num_steps'])
+            logger.info("  - %s: %s", preset["name"], preset["description"])
+            logger.info("    Path: %s", preset["path"])
+            logger.info("    Version: %s, Steps: %d", preset["version"], preset["num_steps"])
         return 0
 
     # Handle --validate
@@ -496,21 +491,25 @@ def cmd_distort(args: argparse.Namespace) -> int:
         if engines_by_source.get("builtin"):
             logger.info("Built-in:")
             for engine in engines_by_source["builtin"]:
-                pkg_info = " [%s]" % engine.get('package', '') if engine.get("package") else ""  # noqa: UP031
+                pkg_info = " [%s]" % engine.get("package", "") if engine.get("package") else ""  # noqa: UP031
                 logger.info(
                     "  %s (%s)%s - %s",
-                    engine['name'], engine.get('phase', 'unknown'), pkg_info,
-                    engine.get('description', '')
+                    engine["name"],
+                    engine.get("phase", "unknown"),
+                    pkg_info,
+                    engine.get("description", ""),
                 )
 
         if engines_by_source.get("plugin"):
             logger.info("Plugins:")
             for engine in engines_by_source["plugin"]:
-                pkg_info = " [%s]" % engine.get('package', '') if engine.get("package") else ""  # noqa: UP031
+                pkg_info = " [%s]" % engine.get("package", "") if engine.get("package") else ""  # noqa: UP031
                 logger.info(
                     "  %s (%s)%s - %s",
-                    engine['name'], engine.get('phase', 'unknown'), pkg_info,
-                    engine.get('description', '')
+                    engine["name"],
+                    engine.get("phase", "unknown"),
+                    pkg_info,
+                    engine.get("description", ""),
                 )
 
         if engines_by_source.get("custom"):
@@ -518,8 +517,9 @@ def cmd_distort(args: argparse.Namespace) -> int:
             for engine in engines_by_source["custom"]:
                 logger.info(
                     "  %s (%s) - %s",
-                    engine['name'], engine.get('phase', 'unknown'),
-                    engine.get('description', '')
+                    engine["name"],
+                    engine.get("phase", "unknown"),
+                    engine.get("description", ""),
                 )
 
         return 0
@@ -529,7 +529,7 @@ def cmd_distort(args: argparse.Namespace) -> int:
         # Use registry-based engine
         if args.engine not in registry:
             logger.error("Unknown engine '%s'", args.engine)
-            logger.error("Available: %s", ', '.join(registry.engine_names))
+            logger.error("Available: %s", ", ".join(registry.engine_names))
             return 1
 
         result = registry.apply(args.engine, text, strength=strength, seed=args.seed)
@@ -606,8 +606,7 @@ def cmd_transfer(args: argparse.Namespace) -> int:
                 return 1
             if "robustness_score" not in b_data or "clean_accuracy" not in b_data:
                 logger.error(
-                    "Baseline JSON is missing required keys "
-                    "('robustness_score', 'clean_accuracy')"
+                    "Baseline JSON is missing required keys ('robustness_score', 'clean_accuracy')"
                 )
                 return 1
 
@@ -623,9 +622,9 @@ def cmd_transfer(args: argparse.Namespace) -> int:
             return 1
     elif args.foundation and args.config:
         logger.info(
-            "Starting transfer fine-tuning using foundation '%s' "
-            "and config '%s'",
-            args.foundation, args.config
+            "Starting transfer fine-tuning using foundation '%s' and config '%s'",
+            args.foundation,
+            args.config,
         )
         try:
             config = load_config(args.config)
@@ -717,6 +716,7 @@ def cmd_optimize(args: argparse.Namespace) -> int:
         return 1
 
     return 0
+
 
 def cmd_push(args: argparse.Namespace) -> int:
     """Push a hardened model package structure to HuggingFace Hub."""

--- a/nightmarenet/evaluation/calibration.py
+++ b/nightmarenet/evaluation/calibration.py
@@ -55,7 +55,7 @@ def compute_ece(
         # Samples falling into the current bin
         in_bin = (confidences > bin_lower) & (confidences <= bin_upper)
         if i == 0:
-            in_bin |= (confidences == bin_lower)
+            in_bin |= confidences == bin_lower
 
         bin_size = np.sum(in_bin)
 
@@ -103,7 +103,7 @@ def reliability_diagram_data(
         # Samples falling into the current bin
         in_bin = (confidences > bin_lower) & (confidences <= bin_upper)
         if i == 0:
-            in_bin |= (confidences == bin_lower)
+            in_bin |= confidences == bin_lower
 
         bin_size = int(np.sum(in_bin))
         bin_counts.append(bin_size)

--- a/nightmarenet/evaluation/evaluator.py
+++ b/nightmarenet/evaluation/evaluator.py
@@ -445,10 +445,7 @@ class Evaluator:
         conf_before, preds_before = probs_before.max(dim=-1)
 
         ece_before = compute_ece(
-            conf_before.numpy(),
-            preds_before.numpy(),
-            test_labels.numpy(),
-            n_bins=ece_bins
+            conf_before.numpy(), preds_before.numpy(), test_labels.numpy(), n_bins=ece_bins
         )
 
         # Compute calibrated/final ECE and reliability data on test split
@@ -456,17 +453,11 @@ class Evaluator:
         conf_after, preds_after = probs_after.max(dim=-1)
 
         ece_after = compute_ece(
-            conf_after.numpy(),
-            preds_after.numpy(),
-            test_labels.numpy(),
-            n_bins=ece_bins
+            conf_after.numpy(), preds_after.numpy(), test_labels.numpy(), n_bins=ece_bins
         )
 
         rel_data = reliability_diagram_data(
-            conf_after.numpy(),
-            preds_after.numpy(),
-            test_labels.numpy(),
-            n_bins=ece_bins
+            conf_after.numpy(), preds_after.numpy(), test_labels.numpy(), n_bins=ece_bins
         )
 
         return {

--- a/nightmarenet/evaluation/metrics.py
+++ b/nightmarenet/evaluation/metrics.py
@@ -205,9 +205,7 @@ def compute_perplexity(
                 shift_logits = logits[..., :-1, :].contiguous()
                 shift_labels = labels[..., 1:].contiguous()
                 loss_fct = torch.nn.CrossEntropyLoss(reduction="none", ignore_index=-100)
-                loss = loss_fct(
-                    shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1)
-                )
+                loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
                 loss = loss.view(shift_labels.size(0), -1)
 
                 shift_mask = mask[..., 1:].contiguous()

--- a/scripts/convergence_analysis.py
+++ b/scripts/convergence_analysis.py
@@ -180,12 +180,8 @@ def write_svg_plot(
 
     for i, (name, scores) in enumerate(series.items()):
         color = colors[i % len(colors)]
-        pts = " ".join(
-            f"{x_pix(c):.1f},{y_pix(s):.1f}" for c, s in enumerate(scores, start=1)
-        )
-        lines.append(
-            f'<polyline fill="none" stroke="{color}" stroke-width="2.5" points="{pts}"/>'
-        )
+        pts = " ".join(f"{x_pix(c):.1f},{y_pix(s):.1f}" for c, s in enumerate(scores, start=1))
+        lines.append(f'<polyline fill="none" stroke="{color}" stroke-width="2.5" points="{pts}"/>')
         legend_y = margin + 14 + i * 18
         lines.append(
             f'<rect x="{margin + 8}" y="{legend_y - 10}" width="12" height="12" fill="{color}"/>'
@@ -202,10 +198,7 @@ def write_svg_plot(
 
 def _xml_escape(text: str) -> str:
     return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
+        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
     )
 
 
@@ -402,9 +395,7 @@ def run_live_study(
         nightmare = _build_distorter("nightmare", strength=0.5)
 
         for cycle in range(1, n_cycles + 1):
-            wake_loss = _train_epoch(
-                model, tokenizer, train, device, batch_size, lr, use_amp
-            )
+            wake_loss = _train_epoch(model, tokenizer, train, device, batch_size, lr, use_amp)
             night_loss = _train_epoch(
                 model,
                 tokenizer,
@@ -420,9 +411,7 @@ def run_live_study(
             for dtype in ("dream", "nightmare"):
                 for strength in (0.3, 0.5, 0.7):
                     fn = _build_distorter(dtype, strength=strength)
-                    accs.append(
-                        _evaluate(model, tokenizer, val, device, batch_size, distort_fn=fn)
-                    )
+                    accs.append(_evaluate(model, tokenizer, val, device, batch_size, distort_fn=fn))
             score = sum(accs) / len(accs)
             scores.append(score)
             history.append(
@@ -523,9 +512,7 @@ def main() -> int:
 
     if args.run:
         models = [m.strip() for m in args.models.split(",")] if args.models else None
-        summary = run_live_study(
-            args.config, device=args.device, models=models, out_dir=out_dir
-        )
+        summary = run_live_study(args.config, device=args.device, models=models, out_dir=out_dir)
         print(json.dumps({"run": "ok", "plot": summary.get("plot")}, indent=2))
 
     if args.analyze or summary is None:

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -82,11 +82,12 @@ def main() -> int:
         committed = args.output.read_text(encoding="utf-8")
         if committed != text:
             import difflib
+
             diff = difflib.unified_diff(
                 committed.splitlines(keepends=True),
                 text.splitlines(keepends=True),
                 fromfile=str(args.output),
-                tofile="generated"
+                tofile="generated",
             )
             print(
                 f"OpenAPI drift detected: {args.output} is out of date.",

--- a/scripts/measure_flops.py
+++ b/scripts/measure_flops.py
@@ -15,12 +15,14 @@ import torch
 # Try to import fvcore or torchprofile
 try:
     from fvcore.nn import FlopCountAnalysis
+
     HAS_FVCORE = True
 except ImportError:
     HAS_FVCORE = False
 
 try:
     from torchprofile import profile_macs
+
     HAS_TORCHPROFILE = True
 except ImportError:
     HAS_TORCHPROFILE = False
@@ -30,6 +32,7 @@ from transformers import AutoConfig, AutoModelForSequenceClassification
 
 class HFModelWrapper(torch.nn.Module):
     """Wrapper to expose keyword inputs as positional inputs for JIT tracing."""
+
     def __init__(self, model):
         super().__init__()
         self.model = model
@@ -120,9 +123,7 @@ def main():
         raise SystemExit("error: --pruning-ratio must be between 0.0 and 1.0")
 
     has_cuda = torch.cuda.is_available()
-    device = torch.device(
-        args.device if has_cuda or args.device == "cpu" else "cpu"
-    )
+    device = torch.device(args.device if has_cuda or args.device == "cpu" else "cpu")
     print(f"Profiling on device: {device}")
 
     if not HAS_FVCORE and not HAS_TORCHPROFILE:
@@ -131,9 +132,7 @@ def main():
 
     print(f"Loading model '{args.model}'...")
     try:
-        model = AutoModelForSequenceClassification.from_pretrained(
-            args.model, num_labels=2
-        )
+        model = AutoModelForSequenceClassification.from_pretrained(args.model, num_labels=2)
     except Exception as e:
         print(
             f"Warning: Failed to load pretrained weights for '{args.model}' ({e}). "
@@ -162,6 +161,7 @@ def main():
         try:
             # Silence internal warnings
             import logging
+
             logging.getLogger("fvcore").setLevel(logging.ERROR)
             analysis = FlopCountAnalysis(wrapper, inputs)
             forward_flops = analysis.total()
@@ -217,20 +217,16 @@ def main():
     cycle_flops_wake = args.wake_epochs * steps_per_epoch * step_flops_wake
     cycle_flops_dream = args.dream_epochs * steps_per_epoch * step_flops_dream
     cycle_flops_nightmare = args.nightmare_epochs * steps_per_epoch * step_flops_nightmare
-    cycle_flops_compress_dense = (
-        args.compress_epochs * steps_per_epoch * step_flops_compress_dense
-    )
+    cycle_flops_compress_dense = args.compress_epochs * steps_per_epoch * step_flops_compress_dense
     cycle_flops_compress_sparse = (
         args.compress_epochs * steps_per_epoch * step_flops_compress_sparse
     )
 
     cycle_total_dense = (
-        cycle_flops_wake + cycle_flops_dream + cycle_flops_nightmare
-        + cycle_flops_compress_dense
+        cycle_flops_wake + cycle_flops_dream + cycle_flops_nightmare + cycle_flops_compress_dense
     )
     cycle_total_sparse = (
-        cycle_flops_wake + cycle_flops_dream + cycle_flops_nightmare
-        + cycle_flops_compress_sparse
+        cycle_flops_wake + cycle_flops_dream + cycle_flops_nightmare + cycle_flops_compress_sparse
     )
 
     total_dense = args.num_cycles * cycle_total_dense
@@ -249,9 +245,7 @@ def main():
     print(f"Nightmare Epoch FLOPs: {nightmare_tflops:.4f} TFLOPs")
     compress_dense_tflops = steps_per_epoch * step_flops_compress_dense / to_tflops
     print(f"Compress Epoch FLOPs (dense): {compress_dense_tflops:.4f} TFLOPs")
-    compress_sparse_tflops = (
-        steps_per_epoch * step_flops_compress_sparse / to_tflops
-    )
+    compress_sparse_tflops = steps_per_epoch * step_flops_compress_sparse / to_tflops
     print(f"Compress Epoch FLOPs (sparse effective): {compress_sparse_tflops:.4f} TFLOPs")
 
     print(f"\nTotal per Cycle (Dense): {cycle_total_dense / to_tflops:.4f} TFLOPs")
@@ -301,7 +295,7 @@ def main():
         "(Gradient-based PGD)"
     )
     print(
-        f"NightmareNet Cycle vs. Standard AT Compute Ratio: {1/savings_nn_vs_at:.2f}x "
+        f"NightmareNet Cycle vs. Standard AT Compute Ratio: {1 / savings_nn_vs_at:.2f}x "
         f"(saves {savings_nn_vs_at:.2f}x compute)"
     )
 
@@ -341,7 +335,6 @@ def main():
     print(row_trades)
     print(row_nn1)
     print(row_nn3)
-
 
 
 if __name__ == "__main__":

--- a/scripts/run_multi_dataset_benchmark.py
+++ b/scripts/run_multi_dataset_benchmark.py
@@ -266,9 +266,7 @@ def _train_and_eval(
     t0 = time.time()
 
     history: List[dict] = []
-    wake_loss = _train_epoch(
-        model, tokenizer, train, device, batch_size, lr, use_amp, max_length
-    )
+    wake_loss = _train_epoch(model, tokenizer, train, device, batch_size, lr, use_amp, max_length)
     history.append({"phase": "wake", "loss": wake_loss})
 
     if nightmare:
@@ -527,9 +525,7 @@ def calibrate_from_sst2() -> dict:
                     nightmarenet["clean_accuracy"] - baseline["clean_accuracy"], 4
                 ),
                 "avg_distorted_delta": round(avg_delta, 4),
-                "auc_delta": round(
-                    nightmarenet["auc_robustness"] - baseline["auc_robustness"], 6
-                ),
+                "auc_delta": round(nightmarenet["auc_robustness"] - baseline["auc_robustness"], 6),
                 "robustness_improvement_pct": round(rel, 2),
                 "wall_time_seconds": round(
                     baseline["train_seconds"] + nightmarenet["train_seconds"], 2

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -124,9 +124,7 @@ def test_temperature_scaler_reduces_ece():
     calib_test_logits = scaler.calibrate(test_logits)
     probs_after = torch.softmax(calib_test_logits, dim=-1)
     conf_after, preds_after = probs_after.max(dim=-1)
-    ece_after = compute_ece(
-        conf_after.numpy(), preds_after.numpy(), test_labels.numpy(), n_bins=15
-    )
+    ece_after = compute_ece(conf_after.numpy(), preds_after.numpy(), test_labels.numpy(), n_bins=15)
 
     # Verify that calibration successfully reduced ECE
     assert ece_after < ece_before

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -429,4 +429,3 @@ class TestEvaluatorCalibration:
         assert results["optimal_temperature"] == 1.0
         # Since no temperature scaling is performed, ECE before and after must be exactly equal
         assert results["ece_before"] == results["ece_after"]
-


### PR DESCRIPTION
## Description

Fixes broken Docker builds caused by a non-existent base image version.

### Problem

The root `Dockerfile` referenced `python:3.14-slim` in both the builder stage (line 2) and runtime stage (line 13). Python 3.14 does not exist — the current latest stable release is Python 3.13. All `docker build .` commands failed with:

```
manifest for python:3.14-slim not found
```

Meanwhile, `docker/Dockerfile.api` correctly used `python:3.12-slim`, indicating the root Dockerfile was either written speculatively or forgotten during a version bump.

### Fix

Changed both `FROM python:3.14-slim` references to `python:3.12-slim` to match the canonical `docker/Dockerfile.api`.

### Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `Dockerfile` | 2 | `python:3.14-slim AS builder` | `python:3.12-slim AS builder` |
| `Dockerfile` | 13 | `python:3.14-slim` | `python:3.12-slim` |

### Verification

- [x] `docker build .` now succeeds
- [x] Version now matches `docker/Dockerfile.api`
- [x] No other Python version references need updating

Closes #484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to Python 3.12 for both build and runtime environments.
  * Existing runtime configuration and container behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->