### PR TITLE
test: benchmark gradient vs attention learned adversarial strategy (#285)

### DIFF
--- a/artifacts/learned-adversarial-benchmark.json
+++ b/artifacts/learned-adversarial-benchmark.json
@@ -1,0 +1,29 @@
+{
+  "model": "distilbert-base-uncased",
+  "device": "cpu",
+  "strength": 0.7,
+  "seed": 42,
+  "repeats": 3,
+  "attention": {
+    "strategy": "attention",
+    "samples": 24,
+    "mean_seconds_per_sample": 0.17897420000493489,
+    "median_seconds_per_sample": 0.17271374999836553,
+    "mean_target_loss_before": 2.7623345851898193,
+    "mean_target_loss_after": 3.0809443593025208,
+    "mean_target_loss_increase": 0.3186097741127014,
+    "changed_outputs": 24
+  },
+  "gradient": {
+    "strategy": "gradient",
+    "samples": 24,
+    "mean_seconds_per_sample": 0.1268412583352377,
+    "median_seconds_per_sample": 0.12643950000347104,
+    "mean_target_loss_before": 2.7623345851898193,
+    "mean_target_loss_after": 3.7494081258773804,
+    "mean_target_loss_increase": 0.987073540687561,
+    "changed_outputs": 24
+  },
+  "gradient_to_attention_slowdown": 0.7087125313689923,
+  "within_requested_3x_budget": true
+}

--- a/docs/research/model-aware-learned-adversarial.md
+++ b/docs/research/model-aware-learned-adversarial.md
@@ -107,3 +107,25 @@ one-cycle experiments with `learned: 0.3`, changing only `learned_strategy` betw
 
 Do not report projected values as measured results. Attach the generated config
 files and raw metric artifacts so the experiment is reproducible.
+
+## Microbenchmark Results (CPU — Preliminary)
+
+> **Note:** These results were collected on CPU only. GPU benchmarks are pending
+> and may show different relative performance between strategies.
+
+**Setup:** `distilbert-base-uncased`, strength 0.7, seed 42, 3 repeats, 24 samples.
+
+| Metric | Attention | Gradient |
+|--------|-----------|----------|
+| Mean latency (s/sample) | 0.179 | 0.127 |
+| Median latency (s/sample) | 0.173 | 0.126 |
+| Mean loss before | 2.762 | 2.762 |
+| Mean loss after | 3.081 | 3.749 |
+| **Mean loss increase** | **0.319** | **0.987** |
+| Changed outputs | 24/24 | 24/24 |
+
+**Gradient-to-attention slowdown ratio:** 0.71x (gradient is *faster* on CPU).
+Within the requested 3x budget: **yes**.
+
+The gradient strategy produces ~3x larger loss increases than attention while
+running ~30% faster on CPU. Raw data: `artifacts/learned-adversarial-benchmark.json`.


### PR DESCRIPTION
## Summary
Benchmarks the gradient-based learned adversarial strategy against the
attention baseline for latency and attack effectiveness, per issue #285.

## Motivation
PR #279 added the gradient-based learned adversarial generator, but it
hadn't been benchmarked against the existing attention strategy for
speed or effectiveness. This validates it before broader adoption.

## Changes
- `artifacts/learned-adversarial-benchmark.json`: microbenchmark output
  (distilbert-base-uncased, strength=0.7, 3 repeats, CPU)
- TODO: robustness comparison configs + results once training runs complete

## Acceptance Criteria
- [x] Microbenchmark run with `--enforce-slowdown`, gradient stays within
      3x latency budget of attention (measured: ~0.71x — gradient is
      actually faster on CPU)
- [ ] TODO: full one-cycle training comparison (attention vs gradient)
      with clean accuracy, robustness sweep, training time, peak memory
- [ ] TODO: `docs/research/model-aware-learned-adversarial.md` updated
      with real numbers

## Type
- [x] Tests

## Pre-submission Requirements
- [ ] Starred repo
- [ ] Followed @Adit-Jain-srm
- [x] Read CONTRIBUTING.md

## Quality Checklist
- [x] `ruff check` — 0 errors
- [x] `mypy` — no new errors
- [x] `pytest tests/` — all pass (895 passed, 23 skipped)
- [ ] New functionality has corresponding tests — N/A, benchmark script only

## Documentation
- [ ] `docs/` updated — pending robustness comparison results

## AI Disclosure
- [ ] This PR includes AI-assisted code — I have reviewed every line and can explain it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for optional random seeds when configuring and rerunning pipelines, enabling more consistent results.
  - Rerun requests now preserve the selected seed when provided.

- **Bug Fixes**
  - Prevented duplicate rerun submissions while a rerun is in progress.
  - Preset controls are temporarily disabled and visually dimmed during reruns.
  - Added benchmark results covering CPU adversarial evaluation performance and budget compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->