### PR TITLE
fix: harden badge extraction and restore package import ergonomics

### DIFF
--- a/nightmarenet/__init__.py
+++ b/nightmarenet/__init__.py
@@ -1,20 +1,47 @@
 """NightmareNet: Autonomous AI Self-Improvement Platform."""
 
+from __future__ import annotations
+
+from typing import Any
+
 __version__ = "0.3.1"  # x-release-please-version
 
-try:
-    from nightmarenet.distortions.registry import get_registry as get_registry
-except ImportError:
-    get_registry = None  # type: ignore[assignment]
-
-try:
-    from nightmarenet.evaluation.evaluator import Evaluator as Evaluator
-except ImportError:
-    Evaluator = None  # type: ignore[assignment, misc]
-
-try:
-    from nightmarenet.pipeline import Pipeline as Pipeline
-except ImportError:
-    Pipeline = None  # type: ignore[assignment, misc]
-
 __all__ = ["Pipeline", "Evaluator", "get_registry", "__version__"]
+
+_LAZY_EXPORTS = frozenset({"Pipeline", "Evaluator", "get_registry"})
+
+_INSTALL_HINT = (
+    "Install NightmareNet with its dependencies, e.g. "
+    "`pip install nightmarenet` (add extras such as `[api]` as needed)."
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy-import public exports so missing deps raise a clear ImportError."""
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    try:
+        if name == "Pipeline":
+            from nightmarenet.pipeline import Pipeline as _Pipeline
+
+            globals()["Pipeline"] = _Pipeline
+            return _Pipeline
+        if name == "Evaluator":
+            from nightmarenet.evaluation.evaluator import Evaluator as _Evaluator
+
+            globals()["Evaluator"] = _Evaluator
+            return _Evaluator
+        # name == "get_registry"
+        from nightmarenet.distortions.registry import get_registry as _get_registry
+
+        globals()["get_registry"] = _get_registry
+        return _get_registry
+    except ImportError as exc:
+        raise ImportError(
+            f"Cannot import {name!r} from nightmarenet: {exc}. {_INSTALL_HINT}"
+        ) from exc
+
+
+def __dir__() -> list[str]:
+    return sorted(list(__all__))

--- a/nightmarenet/api/badge.py
+++ b/nightmarenet/api/badge.py
@@ -141,11 +141,15 @@ def _extract_robustness_score(run: dict) -> Optional[float]:
 
     comparison = run.get("comparison") or metrics.get("comparison") or {}
     if isinstance(comparison, dict):
-        rob_metric = comparison.get("metrics", {}).get("robustness", {})
+        # Explicit None nested values break `.get("k", {}).get(...)` — use `or {}`.
+        comparison_metrics = comparison.get("metrics") or {}
+        rob_metric = comparison_metrics.get("robustness") or {}
         if isinstance(rob_metric, dict):
-            auc = rob_metric.get("trained", {}).get("auc_robustness")
-            if isinstance(auc, (int, float)) and not isinstance(auc, bool):
-                return float(auc)
+            trained = rob_metric.get("trained") or {}
+            if isinstance(trained, dict):
+                auc = trained.get("auc_robustness")
+                if isinstance(auc, (int, float)) and not isinstance(auc, bool):
+                    return float(auc)
         for key in ("trained_auc", "auc_robustness", "robustness_score"):
             auc = comparison.get(key)
             if isinstance(auc, (int, float)) and not isinstance(auc, bool):
@@ -153,7 +157,7 @@ def _extract_robustness_score(run: dict) -> Optional[float]:
 
     trained_res = run.get("trained_results") or metrics.get("trained_results") or {}
     if isinstance(trained_res, dict):
-        rob_res = trained_res.get("robustness", {})
+        rob_res = trained_res.get("robustness") or {}
         if isinstance(rob_res, dict):
             auc = rob_res.get("auc_robustness") or rob_res.get("score")
             if isinstance(auc, (int, float)) and not isinstance(auc, bool):
@@ -199,7 +203,15 @@ async def latest_badge_svg() -> Response:
 
     score: Optional[float] = None
     for run in completed_runs:
-        s = _extract_robustness_score(run)
+        try:
+            s = _extract_robustness_score(run)
+        except Exception as e:
+            logger.warning(
+                "Failed to extract robustness score from run %s: %s",
+                run.get("run_id", "<unknown>"),
+                e,
+            )
+            continue
         if s is not None:
             score = s
             break

--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -18,7 +18,7 @@ Usage:
 
 import importlib.metadata
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 try:
     import torch
@@ -28,7 +28,16 @@ except ImportError:
 from nightmarenet.distortions.base import BaseDistortion
 
 DistortionFn = Callable[[str, float, Optional[int]], str]
-VisionDistortionFn = Callable[..., Any]
+
+if TYPE_CHECKING:
+    import torch as _torch
+
+    VisionDistortionFn = Callable[[_torch.Tensor, float, Optional[int]], _torch.Tensor]
+    VisionApplyReturn = _torch.Tensor
+else:
+    # Runtime: keep flexible when torch is optional / missing at import time.
+    VisionDistortionFn = Callable[..., Any]
+    VisionApplyReturn = Any
 
 logger = logging.getLogger(__name__)
 
@@ -318,7 +327,7 @@ class VisionDistortionRegistry:
         image: Any,
         strength: float = 0.3,
         seed: Optional[int] = None,
-    ) -> Any:
+    ) -> VisionApplyReturn:
         """Apply a named vision distortion to an image tensor."""
         if name not in self._engines:
             available = ", ".join(sorted(self._engines.keys()))

--- a/tests/test_api_badge.py
+++ b/tests/test_api_badge.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import time
 import xml.etree.ElementTree as ET
 
@@ -149,3 +150,36 @@ class TestLatestBadgeSvg:
         monkeypatch.setenv("NIGHTMARENET_API_KEY", "rk_test_key_123")
         r = client.get("/api/v1/badge/latest.svg")
         assert r.status_code == 200
+
+    def test_latest_svg_none_comparison_metrics_no_crash(self):
+        """Explicit None nested metrics must yield 'no data', not HTTP 500.
+
+        Regression for issue #443: ``comparison.get("metrics", {}).get(...)``
+        crashes when ``metrics`` is present but ``None``.
+        """
+        from nightmarenet.api.badge import _extract_robustness_score
+
+        assert (
+            _extract_robustness_score({"status": "complete", "comparison": {"metrics": None}})
+            is None
+        )
+
+        now = time.time()
+        pr._persist_run_state("run-none-metrics", {}, "running", now)
+        pr._update_run_state("run-none-metrics", "complete", now, metrics={})
+
+        # Inject the None-shaped comparison payload the extractor must tolerate.
+        runs_dir = pr._get_runs_dir()
+        run_file = runs_dir / "run-none-metrics.json"
+        with open(run_file, encoding="utf-8") as fh:
+            state = json.load(fh)
+        state["comparison"] = {"metrics": None}
+        with open(run_file, "w", encoding="utf-8") as fh:
+            json.dump(state, fh)
+
+        r = client.get("/api/v1/badge/latest.svg")
+        assert r.status_code == 200
+        body = r.text
+        assert "no data" in body
+        assert "#9f9f9f" in body
+        ET.fromstring(body)


### PR DESCRIPTION
## Summary
- None-safe robustness extraction in `badge.py` (`or {}` instead of `.get(k, {}).get(...)`)
- Wrap `_extract_robustness_score` in try/except inside `latest_badge_svg`
- Lazy `__getattr__` exports in `nightmarenet/__init__.py` (descriptive ImportError, not `None`)
- Restore `VisionDistortionFn` precision via `TYPE_CHECKING` in `registry.py`
- Regression test: `comparison: {"metrics": None}` → `"no data"` badge, not 500
Closes #443
## Test plan
- [ ] `pytest tests/test_api_badge.py -q`
- [ ] Confirm `from nightmarenet import get_registry` still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved badge generation so malformed or incomplete run metrics no longer prevent the latest badge from loading.
  * Added clearer error handling when optional features cannot be loaded.
* **Improvements**
  * Enhanced compatibility for environments where optional vision dependencies are unavailable.
  * Improved type information for vision distortion results.
* **Tests**
  * Added coverage for badge responses when comparison metrics are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->