### PR TITLE
feat(distortions): add Unicode-aware text distortions for CJK, Arabic, Cyrillic, Devanagari

### DIFF
--- a/nightmarenet/distortions/char_maps/__init__.py
+++ b/nightmarenet/distortions/char_maps/__init__.py
@@ -1,0 +1,100 @@
+"""Per-script character maps for Unicode-aware text distortions.
+
+Each script submodule (latin, cyrillic, arabic, cjk, devanagari) exposes:
+
+- ``TYPO_MAP``: ``Dict[str, str]`` mapping a character to a string of
+  plausible mistyped/confused replacement characters, used by
+  ``typo_injection``.
+- ``CONFUSABLES``: ``Dict[str, List[str]]`` mapping a character to visually
+  similar characters (often from a *different* script), used by
+  ``homoglyph_substitution``.
+
+``detect_script`` buckets a single character into one of the supported
+script keys so the distortion functions never have to hardcode Unicode
+ranges themselves. Adding a new script means adding one new module here and
+one entry in the two registries below -- no changes needed in text.py.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Dict, List
+
+from nightmarenet.distortions.char_maps import arabic, cjk, cyrillic, devanagari, latin
+
+SUPPORTED_SCRIPTS = ("latin", "cyrillic", "arabic", "cjk", "devanagari")
+
+_TYPO_MAPS: Dict[str, Dict[str, str]] = {
+    "latin": latin.TYPO_MAP,
+    "cyrillic": cyrillic.TYPO_MAP,
+    "arabic": arabic.TYPO_MAP,
+    "cjk": cjk.TYPO_MAP,
+    "devanagari": devanagari.TYPO_MAP,
+}
+
+_CONFUSABLES: Dict[str, Dict[str, List[str]]] = {
+    "latin": latin.CONFUSABLES,
+    "cyrillic": cyrillic.CONFUSABLES,
+    "arabic": arabic.CONFUSABLES,
+    "cjk": cjk.CONFUSABLES,
+    "devanagari": devanagari.CONFUSABLES,
+}
+
+# Coarse Unicode code-point ranges, only precise enough to pick the right
+# typo/confusables table -- not a full script-detection implementation.
+_SCRIPT_RANGES = (
+    (0x0600, 0x06FF, "arabic"),  # Arabic
+    (0x0750, 0x077F, "arabic"),  # Arabic Supplement
+    (0xFB50, 0xFDFF, "arabic"),  # Arabic Presentation Forms-A
+    (0xFE70, 0xFEFF, "arabic"),  # Arabic Presentation Forms-B
+    (0x0400, 0x04FF, "cyrillic"),  # Cyrillic
+    (0x0500, 0x052F, "cyrillic"),  # Cyrillic Supplement
+    (0x0900, 0x097F, "devanagari"),
+    (0x4E00, 0x9FFF, "cjk"),  # CJK Unified Ideographs
+    (0x3400, 0x4DBF, "cjk"),  # CJK Extension A
+    (0x3040, 0x309F, "cjk"),  # Hiragana
+    (0x30A0, 0x30FF, "cjk"),  # Katakana
+    (0xAC00, 0xD7A3, "cjk"),  # Hangul syllables
+    (0x0041, 0x005A, "latin"),
+    (0x0061, 0x007A, "latin"),
+    (0x00C0, 0x024F, "latin"),  # Latin-1 Supplement + Extended-A/B
+)
+
+
+def detect_script(char: str) -> str:
+    """Return the script bucket for a single character/grapheme cluster.
+
+    Looks at the first code point of ``char`` (the base character of a
+    grapheme cluster, since combining marks appear after it) and falls back
+    to ``"latin"`` for anything unrecognized -- punctuation, digits,
+    symbols, emoji, whitespace, etc. -- so callers always get a usable map.
+    """
+    if not char:
+        return "latin"
+    cp = ord(char[0])
+    for start, end, script in _SCRIPT_RANGES:
+        if start <= cp <= end:
+            return script
+    return "latin"
+
+
+def get_typo_map(script: str) -> Dict[str, str]:
+    """Return the typo-adjacency map for a script, defaulting to Latin."""
+    return _TYPO_MAPS.get(script, _TYPO_MAPS["latin"])
+
+
+def get_confusables(script: str) -> Dict[str, List[str]]:
+    """Return the homoglyph confusables map for a script, defaulting to Latin."""
+    return _CONFUSABLES.get(script, _CONFUSABLES["latin"])
+
+
+def is_rtl(char: str) -> bool:
+    """True if ``char`` has a strong right-to-left Unicode bidi category.
+
+    Only the base character is checked (consistent with detect_script),
+    which is sufficient since combining marks inherit directionality from
+    their base character under the Unicode Bidirectional Algorithm.
+    """
+    if not char:
+        return False
+    return unicodedata.bidirectional(char[0]) in ("AL", "R")

--- a/nightmarenet/distortions/char_maps/arabic.py
+++ b/nightmarenet/distortions/char_maps/arabic.py
@@ -1,0 +1,57 @@
+"""Arabic-script character maps.
+
+Arabic physical keyboard layouts vary significantly by OS and region, so
+instead of guessing a single layout, TYPO_MAP models the most common
+real-world Arabic typo/OCR error class: confusing letters that share the
+same base glyph shape (rasm) and differ only by the number or placement of
+diacritical dots -- e.g. letter pairs like b/t/th, j/h/kh, d/dh, r/z,
+s/sh, and f/q. This is a well-documented error class for both fast typing
+and OCR, and is more representative of real Arabic noise than an assumed
+keyboard layout.
+
+Text using these maps stays right-to-left: all replacements are drawn from
+the same script, and Arabic contextual shaping (initial/medial/final glyph
+forms) is recomputed at render time from the base letters, so substituting
+one base Arabic letter for another does not corrupt shaping or break the
+paragraph's RTL direction.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+TYPO_MAP: Dict[str, str] = {
+    "\u0628": "\u062a\u062b",
+    "\u062a": "\u0628\u062b",
+    "\u062b": "\u0628\u062a",
+    "\u062c": "\u062d\u062e",
+    "\u062d": "\u062c\u062e",
+    "\u062e": "\u062c\u062d",
+    "\u062f": "\u0630",
+    "\u0630": "\u062f",
+    "\u0631": "\u0632",
+    "\u0632": "\u0631",
+    "\u0633": "\u0634",
+    "\u0634": "\u0633",
+    "\u0635": "\u0636",
+    "\u0636": "\u0635",
+    "\u0637": "\u0638",
+    "\u0638": "\u0637",
+    "\u0639": "\u063a",
+    "\u063a": "\u0639",
+    "\u0641": "\u0642",
+    "\u0642": "\u0641",
+    "\u0647": "\u0629",
+    "\u0629": "\u0647",
+    "\u0648": "\u0624",
+    "\u0624": "\u0648",
+    "\u064a": "\u0649\u0626",
+}
+
+CONFUSABLES: Dict[str, List[str]] = {
+    "\u0647": ["\u0629", "\u06be"],
+    "\u064a": ["\u0649", "\u0626"],
+    "\u0648": ["\u0624"],
+    "\u0627": ["\u0623", "\u0625", "\u0622"],
+    "\u0643": ["\u06af"],
+}

