### PR TITLE
fix: wire retry handling into API requests

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,75 +1,129 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock fetch globally
+// Mock fetch globally.
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  });
+}
 
 describe("API module", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    // Clear env var so tests use same-origin
     vi.stubEnv("NEXT_PUBLIC_API_URL", "");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe("getApiBase", () => {
     it("returns empty string in browser context (same-origin)", async () => {
-      // window is defined in jsdom
       const { getApiBase } = await import("@/lib/api");
-      const result = getApiBase();
-      expect(result).toBe("");
+      expect(getApiBase()).toBe("");
     });
 
     it("strips trailing slash from env var", async () => {
       vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8000/");
       const { getApiBase } = await import("@/lib/api");
-      const result = getApiBase();
-      expect(result).not.toMatch(/\/$/);
+      expect(getApiBase()).not.toMatch(/\/$/);
     });
   });
 
   describe("getHealth", () => {
     it("calls /api/v1/health", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ status: "healthy", version: "0.2.0" }),
-      });
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, { status: "healthy", version: "0.2.0" }),
+      );
 
       const { getHealth } = await import("@/lib/api");
       const result = await getHealth();
 
       expect(mockFetch).toHaveBeenCalledWith(
         "/api/v1/health",
-        expect.objectContaining({ headers: expect.any(Object) })
+        expect.objectContaining({ headers: expect.any(Object) }),
       );
       expect(result.status).toBe("healthy");
       expect(result.version).toBe("0.2.0");
     });
 
-    it("throws on non-ok response", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: async () => ({ detail: "Server error" }),
-      });
+    it("retries a transient 503 response and returns the successful result", async () => {
+      vi.useFakeTimers();
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse(503, { detail: "Service temporarily unavailable" }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(200, { status: "healthy", version: "0.2.0" }),
+        );
 
       const { getHealth } = await import("@/lib/api");
-      await expect(getHealth()).rejects.toThrow("Server error");
+      const request = getHealth();
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(request).resolves.toEqual({
+        status: "healthy",
+        version: "0.2.0",
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries a network failure and returns the successful result", async () => {
+      vi.useFakeTimers();
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+        .mockResolvedValueOnce(
+          jsonResponse(200, { status: "healthy", version: "0.2.0" }),
+        );
+
+      const { getHealth } = await import("@/lib/api");
+      const request = getHealth();
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(request).resolves.toEqual({
+        status: "healthy",
+        version: "0.2.0",
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a non-retryable client response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(422, { detail: "Validation failed" }),
+      );
+
+      const { getHealth } = await import("@/lib/api");
+
+      await expect(getHealth()).rejects.toThrow("Validation failed");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("generateDream", () => {
     it("sends POST with correct body", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
           original_text: "test",
           distorted_text: "tset",
           distortion_type: "dream",
           strength: 0.5,
           seed: null,
         }),
-      });
+      );
 
       const { generateDream } = await import("@/lib/api");
       const result = await generateDream({ text: "test", strength: 0.5 });
@@ -79,7 +133,7 @@ describe("API module", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ text: "test", strength: 0.5 }),
-        })
+        }),
       );
       expect(result.distortion_type).toBe("dream");
     });
@@ -87,19 +141,22 @@ describe("API module", () => {
 
   describe("generateNightmare", () => {
     it("sends POST with correct body", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
           original_text: "hello",
           distorted_text: "h3llo",
           distortion_type: "nightmare",
           strength: 0.8,
           seed: 42,
         }),
-      });
+      );
 
       const { generateNightmare } = await import("@/lib/api");
-      const result = await generateNightmare({ text: "hello", strength: 0.8, seed: 42 });
+      const result = await generateNightmare({
+        text: "hello",
+        strength: 0.8,
+        seed: 42,
+      });
 
       expect(result.distortion_type).toBe("nightmare");
       expect(result.seed).toBe(42);
@@ -108,14 +165,13 @@ describe("API module", () => {
 
   describe("optimizeData", () => {
     it("posts to /api/v1/data/optimize", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
           status: "completed",
           run_id: "abc-123",
           optimized_count: 10,
         }),
-      });
+      );
 
       const { optimizeData } = await import("@/lib/api");
       const result = await optimizeData({
@@ -125,7 +181,7 @@ describe("API module", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "/api/v1/data/optimize",
-        expect.objectContaining({ method: "POST" })
+        expect.objectContaining({ method: "POST" }),
       );
       expect(result.status).toBe("completed");
     });
