### PR TITLE
infra: add API load testing with k6 in nightly workflow

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -33,9 +33,9 @@ jobs:
           timeout 30s bash -c 'until curl -s http://127.0.0.1:8000/api/v1/health | grep -q "ok"; do sleep 1; done'
 
       - name: Run k6 Load Test
-        uses: grafana/k6-action@v0.5.0
+        uses: grafana/run-k6-action@v1
         with:
-          filename: scripts/loadtest.js
+          path: scripts/loadtest.js
         env:
           BASE_URL: http://127.0.0.1:8000
 

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -1,0 +1,47 @@
+name: API Load Test
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Run at 3:00 AM UTC every day
+  workflow_dispatch:      # Allow manual triggering
+
+jobs:
+  load-test:
+    name: Run k6 API Load Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install API dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,api]"
+
+      - name: Start API Server
+        run: |
+          RATELIMIT_ENABLED=false uvicorn nightmarenet.api.app:app --host 127.0.0.1 --port 8000 &
+          timeout 30s bash -c 'until curl -s http://127.0.0.1:8000/api/v1/health | grep -q "ok"; do sleep 1; done'
+
+      - name: Run k6 Load Test
+        uses: grafana/k6-action@v0.5.0
+        with:
+          filename: scripts/loadtest.js
+        env:
+          BASE_URL: http://127.0.0.1:8000
+
+      - name: Upload load test results artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: loadtest-results
+          path: loadtest-results.json

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2689,7 +2689,7 @@
                 }
               }
             },
-            "description": "Unprocessable Entity"
+            "description": "Unprocessable Content"
           },
           "500": {
             "content": {
@@ -3291,7 +3291,7 @@
                 }
               }
             },
-            "description": "Request Entity Too Large"
+            "description": "Content Too Large"
           },
           "422": {
             "content": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2689,7 +2689,7 @@
                 }
               }
             },
-            "description": "Unprocessable Content"
+            "description": "Unprocessable Entity"
           },
           "500": {
             "content": {
@@ -3291,7 +3291,7 @@
                 }
               }
             },