--- a/nightmarenet/distortions/char_maps/cjk.py
+++ b/nightmarenet/distortions/char_maps/cjk.py
@@ -1,0 +1,62 @@
+"""CJK-script character maps.
+
+CJK text is entered through an IME (pinyin, zhuyin, romaji, etc.), so there
+is no meaningful "adjacent key" concept the way there is for Latin/Cyrillic
+keyboards. TYPO_MAP instead models visually/structurally similar Han
+characters -- the dominant real-world error class for OCR and fast
+handwriting/typing (e.g. mistaking one stroke-similar character for
+another). Homophone confusions (same pinyin, different character) are
+intentionally out of scope here since they need a pronunciation dictionary;
+see docs/plugin_development.md for how to extend this map with one.
+
+This module also covers Hiragana/Katakana and Hangul syllables for the
+purposes of script bucketing (char_maps.detect_script groups them with CJK)
+even though the maps below focus on Han characters, which are the most
+common case flagged in the issue.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+TYPO_MAP: Dict[str, str] = {
+    "\u5df1": "\u5df2\u5df3",
+    "\u5df2": "\u5df1\u5df3",
+    "\u5df3": "\u5df1\u5df2",
+    "\u4eba": "\u5165\u516b",
+    "\u5165": "\u4eba\u516b",
+    "\u516b": "\u4eba\u5165",
+    "\u65e5": "\u66f0",
+    "\u66f0": "\u65e5",
+    "\u672a": "\u672b",
+    "\u672b": "\u672a",
+    "\u571f": "\u58eb",
+    "\u58eb": "\u571f",
+    "\u5e72": "\u5343",
+    "\u5343": "\u5e72",
+    "\u5200": "\u529b",
+    "\u529b": "\u5200",
+    "\u738b": "\u7389",
+    "\u7389": "\u738b",
+    "\u53c8": "\u53c9",
+    "\u53c9": "\u53c8",
+    "\u620a": "\u620c\u620d",
+    "\u620c": "\u620a\u620d",
+    "\u620d": "\u620a\u620c",
+    "\u5927": "\u592a\u72ac",
+    "\u592a": "\u5927\u72ac",
+    "\u72ac": "\u5927\u592a",
+    "\u76ee": "\u81ea",
+    "\u81ea": "\u76ee",
+    "\u53e3": "\u56d7",
+    "\u56d7": "\u53e3",
+}
+
+CONFUSABLES: Dict[str, List[str]] = {
+    "\u4e00": ["\u4e28", "\uff5c", "1", "l"],
+    "\u53e3": ["\u56d7"],
+    "\u4eba": ["\u5165"],
+    "\u65e5": ["\u66f0"],
+    "\u58eb": ["\u571f"],
+    "\u5df1": ["\u5df2", "\u5df3"],
+}

--- a/nightmarenet/distortions/char_maps/cyrillic.py
+++ b/nightmarenet/distortions/char_maps/cyrillic.py
@@ -1,0 +1,64 @@
+"""Cyrillic-script character maps.
+
+TYPO_MAP models the standard ЙЦУКЕН keyboard layout's physical adjacency.
+CONFUSABLES maps Cyrillic letters to their visually-identical Latin/Greek
+counterparts (the reverse of the pairs in char_maps.latin), plus a couple
+of same-script Cyrillic confusions (е/ё, и/й) that are common typing slips.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+TYPO_MAP: Dict[str, str] = {
+    "й": "цф",
+    "ц": "йыв",
+    "у": "кеа",
+    "к": "уеап",
+    "е": "кнпр",
+    "н": "егшр",
+    "г": "нш",
+    "ш": "гщо",
+    "щ": "шзл",
+    "з": "щхд",
+    "х": "зъж",
+    "ъ": "хэ",
+    "ф": "йыя",
+    "ы": "фцвч",
+    "в": "ыцас",
+    "а": "вупм",
+    "п": "аори",
+    "р": "пенто",
+    "о": "ршгть",
+    "л": "олдщ",
+    "д": "лжэб",
+    "ж": "дъб",
+    "э": "жо",
+    "я": "фчс",
+    "ч": "ясм",
+    "с": "чмвт",
+    "м": "сит",
+    "и": "мтьй",
+    "т": "ирбю",
+    "ь": "тбю",
+    "б": "ьил",
+    "ю": "бт",
+}
+
+CONFUSABLES: Dict[str, List[str]] = {
+    "а": ["a"],
+    "е": ["e", "ё"],
+    "о": ["o", "0"],
+    "р": ["p"],
+    "с": ["c"],
+    "х": ["x"],
+    "у": ["y"],
+    "і": ["i", "1"],
+    "ј": ["j"],
+    "ѕ": ["s"],
+    "һ": ["h"],
+    "к": ["k"],
+    "м": ["m"],
+    "т": ["t"],
+    "и": ["й"],
+}

