### PR TITLE
test: add unit tests for data/loader.py

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1596,7 +1596,7 @@
   "info": {
     "description": "Autonomous AI Self-Improvement Platform \u2014 Dream & Nightmare Distortion Service",
     "title": "NightmareNet API",
-    "version": "0.3.1"
+    "version": "0.4.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,155 @@
+import unittest
+from unittest import mock
+import torch
+
+from nightmarenet.data.loader import DatasetWrapper, VisionDatasetWrapper, load_from_config
+
+
+class DummyHFDataset:
+    def __init__(self, items, columns=None):
+        self.items = items
+        self.column_names = columns or ["text"]
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, str):
+            return [item[idx] for item in self.items]
+        return self.items[idx]
+
+    def train_test_split(self, test_size=0.1, seed=42):
+        split_idx = int(len(self.items) * (1 - test_size))
+        return {
+            "train": DummyHFDataset(self.items[:split_idx], self.column_names),
+            "test": DummyHFDataset(self.items[split_idx:], self.column_names),
+        }
+
+    def filter(self, fn):
+        filtered = [item for item in self.items if fn(item)]
+        return DummyHFDataset(filtered, self.column_names)
+
+    def select(self, indices):
+        selected = [self.items[i] for i in indices]
+        return DummyHFDataset(selected, self.column_names)
+
+
+class DummyStreamingHFDataset:
+    def __init__(self, items, text_column="text"):
+        self.items = items
+        self.features = {text_column: "string"}
+        self.text_column = text_column
+
+    def filter(self, fn):
+        filtered = [item for item in self.items if fn(item)]
+        return DummyStreamingHFDataset(filtered, self.text_column)
+
+    def take(self, n):
+        return DummyStreamingHFDataset(self.items[:n], self.text_column)
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+class TestDataLoaderUnit(unittest.TestCase):
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_load_from_config_valid_text(self, mock_load_dataset):
+        raw_mock = {
+            "train": DummyHFDataset([{"text": "Sample 1"}, {"text": "Sample 2"}, {"text": "Sample 3"}]),
+            "test": DummyHFDataset([{"text": "Test sample"}]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        config = {
+            "dataset": {
+                "name": "wikitext",
+                "config": "wikitext-2-raw-v1",
+                "text_column": "text",
+            },
+            "seed": 42,
+        }
+
+        wrapper = load_from_config(config)
+        self.assertIsInstance(wrapper, DatasetWrapper)
+        self.assertEqual(len(wrapper.get_texts("train")), 3)
+        self.assertEqual(len(wrapper.get_texts("test")), 1)
+
+    @mock.patch("torchvision.datasets.FakeData")
+    def test_load_from_config_vision(self, mock_fakedata):
+        mock_fakedata.return_value = [(torch.randn(3, 32, 32), 0)] * 10
+        config = {
+            "model": {"type": "image_classification"},
+            "dataset": {"name": "cifar10", "max_samples": 5},
+        }
+
+        wrapper = load_from_config(config)
+        self.assertIsInstance(wrapper, VisionDatasetWrapper)
+        self.assertIsNotNone(wrapper.train_data)
+        self.assertIsNotNone(wrapper.test_data)
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_max_samples_truncation(self, mock_load_dataset):
+        items = [{"text": f"Text {i}"} for i in range(20)]
+        raw_mock = {
+            "train": DummyHFDataset(items[:15]),
+            "test": DummyHFDataset(items[15:]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(
+            dataset_name="dummy",
+            text_column="text",
+            max_samples=5,
+        ).load()
+
+        self.assertEqual(len(wrapper.train_data), 5)
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_streaming_mode(self, mock_load_dataset):
+        items = [{"text": f"Stream {i}"} for i in range(10)]
+        raw_mock = {
+            "train": DummyStreamingHFDataset(items),
+            "test": DummyStreamingHFDataset(items[:2]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(
+            dataset_name="dummy",
+            text_column="text",
+            streaming=True,
+            max_samples=4,
+        ).load()
+
+        self.assertIsNotNone(wrapper.train_data)
+        with self.assertRaises(RuntimeError):
+            wrapper.get_texts("train")
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_dataset_wrapper_unloaded_raises(self, mock_load_dataset):
+        wrapper = DatasetWrapper(dataset_name="dummy")
+        with self.assertRaises(RuntimeError):
+            _ = wrapper.train_data
+        with self.assertRaises(RuntimeError):
+            _ = wrapper.test_data
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_invalid_max_samples_validation(self, mock_load_dataset):
+        wrapper = DatasetWrapper(dataset_name="dummy", max_samples=-5)
+        with self.assertRaises(ValueError):
+            wrapper.load()
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_missing_text_column_validation(self, mock_load_dataset):
+        raw_mock = {
+            "train": DummyHFDataset([{"wrong_col": "val"}]),
+            "test": DummyHFDataset([{"wrong_col": "val"}]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(dataset_name="dummy", text_column="text")
+        with self.assertRaises(ValueError):
+            wrapper.load()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -47,10 +47,11 @@ class DummyStreamingHFDataset(IterableDataset):
     def __init__(self, items, text_column="text", features=None):
         self.items = list(items)
         self.text_column = text_column
-        if features is not None:
-            self.features = features
-        else:
-            self.features = {text_column: "string"}
+        self._features = features if features is not None else {text_column: "string"}
+
+    @property
+    def features(self):
+        return self._features
 
     def filter(self, fn):
         filtered = [item for item in self.items if fn(item)]
@@ -281,6 +282,48 @@ class TestDataLoaderUnit(unittest.TestCase):
         wrapper = DatasetWrapper(dataset_name="dummy", text_column="text").load()
         self.assertEqual(len(wrapper.train_data), 9)
         self.assertEqual(len(wrapper.test_data), 1)
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_deterministic_shuffling_and_splitting(self, mock_load_dataset):
+        def make_raw():
+            return {
+                "train": DummyHFDataset([{"text": f"Sample {i}"} for i in range(10)]),
+            }
+
+        mock_load_dataset.side_effect = [make_raw(), make_raw()]
+        wrapper1 = DatasetWrapper(dataset_name="dummy", text_column="text", seed=123).load()
+        wrapper2 = DatasetWrapper(dataset_name="dummy", text_column="text", seed=123).load()
+
+        self.assertEqual(wrapper1.get_texts("train"), wrapper2.get_texts("train"))
+        self.assertEqual(wrapper1.get_texts("test"), wrapper2.get_texts("test"))
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_empty_dataset_handling(self, mock_load_dataset):
+        raw_mock = {
+            "train": DummyHFDataset([{"text": ""}, {"text": "   "}]),
+            "test": DummyHFDataset([{"text": "  \n\t "}]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(dataset_name="dummy", text_column="text").load()
+        self.assertEqual(len(wrapper.train_data), 0)
+        self.assertEqual(len(wrapper.test_data), 0)
+        self.assertEqual(wrapper.get_texts("train"), [])
+        self.assertEqual(wrapper.get_texts("test"), [])
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_dataset_wrapper_iteration(self, mock_load_dataset):
+        samples = [{"text": f"Line {i}"} for i in range(5)]
+        raw_mock = {
+            "train": DummyHFDataset(samples[:4]),
+            "test": DummyHFDataset(samples[4:]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(dataset_name="dummy", text_column="text").load()
+        iterated = [item["text"] for item in wrapper.train_data]
+        self.assertEqual(iterated, ["Line 0", "Line 1", "Line 2", "Line 3"])
+        self.assertEqual(wrapper.train_data[0]["text"], "Line 0")
 
 
 if __name__ == "__main__":

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,14 +1,23 @@
+"""Unit tests for nightmarenet.data.loader."""
+
 import unittest
 from unittest import mock
-import torch
 
-from nightmarenet.data.loader import DatasetWrapper, VisionDatasetWrapper, load_from_config
+import torch
+from datasets import IterableDataset
+
+from nightmarenet.data.loader import (
+    DatasetWrapper,
+    VisionDatasetWrapper,
+    VisionItemWrapper,
+    load_from_config,
+)
 
 
 class DummyHFDataset:
     def __init__(self, items, columns=None):
-        self.items = items
-        self.column_names = columns or ["text"]
+        self.items = list(items)
+        self.column_names = columns or (list(items[0].keys()) if items else ["text"])
 
     def __len__(self):
         return len(self.items)
@@ -34,18 +43,21 @@ class DummyHFDataset:
         return DummyHFDataset(selected, self.column_names)
 
 
-class DummyStreamingHFDataset:
-    def __init__(self, items, text_column="text"):
-        self.items = items
-        self.features = {text_column: "string"}
+class DummyStreamingHFDataset(IterableDataset):
+    def __init__(self, items, text_column="text", features=None):
+        self.items = list(items)
         self.text_column = text_column
+        if features is not None:
+            self.features = features
+        else:
+            self.features = {text_column: "string"}
 
     def filter(self, fn):
         filtered = [item for item in self.items if fn(item)]
-        return DummyStreamingHFDataset(filtered, self.text_column)
+        return DummyStreamingHFDataset(filtered, self.text_column, self.features)
 
     def take(self, n):
-        return DummyStreamingHFDataset(self.items[:n], self.text_column)
+        return DummyStreamingHFDataset(self.items[:n], self.text_column, self.features)
 
     def __iter__(self):
         return iter(self.items)
@@ -55,7 +67,9 @@ class TestDataLoaderUnit(unittest.TestCase):
     @mock.patch("nightmarenet.data.loader.load_dataset")
     def test_load_from_config_valid_text(self, mock_load_dataset):
         raw_mock = {
-            "train": DummyHFDataset([{"text": "Sample 1"}, {"text": "Sample 2"}, {"text": "Sample 3"}]),
+            "train": DummyHFDataset(
+                [{"text": "Sample 1"}, {"text": "Sample 2"}, {"text": "Sample 3"}]
+            ),
             "test": DummyHFDataset([{"text": "Test sample"}]),
         }
         mock_load_dataset.return_value = raw_mock
@@ -74,9 +88,11 @@ class TestDataLoaderUnit(unittest.TestCase):
         self.assertEqual(len(wrapper.get_texts("train")), 3)
         self.assertEqual(len(wrapper.get_texts("test")), 1)
 
-    @mock.patch("torchvision.datasets.FakeData")
-    def test_load_from_config_vision(self, mock_fakedata):
-        mock_fakedata.return_value = [(torch.randn(3, 32, 32), 0)] * 10
+    @mock.patch("torchvision.datasets.CIFAR10")
+    def test_load_from_config_vision_cifar10(self, mock_cifar10):
+        mock_data = [(torch.randn(3, 32, 32), 0)] * 10
+        mock_cifar10.return_value = mock_data
+
         config = {
             "model": {"type": "image_classification"},
             "dataset": {"name": "cifar10", "max_samples": 5},
@@ -86,6 +102,59 @@ class TestDataLoaderUnit(unittest.TestCase):
         self.assertIsInstance(wrapper, VisionDatasetWrapper)
         self.assertIsNotNone(wrapper.train_data)
         self.assertIsNotNone(wrapper.test_data)
+        self.assertEqual(len(wrapper.train_data), 5)
+        self.assertEqual(len(wrapper.test_data), 1)
+
+    @mock.patch("torchvision.datasets.FakeData")
+    @mock.patch(
+        "torchvision.datasets.CIFAR10",
+        side_effect=RuntimeError("CIFAR-10 download failed"),
+    )
+    def test_load_from_config_vision_cifar10_fallback(self, mock_cifar10, mock_fakedata):
+        mock_fakedata.return_value = [(torch.randn(3, 32, 32), 1)] * 10
+        config = {
+            "model": {"type": "image_classification"},
+            "dataset": {"name": "cifar10", "max_samples": 4},
+        }
+
+        wrapper = load_from_config(config)
+        self.assertIsInstance(wrapper, VisionDatasetWrapper)
+        self.assertEqual(len(wrapper.train_data), 4)
+
+    @mock.patch("torchvision.datasets.ImageFolder")
+    @mock.patch("os.path.isdir", return_value=True)
+    def test_load_from_config_vision_imagenet_existing_path(self, mock_isdir, mock_imagefolder):
+        mock_imagefolder.return_value = [(torch.randn(3, 224, 224), 2)] * 15
+        config = {
+            "model": {"type": "image_classification"},
+            "dataset": {"name": "imagenet", "path": "/fake/imagenet", "max_samples": 5},
+        }
+
+        wrapper = load_from_config(config)
+        self.assertIsInstance(wrapper, VisionDatasetWrapper)
+        self.assertEqual(len(wrapper.train_data), 5)
+
+    @mock.patch("torchvision.datasets.FakeData")
+    def test_load_from_config_vision_unknown_dataset(self, mock_fakedata):
+        mock_fakedata.return_value = [(torch.randn(3, 32, 32), 3)] * 10
+        config = {
+            "model": {"type": "image_classification"},
+            "dataset": {"name": "unknown_dataset", "max_samples": 3},
+        }
+
+        wrapper = load_from_config(config)
+        self.assertIsInstance(wrapper, VisionDatasetWrapper)
+        self.assertEqual(len(wrapper.train_data), 3)
+
+    def test_vision_item_wrapper_tensor_conversion(self):
+        mock_raw_data = [(torch.randn(3, 32, 32), 0)]
+        wrapper = VisionItemWrapper(mock_raw_data)
+        self.assertEqual(len(wrapper), 1)
+        item = wrapper[0]
+        self.assertIn("pixel_values", item)
+        self.assertIn("labels", item)
+        self.assertTrue(isinstance(item["pixel_values"], torch.Tensor))
+        self.assertEqual(item["labels"], 0)
 
     @mock.patch("nightmarenet.data.loader.load_dataset")
     def test_max_samples_truncation(self, mock_load_dataset):
@@ -103,6 +172,7 @@ class TestDataLoaderUnit(unittest.TestCase):
         ).load()
 
         self.assertEqual(len(wrapper.train_data), 5)
+        self.assertEqual(len(wrapper.test_data), 1)
 
     @mock.patch("nightmarenet.data.loader.load_dataset")
     def test_streaming_mode(self, mock_load_dataset):
@@ -125,7 +195,24 @@ class TestDataLoaderUnit(unittest.TestCase):
             wrapper.get_texts("train")
 
     @mock.patch("nightmarenet.data.loader.load_dataset")
-    def test_dataset_wrapper_unloaded_raises(self, mock_load_dataset):
+    def test_streaming_mode_missing_text_column(self, mock_load_dataset):
+        items = [{"wrong_col": f"Stream {i}"} for i in range(5)]
+        raw_mock = {
+            "train": DummyStreamingHFDataset(
+                items, text_column="wrong_col", features={"other_col": "string"}
+            ),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(
+            dataset_name="dummy",
+            text_column="text",
+            streaming=True,
+        )
+        with self.assertRaises(ValueError):
+            wrapper.load()
+
+    def test_dataset_wrapper_unloaded_raises(self):
         wrapper = DatasetWrapper(dataset_name="dummy")
         with self.assertRaises(RuntimeError):
             _ = wrapper.train_data
@@ -149,6 +236,51 @@ class TestDataLoaderUnit(unittest.TestCase):
         wrapper = DatasetWrapper(dataset_name="dummy", text_column="text")
         with self.assertRaises(ValueError):
             wrapper.load()
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_filter_empty_and_whitespace_texts(self, mock_load_dataset):
+        raw_mock = {
+            "train": DummyHFDataset(
+                [{"text": "Valid"}, {"text": ""}, {"text": "   "}, {"text": "Also valid"}]
+            ),
+            "test": DummyHFDataset([{"text": "Valid test"}, {"text": ""}]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(dataset_name="dummy", text_column="text").load()
+        self.assertEqual(len(wrapper.train_data), 2)
+        self.assertEqual(len(wrapper.test_data), 1)
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_glue_dataset_fallback(self, mock_load_dataset):
+        mock_load_dataset.side_effect = [
+            RuntimeError("nyu-mll/glue failed"),
+            {
+                "train": DummyHFDataset([{"text": "Sample 1"}]),
+                "validation": DummyHFDataset([{"text": "Val 1"}]),
+            },
+        ]
+        wrapper = DatasetWrapper(dataset_name="glue", subset="sst2", text_column="text").load()
+        self.assertEqual(len(wrapper.train_data), 1)
+        self.assertEqual(len(wrapper.test_data), 1)
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_load_dataset_failure_raises_runtime_error(self, mock_load_dataset):
+        mock_load_dataset.side_effect = RuntimeError("Network error")
+        wrapper = DatasetWrapper(dataset_name="nonexistent")
+        with self.assertRaises(RuntimeError):
+            wrapper.load()
+
+    @mock.patch("nightmarenet.data.loader.load_dataset")
+    def test_train_test_split_created_when_no_test_split(self, mock_load_dataset):
+        raw_mock = {
+            "train": DummyHFDataset([{"text": f"Sample {i}"} for i in range(10)]),
+        }
+        mock_load_dataset.return_value = raw_mock
+
+        wrapper = DatasetWrapper(dataset_name="dummy", text_column="text").load()
+        self.assertEqual(len(wrapper.train_data), 9)
+        self.assertEqual(len(wrapper.test_data), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a comprehensive unit test suite for `nightmarenet/data/loader.py` covering text and vision dataset loading, `load_from_config()`, sample truncation (`max_samples`), streaming dataset mode, iteration mechanics in `DatasetWrapper`, and input validation checks.

## Linked Issue
Resolves #652

## Proposed Changes
- Created `tests/test_data_loader.py` with 7 test functions:
  - `test_load_from_config_valid_text`: Tests `load_from_config()` with a synthetic text dataset configuration.
  - `test_load_from_config_vision`: Tests vision model classification configuration loading `VisionDatasetWrapper`.
  - `test_max_samples_truncation`: Verifies exact sample count truncation when `max_samples` is specified.
  - `test_streaming_mode`: Tests streaming dataset initialization and `get_texts()` exception behavior on iterable datasets.
  - `test_dataset_wrapper_unloaded_raises`: Ensures accessing `.train_data` before `.load()` raises `RuntimeError`.
  - `test_invalid_max_samples_validation`: Validates that negative `max_samples` triggers validation error.
  - `test_missing_text_column_validation`: Verifies `validate_dataset_columns` raises error on missing text columns.

## Acceptance Criteria Checklist
- [x] `tests/test_data_loader.py` created with 7+ test functions
- [x] All tests pass without GPU
- [x] Uses synthetic/mock data (no real dataset downloads)
- [x] Tests complete in under 30 seconds
- [x] Validates `validate_dataset_columns` and `validate_positive_int` execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for text and vision dataset loading.
  * Added tests for fallback behavior, streaming mode, filtering, validation, truncation, tensor conversion, and automatic train/test splitting.
  * Added isolated dummy datasets to support reliable loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->