### PR TITLE
refactor(scripts): extract BASELINE_WAKE_EPOCHS constant and add multi-cycle baseline test

### DIFF
--- a/scripts/compute_cost_analysis.py
+++ b/scripts/compute_cost_analysis.py
@@ -21,6 +21,8 @@ from nightmarenet.utils.config import load_config
 
 # FLOP estimates per sample per epoch (approximate, model-dependent)
 # These are reasonable estimates for common transformer models
+BASELINE_WAKE_EPOCHS = 3
+
 FLOPS_PER_SAMPLE_PER_EPOCH = {
     "distilbert-base-uncased": 2.5e12,  # ~2.5 trillion FLOPs
     "distilgpt2": 1.2e12,  # ~1.2 trillion FLOPs
@@ -183,11 +185,11 @@ def calculate_total_flops(
     total_flops = cycle_flops["total"] * num_cycles
 
     # Calculate baseline (standard fine-tuning equivalent)
-    # Standard FT: 1 cycle, 3 wake epochs, 0 dream, 0 nightmare, 0 compress
+    # Standard FT: 1 cycle, BASELINE_WAKE_EPOCHS wake epochs, 0 dream, 0 nightmare, 0 compress
     baseline_cycle_flops = calculate_cycle_flops(
         model_name,
         num_samples,
-        wake_epochs=3,  # Typical fine-tuning epochs
+        wake_epochs=BASELINE_WAKE_EPOCHS,  # Typical fine-tuning epochs
         dream_epochs=0,
         nightmare_epochs=0,
         compression_rounds=0,
@@ -282,7 +284,7 @@ def print_analysis(analysis: dict) -> None:
     print()
     print("TOTAL FLOPS")
     print(f"  NightmareNet (total): {format_flops(total['nightmarenet'])}")
-    print(f"  Baseline (3 epoch FT): {format_flops(total['baseline'])}")
+    print(f"  Baseline ({BASELINE_WAKE_EPOCHS} epoch FT): {format_flops(total['baseline'])}")
     print()
     print("COMPARISON")
     print(f"  NightmareNet vs Baseline: {comparison['nightmarenet_vs_baseline']:.2f}x")

--- a/tests/test_compute_cost_analysis.py
+++ b/tests/test_compute_cost_analysis.py
@@ -1,6 +1,7 @@
 """Tests for compute_cost_analysis module."""
 
 from scripts.compute_cost_analysis import (
+    BASELINE_WAKE_EPOCHS,
     calculate_cycle_flops,
     calculate_phase_flops,
     calculate_total_flops,
@@ -190,10 +191,28 @@ class TestCalculateTotalFlops:
             flops_per_sample=2.5e12,
         )
 
-        # Baseline: 3 wake epochs only = 2.5e12 * 500 * 3 = 3.75e15
+        # Baseline: BASELINE_WAKE_EPOCHS wake epochs only = 2.5e12 * 500 * 3 = 3.75e15
         expected_baseline = 3.75e15
         assert result["total"]["baseline"] == expected_baseline
         assert result["comparison"]["nightmarenet_vs_baseline"] > 1
+
+    def test_baseline_multi_cycle_scaling(self):
+        """Test baseline scaling semantics when num_cycles > 1."""
+        num_cycles = 4
+        num_samples = 500
+        result = calculate_total_flops(
+            model_name="distilbert-base-uncased",
+            num_samples=num_samples,
+            num_cycles=num_cycles,
+            wake_epochs=3,
+            dream_epochs=2,
+            nightmare_epochs=1,
+            compression_rounds=1,
+            flops_per_sample=2.5e12,
+        )
+
+        single_cycle_baseline = 2.5e12 * num_samples * BASELINE_WAKE_EPOCHS
+        assert result["total"]["baseline"] == single_cycle_baseline * num_cycles
 
     def test_cycle_total_matches_sum(self):
         """Test that cycle_total == sum(phases)."""


### PR DESCRIPTION

### Summary
Extracts the hardcoded baseline fine-tuning wake epoch count in `scripts/compute_cost_analysis.py` into a top-level constant `BASELINE_WAKE_EPOCHS = 3`. Replaces magic numbers in both `calculate_total_flops()` baseline calculations and the `print_analysis()` display label. Also adds unit test coverage for multi-cycle baseline scaling semantics (`num_cycles > 1`) in `tests/test_compute_cost_analysis.py`.

### Linked Issue
Fixes #637

### Acceptance Criteria Checklist
- [x] `BASELINE_WAKE_EPOCHS` constant defined at module level in `scripts/compute_cost_analysis.py`
- [x] Constant used in both `calculate_total_flops()` baseline calculation and `print_analysis()` output label
- [x] Added unit test `test_baseline_multi_cycle_scaling` for `num_cycles > 1` in `tests/test_compute_cost_analysis.py`
- [x] Verified `nightmarenet/distortions/registry.py` typing cleanly matches main branch requirements

### Changes Made
- Modified `scripts/compute_cost_analysis.py`:
  - Extracted `BASELINE_WAKE_EPOCHS = 3` at module level.
  - Used `BASELINE_WAKE_EPOCHS` in `calculate_total_flops()` baseline calculation call.
  - Interpolated `{BASELINE_WAKE_EPOCHS}` in `print_analysis()` display header label.
- Modified `tests/test_compute_cost_analysis.py`:
  - Imported `BASELINE_WAKE_EPOCHS`.
  - Added `test_baseline_multi_cycle_scaling` test case to `TestCalculateTotalFlops`.

### Pre-submission & Quality Checklist
- [x] I am assigned to linked issue #637
- [x] All pytest unit tests pass cleanly (`26 passed in 1.31s`)
- [x] AI usage disclosure: AI-assisted development reviewed and validated line-by-line