--- a/nightmarenet/distortions/char_maps/devanagari.py
+++ b/nightmarenet/distortions/char_maps/devanagari.py
@@ -1,0 +1,37 @@
+"""Devanagari-script character maps.
+
+Not required by the issue's acceptance criteria (which lists CJK, Arabic,
+and Cyrillic), but included as bonus coverage since the Problem section
+explicitly calls out Devanagari as an affected script and the char_maps
+package is designed to make adding a script a small, self-contained file.
+
+TYPO_MAP models two common real-world error classes: visually similar
+consonants, and short/long matra (vowel sign) confusion -- the latter is
+especially important to get right at the grapheme-cluster level, since a
+matra is a combining mark that must stay attached to its base consonant.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+TYPO_MAP: Dict[str, str] = {
+    "\u092c": "\u0935",
+    "\u0935": "\u092c",
+    "\u0921": "\u0926",
+    "\u0926": "\u0921",
+    "\u0927": "\u0918",
+    "\u0918": "\u0927",
+    "\u0925": "\u091f",
+    "\u091f": "\u0925",
+    "\u093f": "\u0940",
+    "\u0940": "\u093f",
+    "\u0941": "\u0942",
+    "\u0942": "\u0941",
+}
+
+CONFUSABLES: Dict[str, List[str]] = {
+    "\u092c": ["\u0935"],
+    "\u0921": ["\u0926"],
+    "\u093f": ["\u0940"],
+}

--- a/nightmarenet/distortions/char_maps/latin.py
+++ b/nightmarenet/distortions/char_maps/latin.py
@@ -1,0 +1,62 @@
+"""Latin-script character maps.
+
+TYPO_MAP: QWERTY keyboard-adjacency, used to simulate fat-finger typos.
+CONFUSABLES: a curated subset of the Unicode confusables database --
+characters from other scripts that render as visually identical (or
+near-identical) to a given Latin letter. This is the classic IDN-homograph
+character set (Cyrillic/Greek look-alikes) rather than a live fetch of
+Unicode's confusables.txt, since this package has no network access to
+unicode.org at runtime. Extend this table as new confusable pairs are
+verified; see docs/plugin_development.md.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+TYPO_MAP: Dict[str, str] = {
+    "a": "sqwz",
+    "b": "vngh",
+    "c": "xdfv",
+    "d": "sfcxer",
+    "e": "rdsw",
+    "f": "dgcvrt",
+    "g": "fhbvty",
+    "h": "gjbnyu",
+    "i": "ujko",
+    "j": "hknmui",
+    "k": "jlmio",
+    "l": "kop",
+    "m": "njk",
+    "n": "bmhj",
+    "o": "iklp",
+    "p": "ol",
+    "q": "wa",
+    "r": "etdf",
+    "s": "adwxez",
+    "t": "rfgy",
+    "u": "yhji",
+    "v": "cfgb",
+    "w": "qase",
+    "x": "zsdc",
+    "y": "tghu",
+    "z": "xsa",
+}
+
+CONFUSABLES: Dict[str, List[str]] = {
+    "a": ["\u0430", "\u0251"],  # Cyrillic а, Latin alpha ɑ
+    "e": ["\u0435"],  # Cyrillic е
+    "o": ["\u043e", "0"],  # Cyrillic о, digit zero
+    "p": ["\u0440", "\u03c1"],  # Cyrillic р, Greek rho ρ
+    "c": ["\u0441", "\u03f2"],  # Cyrillic с, Greek lunate sigma ϲ
+    "x": ["\u0445", "\u03c7"],  # Cyrillic х, Greek chi χ
+    "y": ["\u0443", "\u03b3"],  # Cyrillic у, Greek gamma γ
+    "i": ["\u0456", "1", "l"],  # Cyrillic (Ukrainian) і, digit one, lowercase L
+    "j": ["\u0458"],  # Cyrillic je ј
+    "s": ["\u0455"],  # Cyrillic dze ѕ
+    "h": ["\u04bb"],  # Cyrillic shha һ
+    "k": ["\u043a"],  # Cyrillic к
+    "m": ["\u043c"],  # Cyrillic м
+    "t": ["\u0442"],  # Cyrillic т
+    "n": ["\u0578"],  # Armenian n ո (visually close to Latin n)
+}

