### PR TITLE
test: add useSounds hook tests

### DIFF
--- a/frontend/src/__tests__/useSounds.test.ts
+++ b/frontend/src/__tests__/useSounds.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSounds } from "@/lib/sounds";
+
+// Mock AudioContext since jsdom doesn't have Web Audio API
+const mockOscillator = {
+  type: "sine",
+  frequency: { setValueAtTime: vi.fn() },
+  connect: vi.fn().mockReturnThis(),
+  start: vi.fn(),
+  stop: vi.fn(),
+};
+
+const mockGain = {
+  gain: {
+    setValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+  },
+  connect: vi.fn().mockReturnThis(),
+};
+
+const mockAudioContext = {
+  state: "running",
+  currentTime: 0,
+  sampleRate: 44100,
+  resume: vi.fn(),
+  createOscillator: vi.fn(() => mockOscillator),
+  createGain: vi.fn(() => mockGain),
+  createBuffer: vi.fn(() => ({
+    getChannelData: vi.fn(() => new Float32Array(2646)),
+  })),
+  createBufferSource: vi.fn(() => ({
+    buffer: null,
+    connect: vi.fn().mockReturnThis(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  createBiquadFilter: vi.fn(() => ({
+    type: "bandpass",
+    frequency: { setValueAtTime: vi.fn() },
+    Q: { setValueAtTime: vi.fn() },
+    connect: vi.fn().mockReturnThis(),
+  })),
+  destination: {},
+};
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+
+describe("useSounds hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    
+    // Reset stubs before each test to guarantee isolated states
+    vi.stubGlobal("localStorage", localStorageMock);
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns play functions for every supported sound", () => {
+    vi.stubGlobal("AudioContext", function() { return mockAudioContext; });
+    
+    const { result } = renderHook(() => useSounds());
+
+    expect(typeof result.current.playClick).toBe("function");
+    expect(typeof result.current.playSuccess).toBe("function");
+    expect(typeof result.current.playError).toBe("function");
+    expect(typeof result.current.playTransition).toBe("function");
+    expect(typeof result.current.playNotification).toBe("function");
+    expect(typeof result.current.toggle).toBe("function");
+    expect(result.current.enabled).toBeDefined();
+  });
+
+  it("respects the user's mute preference", () => {
+    vi.stubGlobal("AudioContext", function() { return mockAudioContext; });
+    
+    // Simulate user previously disabling sounds via localStorage
+    localStorageMock.getItem.mockReturnValueOnce("false");
+    
+    const { result } = renderHook(() => useSounds());
+    
+    // Ensure hook initialized in a muted state
+    expect(result.current.enabled).toBe(false);
+    
+    act(() => {
+      result.current.playClick();
+    });
+    
+    // AudioContext should not be interacted with because sounds are disabled
+    expect(mockAudioContext.createOscillator).not.toHaveBeenCalled();
+    
+    // User toggles sounds back on
+    act(() => {
+      result.current.toggle();
+    });
+    
+    expect(result.current.enabled).toBe(true);
+    
+    act(() => {
+      result.current.playClick();
+    });
+    
+    // Now AudioContext should generate the sound
+    expect(mockAudioContext.createOscillator).toHaveBeenCalled();
+  });
+
+  it("does not throw when Audio API is unavailable (SSR-safe)", () => {
+    // Deliberately make AudioContext unavailable to simulate SSR or unsupported browser
+    vi.stubGlobal("AudioContext", undefined);
+    
+    const { result } = renderHook(() => useSounds());
+    
+    expect(() => {
+      act(() => {
+        result.current.playClick();
+        result.current.playSuccess();
+        result.current.playError();
+        result.current.playTransition();
+        result.current.playNotification();
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for the `useSounds` hook to verify sound playback helpers, mute preference handling, and SSR-safe behavior.

## Motivation

The `useSounds` hook is responsible for UI sound effects but currently has no automated test coverage. These tests help ensure expected behavior across different environments and prevent regressions.

- Closes #521

## Changes

- Added `frontend/src/__tests__/useSounds.test.ts`
- Added tests to verify the hook exposes play functions for supported sound types
- Added tests to ensure sounds respect the user's mute preference
- Added tests to verify the hook behaves safely when the Audio API is unavailable (SSR)

## Acceptance Criteria

- [x] `frontend/src/__tests__/useSounds.test.ts` created
- [x] Tests verify the hook returns play functions for each sound type
- [x] Tests verify mute preference is respected
- [x] Tests verify SSR-safe behavior when the Audio API is unavailable
- [x] Minimum of 3 meaningful test cases

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read **CONTRIBUTING.md** in full

## Quality Checklist

- [ ] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [ ] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow Conventional Commits
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (test-only change)
- [ ] README.md updated
- [ ] Docstrings added/updated
- [ ] `docs/` updated
- [ ] Config comments updated
- [ ] CHANGELOG entry added

## AI Disclosure

- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) which has been reviewed before submission.

## Security Considerations

- [x] Not applicable (test-only change)
- [x] No secrets, keys, or credentials included

## Screenshots (if UI/UX change)

Not applicable (test-only change).

## Breaking Changes

N/A

---

<details>
<summary>Reviewer Notes</summary>

This PR is limited to unit tests for the `useSounds` hook. No production code or hook behavior has been modified. The tests focus on validating the public API of the hook, user mute preference handling, and graceful behavior when browser audio APIs are unavailable.

</details>
```