@@ -133,13 +189,19 @@ describe("API module", () => {
 
   describe("suggestConfig", () => {
     it("posts to /api/v1/suggest/config", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          suggestions: [{ param: "lr", current: 0.01, suggested: 0.001, reason: "too high" }],
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
+          suggestions: [
+            {
+              param: "lr",
+              current: 0.01,
+              suggested: 0.001,
+              reason: "too high",
+            },
+          ],
           model: "heuristic",
         }),
-      });
+      );
 
       const { suggestConfig } = await import("@/lib/api");
       const result = await suggestConfig({
@@ -153,14 +215,20 @@ describe("API module", () => {
 
   describe("searchExperiments", () => {
     it("posts natural-language queries to /api/v1/search", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          results: [{ run_id: "exp-47", relevance_score: 0.87, summary: "match", metadata: {} }],
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
+          results: [
+            {
+              run_id: "exp-47",
+              relevance_score: 0.87,
+              summary: "match",
+              metadata: {},
+            },
+          ],
           filters: { status: "completed" },
           backend: "faiss",
         }),
-      });
+      );
 
       const { searchExperiments } = await import("@/lib/api");
       const result = await searchExperiments("robustness improved", 5, {
@@ -176,33 +244,32 @@ describe("API module", () => {
             top_k: 5,
             filters: { status: "completed" },
           }),
-        })
+        }),
       );
       expect(result.results[0].run_id).toBe("exp-47");
     });
   });
 
   describe("error handling", () => {
-    it("extracts detail from error response", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 422,
-        json: async () => ({ detail: "Validation failed" }),
-      });
+    it("extracts detail from an error response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(422, { detail: "Validation failed" }),
+      );
 
       const { getHealth } = await import("@/lib/api");
       await expect(getHealth()).rejects.toThrow("Validation failed");
     });
 
-    it("falls back to status code on non-JSON error", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 503,
-        json: async () => { throw new Error("not json"); },
-      });
+    it("falls back to the status code on a non-JSON error", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("temporarily unavailable", {
+          status: 418,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
 
       const { getHealth } = await import("@/lib/api");
-      await expect(getHealth()).rejects.toThrow("API error 503");
+      await expect(getHealth()).rejects.toThrow("API error 418");
     });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { withRetry } from "./retry";
+
 /**
  * API origin for browser/SSR fetches.
  * - If `NEXT_PUBLIC_API_URL` is set, it wins (e.g. split domains or e2e).
@@ -137,19 +139,18 @@ function authHeaders(): Record<string, string> {
 }
 
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${getApiBase()}${path}`, {
+  const url = `${getApiBase()}${path}`;
+  const requestOptions: RequestInit = {
     ...options,
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(),
       ...options?.headers,
     },
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.detail || body.error || `API error ${res.status}`);
-  }
-  return res.json();
+  };
+
+  const res = await withRetry(() => fetch(url, requestOptions));
+  return res.json() as Promise<T>;
 }
 
 export function getHealth(): Promise<HealthResponse> {


### PR DESCRIPTION
## Summary

Connects NightmareNet's existing retry utility to the shared frontend API
client so transient backend and network failures are retried automatically.

Closes #401

## Changes

- Imported `withRetry` into `frontend/src/lib/api.ts`.
- Routed shared JSON API requests through the existing retry policy.
- Constructed request URL/options once and reused them across attempts.
- Preserved API-key and caller-provided headers.
- Kept multipart upload handling unchanged.
- Updated API mocks to use real `Response` instances.
- Added API-level regression coverage for:
  - successful recovery from HTTP 503;
  - successful recovery from a network `TypeError`;
  - immediate failure for non-retryable HTTP 422.

## Retry behaviour

The integration uses the existing `frontend/src/lib/retry.ts` policy unchanged:

- Network failures: retried
- 429: retried and `Retry-After` respected
- 502 / 503 / 504: retried
- 400 / 401 / 403 / 404 / 422: not retried
- Default retry count: 3 retries after the initial attempt
- Backoff: 1s, 2s, 4s by default

## Validation

- [x] Source-level Issue #401 validator
- [x] `npm test -- src/__tests__/api.test.ts`
- [x] `npm test -- src/tests/retry.test.ts`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`


## Scope

Modified files:

```text
frontend/src/lib/api.ts
frontend/src/__tests__/api.test.ts
```

No backend, upload, WebSocket, dependency, or retry-policy changes are included.

## Type

- [x] Bug fix
- [x] Tests
- [ ] Breaking change
- [ ] Dependency change


## Pre-submission Requirements

> These are mandatory. PRs missing any item will not be reviewed.

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

<!-- Check all that apply. At least one must be checked for non-test PRs. -->

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)


## Security Considerations

<!-- For any PR touching auth, API endpoints, user input handling, or webhooks -->

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Screenshots (if UI/UX change)
<img width="1206" height="741" alt="Screenshot 2026-07-25 123204" src="https://github.com/user-attachments/assets/6c5916fe-78a8-4e8d-8fb8-54fa60c9c294" />
<img width="1205" height="748" alt="Screenshot 2026-07-25 123248" src="https://github.com/user-attachments/assets/11fdb674-8038-422c-9819-ff7b6d42c3b4" />
<img width="1204" height="790" alt="Screenshot 2026-07-25 123304" src="https://github.com/user-attachments/assets/4d413b77-1d63-4745-9abc-43b80543a11f" />
<img width="1194" height="815" alt="Screenshot 2026-07-25 123805" src="https://github.com/user-attachments/assets/d78698a2-5a32-4137-ba8e-a36136dab91c" />


## Breaking Changes

<!-- If this is a breaking change, describe: (1) what breaks, (2) migration path -->

N/A

---

<details>
<summary>Reviewer notes (optional)</summary>

<!-- Anything you want to call the reviewer's attention to:
     - Areas you're uncertain about
     - Alternative approaches you considered
     - Performance implications
     - Known limitations -->

</details>