--- a/nightmarenet/distortions/text.py
+++ b/nightmarenet/distortions/text.py
@@ -10,44 +10,34 @@ import logging
 import random
 import string
 
+import regex
+
+from nightmarenet.distortions import char_maps
 from nightmarenet.utils.validation import validate_strength
 
 logger = logging.getLogger(__name__)
 
 
-# Keyboard adjacency map for simulating typos
-KEYBOARD_ADJACENT = {
-    "a": "sqwz",
-    "b": "vngh",
-    "c": "xdfv",
-    "d": "sfcxer",
-    "e": "rdsw",
-    "f": "dgcvrt",
-    "g": "fhbvty",
-    "h": "gjbnyu",
-    "i": "ujko",
-    "j": "hknmui",
-    "k": "jlmio",
-    "l": "kop",
-    "m": "njk",
-    "n": "bmhj",
-    "o": "iklp",
-    "p": "ol",
-    "q": "wa",
-    "r": "etdf",
-    "s": "adwxez",
-    "t": "rfgy",
-    "u": "yhji",
-    "v": "cfgb",
-    "w": "qase",
-    "x": "zsdc",
-    "y": "tghu",
-    "z": "xsa",
-}
+# Keyboard adjacency map for simulating typos. Kept as a public alias of the
+# canonical Latin map in char_maps.latin for backward compatibility --
+# existing code importing KEYBOARD_ADJACENT from this module keeps working.
+KEYBOARD_ADJACENT = char_maps.latin.TYPO_MAP
+
+
+def _graphemes(text: str) -> list:
+    """Split text into grapheme clusters (user-perceived characters).
+
+    Unlike `list(text)`, which splits on raw Unicode code points, this keeps
+    combining marks attached to their base character -- e.g. Arabic tashkeel,
+    Devanagari matras, or accented Latin letters written as base + combining
+    accent. Operating on graphemes instead of code points is what makes the
+    distortions in this module safe to run on non-Latin scripts.
+    """
+    return regex.findall(r"\X", text)
 
 
 def char_swap(text, strength=0.3) -> str:
-    """Randomly swap adjacent characters in the text.
+    """Randomly swap adjacent grapheme clusters in the text.
 
     Args:
         text: Input text string.
@@ -56,9 +46,9 @@ def char_swap(text, strength=0.3) -> str:
     Returns:
         Corrupted text with some adjacent character pairs swapped.
     """
-    if len(text) < 2:
+    chars = _graphemes(text)
+    if len(chars) < 2:
         return text
-    chars = list(text)
     i = 0
     while i < len(chars) - 1:
         if random.random() < strength * 0.3:
@@ -72,6 +62,11 @@ def char_swap(text, strength=0.3) -> str:
 def char_insert(text, strength=0.3) -> str:
     """Randomly insert characters into the text.
 
+    Inserted characters are drawn from the same script as the grapheme they
+    follow (falling back to Latin lowercase for scripts without a typo map),
+    so CJK/Arabic/Cyrillic/Devanagari text doesn't get random Latin noise
+    spliced in.
+
     Args:
         text: Input text string.
         strength: Float 0–1 controlling the probability of insertion at each position.
@@ -81,17 +76,19 @@ def char_insert(text, strength=0.3) -> str:
     """
     if not text:
         return text
-    chars = list(text)
+    chars = _graphemes(text)
     result = []
     for ch in chars:
         result.append(ch)
         if random.random() < strength * 0.15:
-            result.append(random.choice(string.ascii_lowercase))
+            script = char_maps.detect_script(ch)
+            pool = list(char_maps.get_typo_map(script).keys()) or list(string.ascii_lowercase)
+            result.append(random.choice(pool))
     return "".join(result)
 
 
 def char_delete(text, strength=0.3) -> str:
-    """Randomly delete characters from the text.
+    """Randomly delete grapheme clusters from the text.
 
     Args:
         text: Input text string.
@@ -102,11 +99,15 @@ def char_delete(text, strength=0.3) -> str:
     """
     if not text:
         return text
