### PR TITLE
chore: add granular code ownership rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,70 @@
-# GitHub CODEOWNERS file
-# Specify automatic code reviewers for all changes
+# NightmareNet code ownership
+#
+# GitHub uses the last matching pattern, so the repository-wide fallback comes
+# first and more specific ownership areas follow it.
+# All owners listed here must have write access to the repository.
 
-# Default owner - only Adit-Jain-srm required
+# Repository-wide fallback
 * @Adit-Jain-srm
 
-# Backend code and tests
-nightmarenet/ @Adit-Jain-srm
-tests/ @Adit-Jain-srm
+# Core Python packages
+/nightmarenet/ @Adit-Jain-srm
+/nightmarenet_server/ @Adit-Jain-srm
 
-# Frontend code
-frontend/ @Adit-Jain-srm
+# Python tests
+/tests/ @Adit-Jain-srm
 
-# Workflows and CI configuration
-.github/workflows/ @Adit-Jain-srm
-.github/ @Adit-Jain-srm
+# Frontend application and frontend tests
+/frontend/ @Adit-Jain-srm
 
-# Configuration files
-pyproject.toml @Adit-Jain-srm
-setup.py @Adit-Jain-srm
+# Configuration, distortion presets, and experiment definitions
+/configs/ @Adit-Jain-srm
+/distortions/ @Adit-Jain-srm
+
+# Documentation and examples
+/docs/ @Adit-Jain-srm
+/notebooks/ @Adit-Jain-srm
+/README.md @Adit-Jain-srm
+/CONTRIBUTING.md @Adit-Jain-srm
+/CHANGELOG.md @Adit-Jain-srm
+/SECURITY.md @Adit-Jain-srm
+/CLAUDE.md @Adit-Jain-srm
+
+# Automation, repository policy, and dependency management
+/.github/workflows/ @Adit-Jain-srm
+/.github/actions/ @Adit-Jain-srm
+/.github/ISSUE_TEMPLATE/ @Adit-Jain-srm
+/.github/DISCUSSION_TEMPLATE/ @Adit-Jain-srm
+/.github/dependabot.yml @Adit-Jain-srm
+/.github/pull_request_template.md @Adit-Jain-srm
+/.github/release.yml @Adit-Jain-srm
+/.github/FUNDING.yml @Adit-Jain-srm
+
+# Protect ownership policy from unowned changes
+/.github/CODEOWNERS @Adit-Jain-srm
+
+# Packaging, release, and Python tooling
+/pyproject.toml @Adit-Jain-srm
+/alembic.ini @Adit-Jain-srm
+/.python-version @Adit-Jain-srm
+/.pre-commit-config.yaml @Adit-Jain-srm
+
+# Containers and deployment
+/Dockerfile @Adit-Jain-srm
+/docker-compose.yml @Adit-Jain-srm
+/docker-compose.prod.yml @Adit-Jain-srm
+/.dockerignore @Adit-Jain-srm
+/docker/ @Adit-Jain-srm
+
+# Data versioning and tracked datasets
+/.dvc/ @Adit-Jain-srm
+/.dvcignore @Adit-Jain-srm
+/data/ @Adit-Jain-srm
+
+# Developer tooling and utility scripts
+/scripts/ @Adit-Jain-srm
+/.cursor/ @Adit-Jain-srm
+/.editorconfig @Adit-Jain-srm
+/.gitattributes @Adit-Jain-srm
+/.gitignore @Adit-Jain-srm
+/.nvmrc @Adit-Jain-srm


### PR DESCRIPTION
## Summary

Makes NightmareNet's CODEOWNERS policy granular and easier to audit while
preserving `@Adit-Jain-srm` as the repository-wide fallback owner.

Closes #330

## Changes

- Preserved the global fallback rule.
- Added explicit ownership groups for:
  - core Python package;
  - API/server package;
  - tests;
  - frontend;
  - configuration and distortion presets;
  - documentation and notebooks;
  - CI, custom actions, and repository policy;
  - packaging and release configuration;
  - containers and deployment;
  - DVC/data areas;
  - scripts and developer tooling.
- Anchored literal paths at the repository root.
- Explicitly protected `.github/CODEOWNERS`.
- Removed the obsolete `setup.py` rule because that file is absent from the
  current repository.

## Validation

- [x] Local CODEOWNERS structural validation passes
- [x] Every required literal ownership path exists
- [x] Fallback rule precedes all specific rules
- [x] `.github/CODEOWNERS` owns itself
- [x] No unsupported negation or character-range syntax
- [x] `git diff --check`
- [ ] GitHub CODEOWNERS error endpoint returns an empty `errors` array after push

### GitHub validation

```powershell
gh api "repos/Jidnyasa-P/NightmareNet/codeowners/errors?ref=chore/330-granular-codeowners"
```

Expected:

```json
{
  "errors": []
}
```

## Scope

The committed change is limited to:

```text
.github/CODEOWNERS
```

No application, test, workflow, dependency, or runtime behaviour is changed.

## Type

- [x] Repository governance / maintenance
- [ ] Runtime change
- [ ] Breaking change


## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>
