### PR TITLE
infra: add safe PyPI release verification workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,24 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      verify_only:
+        description: "Build and verify distributions without publishing"
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    name: Build and verify distributions
     runs-on: ubuntu-latest
 
     steps:
@@ -18,13 +33,53 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install build tools
-        run: python -m pip install --upgrade pip build
+      - name: Install build and verification tools
+        run: python -m pip install --upgrade pip build twine
 
       - name: Build sdist and wheel
         run: python -m build
 
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Verify distribution set
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+          import zipfile
+
+          dist = Path("dist")
+          wheels = sorted(dist.glob("*.whl"))
+          sdists = sorted(dist.glob("*.tar.gz"))
+
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one wheel, found {len(wheels)}")
+          if len(sdists) != 1:
+              raise SystemExit(f"Expected exactly one sdist, found {len(sdists)}")
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              wheel_files = archive.namelist()
+              if not any(name.endswith(".dist-info/METADATA") for name in wheel_files):
+                  raise SystemExit("Wheel is missing .dist-info/METADATA")
+              if not any(name == "nightmarenet/__init__.py" for name in wheel_files):
+                  raise SystemExit("Wheel is missing the nightmarenet package")
+
+          with tarfile.open(sdists[0], "r:gz") as archive:
+              sdist_files = archive.getnames()
+              if not any(name.endswith("/pyproject.toml") for name in sdist_files):
+                  raise SystemExit("Source distribution is missing pyproject.toml")
+              if not any(name.endswith("/nightmarenet/__init__.py") for name in sdist_files):
+                  raise SystemExit("Source distribution is missing the nightmarenet package")
+
+          print(f"Verified wheel: {wheels[0].name}")
+          print(f"Verified sdist: {sdists[0].name}")
+          PY
+
       - name: Check version matches tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION=$(python -c "import nightmarenet; print(nightmarenet.__version__)")
@@ -33,20 +88,45 @@ jobs:
             exit 1
           fi
 
-      - name: Upload build artifacts
+      - name: Smoke-test built wheel
+        shell: bash
+        run: |
+          python -m venv .release-smoke
+          .release-smoke/bin/python -m pip install --upgrade pip
+          .release-smoke/bin/python -m pip install --no-deps dist/*.whl
+          .release-smoke/bin/python - <<'PY'
+          from importlib.metadata import version
+          import nightmarenet
+
+          installed_version = version("nightmarenet")
+          if installed_version != nightmarenet.__version__:
+              raise SystemExit(
+                  "Installed metadata version "
+                  f"{installed_version} does not match package version "
+                  f"{nightmarenet.__version__}"
+              )
+
+          print(f"Installed nightmarenet {installed_version} successfully")
+          PY
+
+      - name: Upload verified build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+          if-no-files-found: error
+          retention-days: 7
 
   github-release:
+    name: Publish GitHub Release assets
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - name: Download build artifacts
+      - name: Download verified build artifacts
         uses: actions/download-artifact@v8
         with:
           name: dist
@@ -59,16 +139,19 @@ jobs:
           fail_on_unmatched_files: true
 
   publish:
+    name: Publish verified distributions to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/nightmarenet
     permissions:
-      id-token: write # required for PyPI trusted publishing (OIDC)
+      contents: read
+      id-token: write
 
     steps:
-      - name: Download build artifacts
+      - name: Download verified build artifacts
         uses: actions/download-artifact@v8
         with:
           name: dist
@@ -76,3 +159,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,6 +54,28 @@ warning. release-please can still open or update the Release PR, but a tag creat
 with that fallback token will not trigger the downstream release workflow. In that
 case, a maintainer must push the release tag manually after reviewing the Release PR.
 
+
+## Verify the release workflow without publishing
+
+The release workflow supports a safe manual verification run:
+
+1. Open **Actions → Release → Run workflow**.
+2. Select the branch or commit to verify.
+3. Keep **Build and verify distributions without publishing** enabled.
+4. Start the workflow.
+
+A manual run performs the same pre-publication checks as a tagged release:
+
+- builds one wheel and one source distribution
+- runs `twine check` on both artifacts
+- inspects both archives for required package files
+- installs the wheel in a clean virtual environment
+- verifies installed metadata matches `nightmarenet.__version__`
+- uploads the verified artifacts for inspection
+
+Manual runs never execute the GitHub Release or PyPI publishing jobs. Those jobs
+remain restricted to pushed tags matching `v*`.
+
 ## Bootstrap: first release (`v0.2.1`)
 
 The package is prepared at **0.2.1**. After the release-automation PR is on


### PR DESCRIPTION
## Summary

Adds a safe, manually runnable verification path for the PyPI release workflow
and strengthens the checks performed before any distribution is published.

Closes #308

## Changes

- Added `workflow_dispatch` support for verification-only release runs.
- Kept GitHub Release and PyPI publishing jobs restricted to pushed `v*` tags.
- Added `twine check` for wheel and source-distribution metadata.
- Added archive checks confirming one wheel, one sdist, and required package
  files.
- Added a clean-environment wheel installation smoke test.
- Verified installed metadata matches `nightmarenet.__version__`.
- Added explicit artifact failure handling and seven-day retention.
- Added published artifact hash output.
- Kept build and OIDC-enabled publishing in separate jobs.
- Documented the manual verification workflow.

## Security and release safety

- Manual workflow runs cannot publish to GitHub Releases or PyPI.
- `id-token: write` remains scoped only to the PyPI publish job.
- The publishing job only downloads artifacts produced and verified by the
  unprivileged build job.
- No PyPI API token or repository secret was added.

## Validation

- [x] Structural Issue #308 validator
- [x] `python -m build`
- [x] `python -m twine check dist/*`
- [x] Exactly one wheel and one source distribution produced
- [x] Clean-environment wheel installation
- [x] Installed version matches `nightmarenet.__version__`
- [ ] `actionlint .github/workflows/release.yml` (run if available)
- [ ] Manual GitHub Actions verification run attached after pushing

## Local verification output

```text
Paste the exact build, twine, artifact, and smoke-install output here.
```

## Manual Actions verification

After opening the PR from the fork, the upstream workflow cannot use the
repository's protected PyPI environment. After merge or maintainer testing:

1. Open Actions → Release → Run workflow.
2. Keep verification-only mode enabled.
3. Confirm only the build job runs.
4. Confirm GitHub Release and PyPI jobs are skipped.
5. Download and inspect the uploaded `dist` artifact.

## Acceptance Criteria

- [x] Release workflow can be verified without publishing.
- [x] Wheel and sdist metadata are validated.
- [x] Built wheel is smoke-installed before publishing.
- [x] GitHub Release and PyPI publication remain tag-only.
- [x] Trusted Publishing uses job-scoped OIDC permissions.
- [x] The same verified artifacts are reused by release and publish jobs.
- [x] Maintainer verification steps are documented.

## Type

- [x] Infrastructure / CI
- [x] Documentation
- [ ] Runtime code
- [ ] Breaking change


## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`


## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots 
<img width="1162" height="268" alt="Screenshot 2026-07-25 121443" src="https://github.com/user-attachments/assets/08fb9582-2e56-4074-b616-e63d385b7630" />


## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>