-    return "".join(ch for ch in text if random.random() > strength * 0.15)
+    return "".join(ch for ch in _graphemes(text) if random.random() > strength * 0.15)
 
 
 def keyboard_typo(text, strength=0.3) -> str:
-    """Replace characters with keyboard-adjacent characters to simulate typos.
+    """Replace characters with QWERTY-keyboard-adjacent characters (Latin only).
+
+    Kept as a Latin-only, backward-compatible entry point. For script-aware
+    typo simulation across CJK/Arabic/Cyrillic/Devanagari text, use
+    `typo_injection` instead.
 
     Args:
         text: Input text string.
@@ -117,12 +118,79 @@ def keyboard_typo(text, strength=0.3) -> str:
     """
     if not text:
         return text
-    chars = list(text)
+    chars = _graphemes(text)
     for i, ch in enumerate(chars):
         if random.random() < strength * 0.2 and ch.lower() in KEYBOARD_ADJACENT:
             adjacent = KEYBOARD_ADJACENT[ch.lower()]
             replacement = random.choice(adjacent)
             chars[i] = replacement.upper() if ch.isupper() else replacement
+    return "".join(chars)
+
+
+def typo_injection(text, strength=0.3) -> str:
+    """Replace characters with script-appropriate confused characters.
+
+    Unicode-aware, multi-script equivalent of `keyboard_typo`: each grapheme
+    cluster is matched against the typo map for its own script (Latin
+    keyboard-adjacency, Cyrillic ЙЦУКЕН-adjacency, Arabic dotted-letter
+    confusion, CJK visually-similar-character confusion, Devanagari
+    consonant/matra confusion), so mixed-script text gets plausible
+    per-script noise instead of being skipped or corrupted.
+
+    Args:
+        text: Input text string.
+        strength: Float 0–1 controlling the probability of each character being replaced.
+
+    Returns:
+        Corrupted text with script-aware character replacements.
+    """
+    if not text:
+        return text
+    chars = _graphemes(text)
+    for i, ch in enumerate(chars):
+        if random.random() >= strength * 0.2:
+            continue
+        script = char_maps.detect_script(ch)
+        typo_map = char_maps.get_typo_map(script)
+        base = ch.lower() if script in ("latin", "cyrillic") else ch
+        if base not in typo_map:
+            continue
+        replacement = random.choice(typo_map[base])
+        if script in ("latin", "cyrillic") and ch.isupper():
+            replacement = replacement.upper()
+        chars[i] = replacement
+    return "".join(chars)
+
+
+def homoglyph_substitution(text, strength=0.3) -> str:
+    """Replace characters with visually-similar Unicode homoglyphs.
+
+    Uses a curated subset of the Unicode confusables database (see
+    char_maps/*.py) to substitute characters with look-alikes -- often from
+    a different script, e.g. Latin "a" -> Cyrillic "а". This simulates
+    homograph-style corruption (the same class of confusion used in IDN
+    homograph attacks) across Latin, Cyrillic, Arabic, CJK, and Devanagari
+    text.
+
+    Args:
+        text: Input text string.
+        strength: Float 0–1 controlling the probability of each character being replaced.
+
+    Returns:
+        Corrupted text with homoglyph substitutions applied.
+    """
+    if not text:
+        return text
+    chars = _graphemes(text)
+    for i, ch in enumerate(chars):
+        if random.random() >= strength * 0.2:
+            continue
+        script = char_maps.detect_script(ch)
+        confusables = char_maps.get_confusables(script)
+        base = ch.lower() if script in ("latin", "cyrillic") else ch
+        if base not in confusables or not confusables[base]:
+            continue
+        chars[i] = random.choice(confusables[base])
     return "".join(chars)
 
 
@@ -301,6 +369,8 @@ def apply_text_distortions(text, strength=0.3, config=None) -> str:
             "char_insert": char_insert,
             "char_delete": char_delete,
             "keyboard_typo": keyboard_typo,
+            "typo_injection": typo_injection,
+            "homoglyph_substitution": homoglyph_substitution,
             "word_shuffle": word_shuffle,
             "token_mask": token_mask,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "requests>=2.31.0",
     "pydantic>=2.0",
+    "regex>=2023.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_distortions_multilingual.py
+++ b/tests/test_distortions_multilingual.py
@@ -1,0 +1,239 @@
+"""Tests for Unicode-aware, multi-script text distortions.
+
+Covers the acceptance criteria in issue #310:
+- char_swap works correctly on CJK strings (no broken grapheme clusters)
+- typo_injection has character maps for Arabic, Cyrillic, and CJK
+- homoglyph_substitution uses confusables tables for non-Latin scripts
+- RTL text maintains correct base directionality after distortion
+- Existing Latin-alphabet behavior is unchanged (see tests/test_distortions.py)
+"""
+
+from __future__ import annotations
+
+import random
+import unicodedata
+
+import regex
+
+from nightmarenet.distortions import char_maps
+from nightmarenet.distortions.text import (
+    char_delete,
+    char_insert,
+    char_swap,
+    homoglyph_substitution,
+    typo_injection,
+)
+
+SEED = 42
+
+# "你好世界，这是一个测试。" (Hello world, this is a test.)
+CJK_TEXT = "\u4f60\u597d\u4e16\u754c\uff0c\u8fd9\u662f\u4e00\u4e2a\u6d4b\u8bd5\u3002"
+# "مرحبا بالعالم" (Hello world)
+ARABIC_TEXT = "\u0645\u0631\u062d\u0628\u0627 \u0628\u0627\u0644\u0639\u0627\u0644\u0645"
+# "привет мир" (hello world)
+CYRILLIC_TEXT = "\u043f\u0440\u0438\u0432\u0435\u0442 \u043c\u0438\u0440"
+# "नमस्ते दुनिया" (hello world)
+DEVANAGARI_TEXT = "\u0928\u092e\u0938\u094d\u0924\u0947 \u0926\u0941\u0928\u093f\u092f\u093e"
+
+
+def _base_direction(text: str) -> str:
+    """First-strong-character paragraph direction per Unicode Bidi rule P2/P3."""
+    for ch in text:
+        bidi = unicodedata.bidirectional(ch)
+        if bidi in ("L",):
+            return "ltr"
+        if bidi in ("AL", "R"):
+            return "rtl"
+    return "neutral"
+
+
+class TestGraphemeAwareness:
+    """char_swap (and friends) must never split a grapheme cluster."""
+
+    def setup_method(self):
+        random.seed(SEED)
+
+    def test_char_swap_cjk_no_broken_clusters(self):
+        result = char_swap(CJK_TEXT, strength=1.0)
+        original_graphemes = set(regex.findall(r"\X", CJK_TEXT))
+        result_graphemes = regex.findall(r"\X", result)
+        assert all(g in original_graphemes for g in result_graphemes)
+        assert len(result_graphemes) == len(regex.findall(r"\X", CJK_TEXT))
+
+    def test_char_swap_combining_marks_stay_attached(self):
+        text = "cafe\u0301 man\u0303ana"  # café mañana, decomposed form
+        result = char_swap(text, strength=1.0)
+        graphemes = regex.findall(r"\X", result)
+        for g in graphemes:
+            if len(g) > 1:
+                assert unicodedata.combining(g[0]) == 0
+
+    def test_char_swap_devanagari_matras_stay_attached(self):
+        result = char_swap(DEVANAGARI_TEXT, strength=1.0)
+        original_graphemes = set(regex.findall(r"\X", DEVANAGARI_TEXT))
+        result_graphemes = regex.findall(r"\X", result)
+        assert all(g in original_graphemes for g in result_graphemes)
+
+
+class TestScriptDetection:
+    def test_detects_cjk(self):
+        assert char_maps.detect_script("\u4f60") == "cjk"
+
+    def test_detects_arabic(self):
+        assert char_maps.detect_script("\u0645") == "arabic"
+
+    def test_detects_cyrillic(self):
+        assert char_maps.detect_script("\u043f") == "cyrillic"
+
+    def test_detects_devanagari(self):
+        assert char_maps.detect_script("\u0928") == "devanagari"
+
+    def test_detects_latin_default(self):
+        assert char_maps.detect_script("a") == "latin"
+        assert char_maps.detect_script("!") == "latin"
+
+    def test_is_rtl(self):
+        assert char_maps.is_rtl("\u0645") is True
+        assert char_maps.is_rtl("a") is False
+        assert char_maps.is_rtl("\u4f60") is False
+
+
+class TestTypoInjection:
+    def setup_method(self):
+        random.seed(SEED)
+
+    def test_typo_injection_produces_output_per_script(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT, DEVANAGARI_TEXT):
+            result = typo_injection(text, strength=1.0)
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+    def test_typo_injection_changes_text_at_high_strength(self):
+        mappable_text = "\u4eba\u65e5\u571f\u5e72\u5200\u738b"  # 人日土干刀王
+        changed = False
+        for seed in range(20):
+            random.seed(seed)
+            if typo_injection(mappable_text, strength=1.0) != mappable_text:
+                changed = True
+                break
+        assert changed
+
+    def test_typo_injection_arabic_has_map_coverage(self):
+        assert len(char_maps.arabic.TYPO_MAP) > 0
+
+    def test_typo_injection_cyrillic_has_map_coverage(self):
+        assert len(char_maps.cyrillic.TYPO_MAP) > 0
+
+    def test_typo_injection_cjk_has_map_coverage(self):
+        assert len(char_maps.cjk.TYPO_MAP) > 0
+
+    def test_typo_injection_empty_input(self):
+        assert typo_injection("", strength=0.5) == ""
+
+    def test_typo_injection_zero_strength_is_noop(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT):
+            assert typo_injection(text, strength=0.0) == text
+
+    def test_typo_injection_preserves_grapheme_count(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT, DEVANAGARI_TEXT):
+            result = typo_injection(text, strength=1.0)
+            assert len(regex.findall(r"\X", result)) == len(regex.findall(r"\X", text))
+
+
+class TestHomoglyphSubstitution:
+    def setup_method(self):
+        random.seed(SEED)
+
+    def test_homoglyph_substitution_produces_output(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT, "apple orange banana"):
+            result = homoglyph_substitution(text, strength=1.0)
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+    def test_homoglyph_substitution_uses_confusables_table(self):
+        random.seed(SEED)
+        result = homoglyph_substitution("aeiou aeiou aeiou aeiou aeiou", strength=1.0)
+        assert result != "aeiou aeiou aeiou aeiou aeiou"
+
+    def test_homoglyph_substitution_empty_input(self):
+        assert homoglyph_substitution("", strength=0.5) == ""
+
+    def test_homoglyph_substitution_zero_strength_is_noop(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT):
+            assert homoglyph_substitution(text, strength=0.0) == text
+
+    def test_homoglyph_substitution_non_latin_tables_exist(self):
+        assert len(char_maps.cyrillic.CONFUSABLES) > 0
+        assert len(char_maps.arabic.CONFUSABLES) > 0
+        assert len(char_maps.cjk.CONFUSABLES) > 0
+
+
+class TestRTLDirectionality:
+    """RTL text must keep its overall (base) direction after distortion."""
+
+    def setup_method(self):
+        random.seed(SEED)
+
+    def test_arabic_base_direction_preserved_char_swap(self):
+        assert _base_direction(ARABIC_TEXT) == "rtl"
+        result = char_swap(ARABIC_TEXT, strength=1.0)
+        assert _base_direction(result) == "rtl"
+
+    def test_arabic_base_direction_preserved_typo_injection(self):
+        result = typo_injection(ARABIC_TEXT, strength=1.0)
+        assert _base_direction(result) == "rtl"
+
+    def test_arabic_base_direction_preserved_homoglyph(self):
+        result = homoglyph_substitution(ARABIC_TEXT, strength=1.0)
+        assert _base_direction(result) == "rtl"
+
+    def test_arabic_base_direction_preserved_char_insert(self):
+        result = char_insert(ARABIC_TEXT, strength=1.0)
+        assert _base_direction(result) == "rtl"
+
+    def test_arabic_char_insert_does_not_inject_latin_noise(self):
+        result = char_insert(ARABIC_TEXT, strength=1.0)
+        inserted_chars = set(result) - set(ARABIC_TEXT)
+        assert all(char_maps.detect_script(c) != "latin" for c in inserted_chars if c.isalpha())
+
+
+class TestRoundtripValidation:
+    """Distortions should never crash, drop to empty, or corrupt structure."""
+
+    @staticmethod
+    def _roundtrip_checks(text, fn):
+        result = fn(text, strength=0.5)
+        assert isinstance(result, str)
+        assert "\ufffd" not in result
+        original_graphemes = regex.findall(r"\X", text)
+        result_graphemes = regex.findall(r"\X", result)
+        return original_graphemes, result_graphemes
+
+    def test_cjk_roundtrip_all_functions(self):
+        for fn in (char_swap, typo_injection, homoglyph_substitution):
+            random.seed(SEED)
+            orig, result = self._roundtrip_checks(CJK_TEXT, fn)
+            assert len(result) == len(orig)
+
+    def test_arabic_roundtrip_all_functions(self):
+        for fn in (char_swap, typo_injection, homoglyph_substitution):
+            random.seed(SEED)
+            orig, result = self._roundtrip_checks(ARABIC_TEXT, fn)
+            assert len(result) == len(orig)
+
+    def test_cyrillic_roundtrip_all_functions(self):
+        for fn in (char_swap, typo_injection, homoglyph_substitution):
+            random.seed(SEED)
+            orig, result = self._roundtrip_checks(CYRILLIC_TEXT, fn)
+            assert len(result) == len(orig)
+
+    def test_devanagari_roundtrip_all_functions(self):
+        for fn in (char_swap, typo_injection, homoglyph_substitution):
+            random.seed(SEED)
+            orig, result = self._roundtrip_checks(DEVANAGARI_TEXT, fn)
+            assert len(result) == len(orig)
+
+    def test_char_delete_never_crashes_non_latin(self):
+        for text in (CJK_TEXT, ARABIC_TEXT, CYRILLIC_TEXT, DEVANAGARI_TEXT):
+            result = char_delete(text, strength=0.5)
+            assert isinstance(result, str)


### PR DESCRIPTION
## Summary
Refactors `distortions/text.py` to be grapheme-cluster-aware (not code-point-based) and adds script-aware `typo_injection` and `homoglyph_substitution` functions with dedicated character maps for Arabic, Cyrillic, CJK, and Devanagari.

## Motivation
The existing character-level distortions (`char_swap`, `char_insert`, `char_delete`, `keyboard_typo`) split text with `list(text)`, which operates on raw Unicode code points. This breaks combining marks (Arabic tashkeel, Devanagari matras, accented Latin letters) apart from their base character, and there was no `typo_injection` or homoglyph substitution capability at all for non-Latin scripts. This limited NightmareNet's applicability to English-only NLP tasks.

Closes #310

## Changes
- `nightmarenet/distortions/text.py`:
  - Added `_graphemes()` helper using `regex.findall(r"\X", text)` (Unicode extended grapheme clusters) and switched `char_swap`, `char_insert`, `char_delete`, and `keyboard_typo` to operate on graphemes instead of raw code points.
  - `char_insert` now draws inserted characters from the same script as the surrounding text (via `char_maps.detect_script`) instead of always inserting ASCII lowercase, so non-Latin text doesn't get random Latin noise spliced in.
  - Added `typo_injection()`: script-aware typo simulation, dispatches to the correct per-script typo map for each grapheme.
  - Added `homoglyph_substitution()`: Unicode confusables-based substitution, using curated per-script confusables tables.
  - `KEYBOARD_ADJACENT` is now an alias for `char_maps.latin.TYPO_MAP` (single source of truth), so existing imports still work.
  - `typo_injection` and `homoglyph_substitution` are registered in `apply_text_distortions`'s `distortion_funcs` dict but intentionally **not** added to `default_config`, to avoid changing existing pipeline output for anyone using the default distortion mix. They're available via a custom `config` dict.
- `nightmarenet/distortions/char_maps/` (new package):
  - `latin.py`, `cyrillic.py`, `arabic.py`, `cjk.py`: `TYPO_MAP` + `CONFUSABLES` tables for each required script.
  - `devanagari.py`: same, added as bonus coverage since the issue's Problem section names Devanagari even though Acceptance Criteria only requires Arabic/Cyrillic/CJK.
  - `__init__.py`: `detect_script()` (Unicode range-based script bucketing), `get_typo_map()`, `get_confusables()`, `is_rtl()`.
- `tests/test_distortions_multilingual.py` (new): grapheme-cluster integrity tests, script detection tests, typo_injection/homoglyph_substitution coverage per script, RTL base-direction preservation tests, and roundtrip validation for Arabic/Cyrillic/CJK/Devanagari.
- `pyproject.toml`: added `regex>=2023.0.0` dependency (stdlib `re` has no `\X` grapheme-cluster support).

## Acceptance Criteria
- [x] `char_swap` works correctly on CJK strings (no broken grapheme clusters)
- [x] `typo_injection` has character maps for Arabic, Cyrillic, and CJK
- [x] Homoglyph substitution uses Unicode confusables for non-Latin (curated subset — see Reviewer Notes)
- [x] RTL text maintains correct directionality after distortion
- [x] Tests cover at least 3 non-Latin scripts with roundtrip validation (Arabic, Cyrillic, CJK, plus Devanagari as bonus)
- [x] Existing Latin-alphabet tests still pass (no regression) — 40/40 pre-existing tests pass unchanged, plus 32 new tests

## Type
- [x] Feature (non-breaking change that adds functionality)
- [x] Tests

---

## Pre-submission Requirements
- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist
- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [ ] `mypy nightmarenet/ --ignore-missing-imports` — not yet run, will confirm
- [x] `pytest tests/` — `test_distortions.py` + `test_distortions_multilingual.py` pass (72/72)
- [x] New functionality has corresponding tests
- [x] Commit messages follow Conventional Commits (`feat:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`)

## Documentation
- [x] Docstrings added/updated (Google style, public APIs only)

## AI Disclosure
- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations
- [x] Not applicable (no security-sensitive changes)

## Breaking Changes
N/A — new functions are additive and opt-in; existing `default_config` behavior is unchanged.

---

<details>
<summary>Reviewer notes</summary>

- The homoglyph confusables tables are a **curated subset**, not a live sync of Unicode's `confusables.txt` — this sandbox/dev environment has no network access to unicode.org. Extending these tables with the full database is a natural follow-up.
- CJK `typo_injection` uses visually/structurally similar Han character confusion rather than keyboard adjacency, since CJK input goes through an IME and has no meaningful "adjacent key" concept. Documented in `char_maps/cjk.py`.
- Arabic `typo_injection` uses dotted-letter confusion (e.g. ب/ت/ث) rather than a guessed keyboard layout, since Arabic keyboard layouts vary significantly by OS/region. Documented in `char_maps/arabic.py`.
- RTL correctness is verified via first-strong-character base direction (Unicode Bidi rule P2/P3) before/after distortion, since Python `str` already preserves logical (not visual) order — the real risk was injecting foreign-script noise that could shift the paragraph's base direction, which `char_insert`'s script-awareness now prevents.
- Devanagari support goes beyond the acceptance criteria's minimum (3 scripts) since the issue's Problem section explicitly names it.
- `typo_injection`/`homoglyph_substitution` are opt-in (not in `default_config`) by design — happy to wire them into the default pipeline mix if that's preferred, just flagging the decision for review.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Unicode-aware text distortions across Latin, Cyrillic, Arabic, CJK, and Devanagari scripts.
  - Added script-appropriate typo injection and homoglyph substitution.
  - Improved character swapping, insertion, and deletion while preserving grapheme clusters and text direction.
  - Added automatic script and right-to-left detection.

- **Bug Fixes**
  - Reduced the risk of breaking combined characters and multilingual text during distortions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->