### PR TITLE
fix: wire bottleneck method into compression phase

### DIFF
--- a/nightmarenet/training/phases.py
+++ b/nightmarenet/training/phases.py
@@ -597,6 +597,20 @@ class CompressionPhase:
                 logger.error("Compression Phase - Failed to apply pruning: %s", exc)
                 stats = {"pruned_params": 0, "total_params": 0}
                 pruning_succeeded = False
+        elif method == "bottleneck":
+            rank_ratio = self.config.get("bottleneck_rank_ratio", 0.5)
+            try:
+                from nightmarenet.compression.pruning import apply_bottleneck_to_model
+
+                stats = apply_bottleneck_to_model(
+                    self.model,
+                    rank_ratio=rank_ratio,
+                )
+                pruning_succeeded = True
+            except Exception as exc:
+                logger.error("Compression Phase - Failed to apply bottleneck: %s", exc)
+                stats = {"wrapped_count": 0, "rank_ratio": rank_ratio}
+                pruning_succeeded = False
         else:
             logger.warning("Unknown pruning method '%s'; skipping.", method)
             stats = {"pruned_params": 0, "total_params": 0}

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -4,6 +4,8 @@ Covers MagnitudePruner, BottleneckWrapper, and apply_bottleneck_to_model.
 Uses a tiny hand-built model fixture — no downloads, no GPU needed.
 """
 
+from unittest.mock import patch
+
 import pytest
 import torch
 import torch.nn as nn
@@ -168,3 +170,57 @@ class TestBottleneckWrapper:
         out = tiny_block(x)
         assert out.shape == (4, 16)
         assert torch.isfinite(out).all()
+
+# ---------------------------------------------------------------------------
+# CompressionPhase integration
+# ---------------------------------------------------------------------------
+
+
+class TestCompressionPhaseBottleneck:
+    def test_bottleneck_method_is_applied_and_preserves_forward_pass(self, tiny_block):
+        from nightmarenet.training.phases import CompressionPhase
+
+        phase = CompressionPhase(
+            model=tiny_block,
+            config={
+                "pruning_method": "bottleneck",
+                "bottleneck_rank_ratio": 0.25,
+                "finetune_after_prune": False,
+            },
+        )
+
+        stats = phase.run()
+
+        assert stats["method"] == "bottleneck"
+        assert stats["wrapped_count"] == 1
+        assert stats["rank_ratio"] == 0.25
+        assert isinstance(tiny_block.mlp, BottleneckWrapper)
+
+        output = tiny_block(torch.randn(4, 16))
+        assert output.shape == (4, 16)
+        assert torch.isfinite(output).all()
+
+    def test_bottleneck_success_allows_distillation(self, tiny_block):
+        from nightmarenet.training.phases import CompressionPhase
+
+        optimizer = torch.optim.SGD(tiny_block.parameters(), lr=0.01)
+        phase = CompressionPhase(
+            model=tiny_block,
+            config={
+                "pruning_method": "bottleneck",
+                "bottleneck_rank_ratio": 0.5,
+                "distillation": True,
+                "finetune_after_prune": False,
+            },
+        )
+
+        with patch(
+            "nightmarenet.compression.distillation.run_distillation",
+            return_value={"distillation_loss": 0.1},
+        ) as mock_distill:
+            stats = phase.run(dataloader=[{}], optimizer=optimizer)
+
+        mock_distill.assert_called_once()
+        assert stats["wrapped_count"] == 1
+        assert stats["distillation_loss"] == 0.1
+


### PR DESCRIPTION
## Summary

Wires the existing bottleneck compression implementation into
`CompressionPhase.run()` so `compression.pruning_method: "bottleneck"` is no
longer dead configuration.

## Motivation

`configs/default.yaml` exposes the bottleneck method and rank ratio, and
`apply_bottleneck_to_model()` is already implemented and tested. However,
`CompressionPhase` previously handled only magnitude pruning, causing
bottleneck users to receive an unknown-method warning and no compression.

Closes #216

## Changes

- Added a `bottleneck` branch to `CompressionPhase.run()`.
- Read `bottleneck_rank_ratio` from compression config with the documented
  default of `0.5`.
- Passed the configured ratio to `apply_bottleneck_to_model()`.
- Marked a successful bottleneck application as compression success so existing
  RSLAD distillation continues to run.
- Preserved existing magnitude-pruning behaviour.
- Added focused regression tests covering:
  - configured bottleneck application;
  - returned `wrapped_count` and `rank_ratio`;
  - model forward-pass validity after wrapping;
  - RSLAD distillation execution after successful bottleneck compression.

## Acceptance Criteria

- [x] `pruning_method: "bottleneck"` triggers `apply_bottleneck_to_model()`
- [x] `bottleneck_rank_ratio` is passed through correctly
- [x] Stats include `wrapped_count` and `rank_ratio`
- [x] Model forward pass works after bottleneck wrapping
- [x] RSLAD distillation still triggers after successful bottleneck wrapping
- [x] Existing magnitude-pruning behaviour is unchanged
- [x] `CompressionPhase` bottleneck test produces a non-zero `wrapped_count`

## Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read `CONTRIBUTING.md` in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors
- [x] Focused compression tests pass
- [x] Full `pytest tests/` or non-slow suite passes
- [x] New functionality has corresponding tests
- [x] Commit uses Conventional Commits
- [x] No hosted-only dependency imports added

## Test Results

```text
tests/test_compression.py: 17 passed
```

Paste the local Ruff, mypy, distillation-test, and full-suite summaries here
before submitting the PR.

## Documentation

- [x] No documentation needed; the existing documented config option now works
- [ ] README.md updated
- [ ] Docstrings added/updated
- [ ] `docs/` updated
- [ ] Config comments updated
- [ ] CHANGELOG entry added

## Security Considerations

- [x] Not applicable
- [x] No secrets, keys, or credentials in code or comments

## Screenshots
<img width="1223" height="288" alt="Screenshot 2026-07-25 112757" src="https://github.com/user-attachments/assets/9467385f-9f9c-4466-b5ab-7a309a7dc5fa" />
<img width="1185" height="286" alt="Screenshot 2026-07-25 113103" src="https://github.com/user-attachments/assets/dac81d64-0715-4578-9387-c4029340108d" />
<img width="1212" height="296" alt="Screenshot 2026-07-25 113110" src="https://github.com/user-attachments/assets/c820f897-c34c-4895-bb61-bf0aaf9220f1" />
<img width="1215" height="611" alt="Screenshot 2026-07-25 113625" src="https://github.com/user-attachments/assets/60a4ada8-e8cf-442b-8697-6005baa390cd" />


## Breaking Changes

N/A

---

<details>
<summary>Reviewer notes</summary>

The bottleneck utility and configuration were already present; this PR only
connects them to the compression pipeline and adds regression coverage.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bottleneck-based model compression as an available compression method.
  * Supports configurable bottleneck rank ratios.
  * Preserves downstream distillation and fine-tuning workflows when compression succeeds.

* **Bug Fixes**
  * Compression failures are now handled gracefully with diagnostic statistics and error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->