-            "description": "Content Too Large"
+            "description": "Request Entity Too Large"
           },
           "422": {
             "content": {

--- a/frontend/src/tests/ExperimentList.test.tsx
+++ b/frontend/src/tests/ExperimentList.test.tsx
@@ -31,7 +31,7 @@ vi.mock("@/components/ui/Toast", () => ({
 
 // Mock API
 vi.mock("@/lib/api", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = (await importOriginal()) as Record<string, any>;
   return {
     ...actual,
     deleteExperiment: vi.fn(),
@@ -154,7 +154,7 @@ describe("ExperimentList Row Actions", () => {
   });
 
   it("Confirm delete calls deleteExperiment(id) and shows success toast", async () => {
-    vi.mocked(api.deleteExperiment).mockResolvedValueOnce(undefined);
+    vi.mocked(api.deleteExperiment).mockResolvedValueOnce({ id: "exp_123", message: "Deleted" } as any);
     render(<ExperimentList experiments={mockExperiments} />);
     openMenu("test-experiment");
 

--- a/frontend/src/tests/retryLazy.test.ts
+++ b/frontend/src/tests/retryLazy.test.ts
@@ -4,10 +4,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { retryLazy } from "../lib/retryLazy";
 
 class TestErrorBoundary extends React.Component<
-  { children: React.ReactNode; fallback?: React.ReactNode },
+  { children?: React.ReactNode; fallback?: React.ReactNode },
   { hasError: boolean; error: Error | null }
 > {
-  constructor(props: { children: React.ReactNode; fallback?: React.ReactNode }) {
+  constructor(props: { children?: React.ReactNode; fallback?: React.ReactNode }) {
     super(props);
     this.state = { hasError: false, error: null };
   }

--- a/frontend/src/tests/retryLazy.test.ts
+++ b/frontend/src/tests/retryLazy.test.ts
@@ -108,12 +108,12 @@ describe("retryLazy", () => {
         TestErrorBoundary,
         {
           fallback: React.createElement("div", null, "Boundary caught: Permanent CDN Failure"),
-          children: React.createElement(
-            Suspense,
-            { fallback: React.createElement("div", null, "Loading...") },
-            React.createElement(LazyPanel),
-          ),
         },
+        React.createElement(
+          Suspense,
+          { fallback: React.createElement("div", null, "Loading...") },
+          React.createElement(LazyPanel),
+        ),
       ),
     );
 

--- a/nightmarenet/api/app.py
+++ b/nightmarenet/api/app.py
@@ -149,7 +149,8 @@ async def telemetry_middleware(request: Request, call_next):
 
 
 # --- Rate limiting ---
-limiter = Limiter(key_func=get_remote_address)
+_rate_limit_enabled = os.environ.get("RATELIMIT_ENABLED", "true").lower() not in ("false", "0", "off", "no")
+limiter = Limiter(key_func=get_remote_address, enabled=_rate_limit_enabled)
 app.state.limiter = limiter
 app.add_middleware(SlowAPIMiddleware)  # type: ignore[arg-type]
 

--- a/nightmarenet/api/app.py
+++ b/nightmarenet/api/app.py
@@ -175,9 +175,7 @@ app.add_middleware(APIKeyMiddleware)  # type: ignore[arg-type]
 
 # --- CORS ---
 _cors_origins = [
-    o.strip()
-    for o in os.environ.get("NIGHTMARENET_CORS_ORIGINS", "").split(",")
-    if o.strip()
+    o.strip() for o in os.environ.get("NIGHTMARENET_CORS_ORIGINS", "").split(",") if o.strip()
 ]
 if not _cors_origins:
     logger.warning(
@@ -417,18 +415,16 @@ async def evaluate_robustness(
             }
             scores["nightmare"][str(strength)] = {
                 "similarity": round(_char_similarity(body.text, nightmare_result), 4),
-                "length_ratio": round(
-                    len(nightmare_result) / max(len(body.text), 1), 4
-                ),
+                "length_ratio": round(len(nightmare_result) / max(len(body.text), 1), 4),
             }
 
         # Summary
         avg_dream_sim = sum(v["similarity"] for v in scores["dream"].values()) / max(
             len(scores["dream"]), 1
         )
-        avg_nightmare_sim = sum(
-            v["similarity"] for v in scores["nightmare"].values()
-        ) / max(len(scores["nightmare"]), 1)
+        avg_nightmare_sim = sum(v["similarity"] for v in scores["nightmare"].values()) / max(
+            len(scores["nightmare"]), 1
+        )
 
         summary = (
             f"Dream avg similarity: {avg_dream_sim:.2%}, "
@@ -678,17 +674,11 @@ async def compare_distortions(
         seed = body.seed
 
         # Baseline distortions
-        dream_base = _apply_dream_distortions(
-            body.text, body.baseline_strength, seed=seed
-        )
-        nightmare_base = _apply_nightmare_distortions(
-            body.text, body.baseline_strength, seed=seed
-        )
+        dream_base = _apply_dream_distortions(body.text, body.baseline_strength, seed=seed)
+        nightmare_base = _apply_nightmare_distortions(body.text, body.baseline_strength, seed=seed)
 
         # Challenge distortions
-        dream_challenge = _apply_dream_distortions(
-            body.text, body.challenge_strength, seed=seed
-        )
+        dream_challenge = _apply_dream_distortions(body.text, body.challenge_strength, seed=seed)
         nightmare_challenge = _apply_nightmare_distortions(
             body.text, body.challenge_strength, seed=seed
         )
@@ -711,13 +701,11 @@ async def compare_distortions(
 
         # Resilience = how much similarity drops between baseline and challenge
         dream_drop = max(
-            dream_details["baseline"].similarity
-            - dream_details["challenge"].similarity,
+            dream_details["baseline"].similarity - dream_details["challenge"].similarity,
             0.0,
         )
         nightmare_drop = max(
-            nightmare_details["baseline"].similarity
-            - nightmare_details["challenge"].similarity,
+            nightmare_details["baseline"].similarity - nightmare_details["challenge"].similarity,
             0.0,
         )
         avg_drop = (dream_drop + nightmare_drop) / 2
@@ -782,9 +770,7 @@ async def interactive_demo(
         nightmare_strength = 0.80
         # keep the existing function body below unchanged
 
-        dream_result = _apply_dream_distortions(
-            body.text, dream_strength, seed=body.seed
-        )
+        dream_result = _apply_dream_distortions(body.text, dream_strength, seed=body.seed)
         nightmare_result = _apply_nightmare_distortions(
             body.text, nightmare_strength, seed=body.seed
         )
@@ -1147,9 +1133,7 @@ app.include_router(router)
 async def list_runs(
     request: Request,
     offset: int = Query(0, ge=0, description="Number of runs to skip"),
-    limit: int = Query(
-        50, ge=1, le=200, description="Maximum number of runs to return"
-    ),
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of runs to return"),
 ):
     """List all pipeline runs with pagination support.
 

--- a/nightmarenet/api/app.py
+++ b/nightmarenet/api/app.py
@@ -149,7 +149,12 @@ async def telemetry_middleware(request: Request, call_next):
 
 
 # --- Rate limiting ---
-_rate_limit_enabled = os.environ.get("RATELIMIT_ENABLED", "true").lower() not in ("false", "0", "off", "no")
+_rate_limit_enabled = os.environ.get("RATELIMIT_ENABLED", "true").lower() not in (
+    "false",
+    "0",
+    "off",
+    "no",
+)
 limiter = Limiter(key_func=get_remote_address, enabled=_rate_limit_enabled)
 app.state.limiter = limiter
 app.add_middleware(SlowAPIMiddleware)  # type: ignore[arg-type]

--- a/scripts/loadtest.js
+++ b/scripts/loadtest.js
@@ -1,0 +1,53 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '60s',
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || __ENV.TARGET_URL || 'http://127.0.0.1:8000';
+const API_KEY = __ENV.API_KEY || '';
+
+export default function () {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (API_KEY) {
+    headers['X-API-Key'] = API_KEY;
+  }
+
+  // 1. Health Endpoint
+  const healthRes = http.get(`${BASE_URL}/api/v1/health`, { headers });
+  check(healthRes, {
+    'health status is 200': (r) => r.status === 200,
+  });
+
+  // 2. Distortion Generation Endpoint
+  const dreamPayload = JSON.stringify({
+    text: 'Load testing NightmareNet API endpoint for latency and stability verification.',
+    strength: 0.3,
+  });
+  const dreamRes = http.post(`${BASE_URL}/api/v1/generate/dream`, dreamPayload, { headers });
+  check(dreamRes, {
+    'dream distortion status is 200': (r) => r.status === 200,
+  });
+
+  // 3. Pipeline List Endpoint
+  const pipelineRes = http.get(`${BASE_URL}/api/v1/pipeline/runs`, { headers });
+  check(pipelineRes, {
+    'pipeline runs status is 200': (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+}
+
+export function handleSummary(data) {
+  return {
+    'loadtest-results.json': JSON.stringify(data, null, 2),
+  };
+}


### PR DESCRIPTION
## Problem
No load testing exists for the API. Under concurrent users, unknown bottlenecks (GIL contention, DB pool exhaustion, memory leaks) may cause degraded service. The nightly workflow should include a basic load test to catch regressions.

## Proposed Solution
- Added a k6 load test script (`scripts/loadtest.js`) configured with 10 Virtual Users (VUs) and a 60s duration.
- Added a nightly GitHub Actions workflow (`.github/workflows/loadtest.yml`) running at 03:00 UTC and on-demand via `workflow_dispatch`.
- Enforced latency and reliability gates: `p95 latency < 2000ms` (`http_req_duration: ['p(95)<2000']`) and `error rate < 5%` (`http_req_failed: ['rate<0.05']`).
- Exercises key endpoints: `GET /api/v1/health`, `POST /api/v1/generate/dream`, and `GET /api/v1/pipeline/runs`.
- Uploads execution results (`loadtest-results.json`) as a workflow artifact.
- Updated `nightmarenet/api/app.py` to respect the `RATELIMIT_ENABLED` environment variable for rate-limit opt-out during automated load tests.

## Acceptance Criteria Checklist
- -[x] New `.github/workflows/loadtest.yml` running nightly (or on-demand)
- -[x] Uses k6 script (`scripts/loadtest.js`, 10 VUs, 60s duration)
-- [x] Tests: health endpoint, distortion generation, pipeline list
- -[x] Reports p95 latency and error rate
- -[x] Fails if p95 > 2000ms or error rate > 5%
- -[x] Results uploaded as workflow artifact

## AI-Assitance Code Disclosure
This PR indulges AI-assistance in code. All lines have been reviewed and verified.

## Notes
Closes #533



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API load-testing script that exercises health checks, dream generation, and pipeline runs with defined success/failure thresholds.

- **Tests**
  - Automates load testing and saves results to a `loadtest-results.json` artifact.
  - Updated frontend tests for optional boundary children typing and async API mocking behavior.

- **Chores**
  - Added a scheduled (daily) and manually triggerable workflow to run the load test against a local API instance and upload results.

- **Improvements**
  - Made API rate limiting configurable via environment variable (enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->