### PR TITLE
test: add RobustnessRadar coverage for axes and empty state

### DIFF
--- a/frontend/src/__tests__/RobustnessRadar.test.tsx
+++ b/frontend/src/__tests__/RobustnessRadar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 
 vi.mock("framer-motion", () => {
@@ -11,7 +11,15 @@ vi.mock("framer-motion", () => {
       void transition;
       return React.createElement(tag, rest, children as React.ReactNode);
     };
-  return { motion: new Proxy({}, { get: (_t, p: string) => mock(p) }) };
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, property: string | symbol) =>
+          typeof property === "string" ? mock(property) : undefined,
+      },
+    ),
+  };
 });
 
 vi.mock("@/lib/hooks", () => ({
@@ -28,8 +36,12 @@ const mockSeries = [
 describe("RobustnessRadar", () => {
   it("renders with mock robustness data across multiple axes", () => {
     render(<RobustnessRadar series={mockSeries} />);
+    const chart = screen.getByRole("group", { name: "Robustness radar" });
+
     expect(screen.getByText("Robustness Radar")).toBeInTheDocument();
-    expect(screen.getByLabelText("Robustness radar")).toBeInTheDocument();
+    expect(chart).toBeInTheDocument();
+    expect(chart.querySelector('polygon[fill="#22c55e"]')).not.toBeNull();
+    expect(chart.querySelector('polygon[fill="#ef4444"]')).not.toBeNull();
     expect(screen.getByText("Hardened")).toBeInTheDocument();
     expect(screen.getByText("Baseline")).toBeInTheDocument();
     expect(screen.getByText("86")).toBeInTheDocument();
@@ -45,8 +57,9 @@ describe("RobustnessRadar", () => {
 
   it("labels axes with the distortion type names", () => {
     render(<RobustnessRadar series={mockSeries} />);
+    const chart = screen.getByRole("group", { name: "Robustness radar" });
     for (const label of ["Character", "Word", "Semantic", "Syntactic", "Attacks"]) {
-      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+      expect(within(chart).getByText(label)).toBeInTheDocument();
     }
   });
 });

--- a/frontend/src/__tests__/RobustnessRadar.test.tsx
+++ b/frontend/src/__tests__/RobustnessRadar.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("framer-motion", () => {
+  const mock = (tag: string) =>
+    function Motion(props: Record<string, unknown>) {
+      const { children, initial, animate, transition, ...rest } = props;
+      void initial;
+      void animate;
+      void transition;
+      return React.createElement(tag, rest, children as React.ReactNode);
+    };
+  return { motion: new Proxy({}, { get: (_t, p: string) => mock(p) }) };
+});
+
+vi.mock("@/lib/hooks", () => ({
+  useDemoMode: () => ({ isLive: false, isLoading: false }),
+}));
+
+import { RobustnessRadar } from "@/components/dashboard/RobustnessRadar";
+
+const mockSeries = [
+  { label: "Hardened", color: "#22c55e", values: [86, 81, 84, 79, 72] },
+  { label: "Baseline", color: "#ef4444", values: [62, 58, 71, 65, 41] },
+];
+
+describe("RobustnessRadar", () => {
+  it("renders with mock robustness data across multiple axes", () => {
+    render(<RobustnessRadar series={mockSeries} />);
+    expect(screen.getByText("Robustness Radar")).toBeInTheDocument();
+    expect(screen.getByLabelText("Robustness radar")).toBeInTheDocument();
+    expect(screen.getByText("Hardened")).toBeInTheDocument();
+    expect(screen.getByText("Baseline")).toBeInTheDocument();
+    expect(screen.getByText("86")).toBeInTheDocument();
+    expect(screen.getByText("62")).toBeInTheDocument();
+  });
+
+  it("shows empty state when there is no evaluation data", () => {
+    render(<RobustnessRadar series={[]} />);
+    expect(screen.getByText("No evaluation data")).toBeInTheDocument();
+    expect(screen.getByText(/no robustness metrics to display/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Robustness radar")).not.toBeInTheDocument();
+  });
+
+  it("labels axes with the distortion type names", () => {
+    render(<RobustnessRadar series={mockSeries} />);
+    for (const label of ["Character", "Word", "Semantic", "Syntactic", "Attacks"]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/frontend/src/components/dashboard/RobustnessRadar.tsx
+++ b/frontend/src/components/dashboard/RobustnessRadar.tsx
@@ -21,14 +21,25 @@ interface RadarSeries {
   values: number[];
 }
 
-const SERIES: RadarSeries[] = [
+type RadarComparison = readonly [RadarSeries, RadarSeries];
+
+const SERIES: RadarComparison = [
   { label: "Hardened", color: "var(--color-success)", values: [86, 81, 84, 79, 72] },
   { label: "Baseline", color: "var(--color-nightmare)", values: [62, 58, 71, 65, 41] },
 ];
 
-export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } = {}) {
+function isRadarComparison(series: readonly RadarSeries[]): series is RadarComparison {
+  return (
+    series.length === 2 &&
+    series[0].values.length === AXES.length &&
+    series[1].values.length === AXES.length
+  );
+}
+
+export function RobustnessRadar({ series = SERIES }: { series?: readonly RadarSeries[] } = {}) {
   const { isLive } = useDemoMode();
-  const hasEvaluationData = series.length >= 2;
+  const comparison = isRadarComparison(series) ? series : null;
+  const hasEvaluationData = comparison !== null;
   const size = 280;
   const cx = size / 2;
   const cy = size / 2;
@@ -58,7 +69,7 @@ export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } 
         ) : undefined
       }
     >
-      {!hasEvaluationData ? (
+      {!comparison ? (
         <EmptyState
           icon={<IconRadar size={18} />}
           title="No evaluation data"
@@ -89,7 +100,7 @@ export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } 
                 return <line key={i} x1={cx} y1={cy} x2={px} y2={py} stroke="rgba(255,255,255,0.04)" />;
               })}
 
-              {series.map((s, idx) => (
+              {comparison.map((s, idx) => (
                 <g key={s.label}>
                   <motion.polygon
                     points={polygonFor(s.values)}
@@ -131,14 +142,16 @@ export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } 
 
             <div className="w-full flex-1 space-y-2 lg:max-w-[180px]">
               {AXES.map((a, i) => {
-                const h = series[0].values[i];
-                const b = series[1].values[i];
+                const h = comparison[0].values[i];
+                const b = comparison[1].values[i];
                 const delta = h - b;
                 return (
                   <div key={a.key} className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
                     <div className="flex items-center justify-between">
                       <span className="text-[11px] uppercase tracking-widest text-slate-400">{a.label}</span>
-                      <span className="font-mono text-xs text-emerald-300">+{delta}</span>
+                      <span className="font-mono text-xs text-emerald-300">
+                        {delta >= 0 ? `+${delta}` : delta}
+                      </span>
                     </div>
                     <div className="mt-1 flex items-center gap-2 text-[11px]">
                       <span className="font-mono text-slate-100">{h}</span>
@@ -152,7 +165,7 @@ export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } 
           </div>
 
           <div className="mt-3 flex items-center justify-center gap-4 text-[11px]">
-            {series.map((s) => (
+            {comparison.map((s) => (
               <span key={s.label} className="inline-flex items-center gap-1.5 text-slate-400">
                 <span className="inline-block h-2 w-2 rounded-full" style={{ background: s.color, boxShadow: `0 0 6px ${s.color}` }} />
                 {s.label}

--- a/frontend/src/components/dashboard/RobustnessRadar.tsx
+++ b/frontend/src/components/dashboard/RobustnessRadar.tsx
@@ -26,9 +26,9 @@ const SERIES: RadarSeries[] = [
   { label: "Baseline", color: "var(--color-nightmare)", values: [62, 58, 71, 65, 41] },
 ];
 
-export function RobustnessRadar() {
+export function RobustnessRadar({ series = SERIES }: { series?: RadarSeries[] } = {}) {
   const { isLive } = useDemoMode();
-  const hasEvaluationData = SERIES.length >= 2;
+  const hasEvaluationData = series.length >= 2;
   const size = 280;
   const cx = size / 2;
   const cy = size / 2;
@@ -89,7 +89,7 @@ export function RobustnessRadar() {
                 return <line key={i} x1={cx} y1={cy} x2={px} y2={py} stroke="rgba(255,255,255,0.04)" />;
               })}
 
-              {SERIES.map((s, idx) => (
+              {series.map((s, idx) => (
                 <g key={s.label}>
                   <motion.polygon
                     points={polygonFor(s.values)}
@@ -131,8 +131,8 @@ export function RobustnessRadar() {
 
             <div className="w-full flex-1 space-y-2 lg:max-w-[180px]">
               {AXES.map((a, i) => {
-                const h = SERIES[0].values[i];
-                const b = SERIES[1].values[i];
+                const h = series[0].values[i];
+                const b = series[1].values[i];
                 const delta = h - b;
                 return (
                   <div key={a.key} className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
@@ -152,7 +152,7 @@ export function RobustnessRadar() {
           </div>
 
           <div className="mt-3 flex items-center justify-center gap-4 text-[11px]">
-            {SERIES.map((s) => (
+            {series.map((s) => (
               <span key={s.label} className="inline-flex items-center gap-1.5 text-slate-400">
                 <span className="inline-block h-2 w-2 rounded-full" style={{ background: s.color, boxShadow: `0 0 6px ${s.color}` }} />
                 {s.label}


### PR DESCRIPTION
## Summary
Adds Vitest coverage for `RobustnessRadar`, including multi-axis mock data, distortion axis labels, and the empty state. Optional `series` prop lets tests pass `[]` without changing default demo behavior.
Fixes #518
## Before / after
- **Before:** no tests; empty state unreachable (hardcoded series always length 2)
- **After:** `RobustnessRadar.test.tsx` (3 cases) + optional `series` for empty-state coverage
## Acceptance criteria
- [x] `frontend/src/__tests__/RobustnessRadar.test.tsx` created
- [x] Tests cover: renders with mock robustness data (multiple axes)
- [x] Tests cover: handles empty data (empty state shown)
- [x] Tests cover: correct axis labels match distortion types
- [x] Minimum 3 test cases
## Test plan
- [x] `cd frontend && npm test -- src/__tests__/RobustnessRadar.test.tsx`
- [ ] CI `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Robustness Radar now supports displaying custom data series, enabling more flexible comparisons and visualizations.
  - Preserves the existing default radar data when no custom series is provided.

- **Tests**
  - Added coverage for populated charts, labels, values, accessibility text, distortion axes, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->