### PR TITLE
refactor(api): remove unused pipeline stub schemas

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2599,7 +2599,7 @@
                 }
               }
             },
-            "description": "Unprocessable Entity"
+            "description": "Unprocessable Content"
           },
           "500": {
             "content": {
@@ -3069,7 +3069,7 @@
                 }
               }
             },
-            "description": "Request Entity Too Large"
+            "description": "Content Too Large"
           },
           "422": {
             "content": {

--- a/nightmarenet/api/schemas.py
+++ b/nightmarenet/api/schemas.py
@@ -374,34 +374,6 @@ class TestWebhookRequest(BaseModel):
     )
 
 
-class PipelineTrainRequest(BaseModel):
-    """Request body for training a pipeline."""
-
-    config: dict[str, Any] = Field(..., description="Training config")
-    model_name: str = Field(default="gpt2", description="Model to train")
-    cycles: int = Field(default=1, ge=1, le=100)
-
-
-class PipelineEvaluateRequest(BaseModel):
-    """Request body for evaluating a pipeline."""
-
-    config: dict[str, Any] = Field(..., description="Evaluation config")
-    model_name: str = Field(default="gpt2", description="Model to evaluate")
-
-
-class PipelineCancelRequest(BaseModel):
-    """Request body for cancelling a pipeline run."""
-
-    pipeline_id: str = Field(..., description="ID of the pipeline to cancel")
-    force: bool = Field(default=False, description="Force cancellation")
-
-
-class SettingsWebhooksRequest(BaseModel):
-    """Request body for updating webhook settings."""
-
-    webhooks: list[WebhookConfigSchema] = Field(..., description="List of webhook configurations")
-
-
 class WebhookTestResponse(BaseModel):
     """Response for testing webhooks, preserving legacy contract."""
 


### PR DESCRIPTION
## Summary

Removes unused pipeline stub Pydantic request schemas that remained after the corresponding API endpoints were removed.

Closes #605

## Changes

- Removed `PipelineTrainRequest`
- Removed `PipelineEvaluateRequest`
- Removed `PipelineCancelRequest`
- Removed `SettingsWebhooksRequest`
- Regenerated `docs/api/openapi.json`
- Verified there are no remaining references to these schemas

## Validation

- [x] Verified the removed schemas had no remaining consumers
- [x] Regenerated the OpenAPI specification
- [x] Ran `ruff check nightmarenet/`
- [x] Ran project tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API error descriptions to use the standardized terms “Unprocessable Content” and “Content Too Large.”

* **API Changes**
  * Removed support for several legacy pipeline and webhook request schemas. Integrations relying on these deprecated request formats may need to migrate to the current API contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->