### PR TITLE
test: expand validation.py tests for complete public API coverage

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,15 +1,112 @@
+import unittest
+import pytest
 from fastapi.testclient import TestClient
 
 from nightmarenet.api.app import app
+from nightmarenet.utils.validation import (
+    validate_strength,
+    validate_positive_int,
+    validate_positive_float,
+    validate_ratio,
+    validate_text,
+    validate_dataset_columns,
+    validate_non_empty_dataset,
+    validate_config_keys,
+    validate_dataloader,
+)
 
 client = TestClient(app)
 
 
 def test_webhook_settings_validation_fails_on_bad_data():
-    # Passing a string instead of a list of webhook configurations
     bad_payload = {"webhooks": "this_is_not_a_valid_list"}
     response = client.post("/api/v1/settings/webhooks", json=bad_payload)
-
-    # We expect a 422 validation error because it's the wrong data type
     assert response.status_code == 422
     assert "detail" in response.json()
+
+
+class TestValidationUtils(unittest.TestCase):
+    def test_validate_strength_valid(self):
+        self.assertEqual(validate_strength(0.0), 0.0)
+        self.assertEqual(validate_strength(0.5), 0.5)
+        self.assertEqual(validate_strength(1.0), 1.0)
+        self.assertEqual(validate_strength(1), 1.0)
+
+    def test_validate_strength_invalid(self):
+        with self.assertRaises(ValueError):
+            validate_strength(-0.1)
+        with self.assertRaises(ValueError):
+            validate_strength(1.1)
+        with self.assertRaises(TypeError):
+            validate_strength("0.5")  # type: ignore
+
+    def test_validate_positive_int_valid(self):
+        self.assertEqual(validate_positive_int(1), 1)
+        self.assertEqual(validate_positive_int(100), 100)
+        self.assertEqual(validate_positive_int(0, allow_zero=True), 0)
+
+    def test_validate_positive_int_invalid(self):
+        with self.assertRaises(ValueError):
+            validate_positive_int(0)
+        with self.assertRaises(ValueError):
+            validate_positive_int(-5)
+        with self.assertRaises(TypeError):
+            validate_positive_int(1.5)  # type: ignore
+        with self.assertRaises(TypeError):
+            validate_positive_int(True)  # type: ignore
+
+    def test_validate_positive_float(self):
+        self.assertEqual(validate_positive_float(0.1), 0.1)
+        self.assertEqual(validate_positive_float(0, allow_zero=True), 0.0)
+        with self.assertRaises(ValueError):
+            validate_positive_float(0.0)
+        with self.assertRaises(TypeError):
+            validate_positive_float("abc")  # type: ignore
+
+    def test_validate_ratio(self):
+        self.assertEqual(validate_ratio(0.0), 0.0)
+        self.assertEqual(validate_ratio(0.999), 0.999)
+        with self.assertRaises(ValueError):
+            validate_ratio(1.0)
+        with self.assertRaises(ValueError):
+            validate_ratio(-0.1)
+
+    def test_validate_text(self):
+        self.assertEqual(validate_text("hello"), "hello")
+        self.assertEqual(validate_text("", allow_empty=True), "")
+        with self.assertRaises(ValueError):
+            validate_text("", allow_empty=False)
+        with self.assertRaises(TypeError):
+            validate_text(123)  # type: ignore
+
+    def test_validate_dataset_columns(self):
+        class DummyDS:
+            column_names = ["text", "label"]
+
+        validate_dataset_columns(DummyDS(), ["text"])
+        with self.assertRaises(ValueError):
+            validate_dataset_columns(DummyDS(), ["text", "missing_col"])
+        with self.assertRaises(AttributeError):
+            validate_dataset_columns(object(), ["text"])
+
+    def test_validate_non_empty_dataset(self):
+        validate_non_empty_dataset([1, 2, 3])
+        with self.assertRaises(ValueError):
+            validate_non_empty_dataset([])
+
+    def test_validate_config_keys(self):
+        config = {"a": 1, "b": 2}
+        validate_config_keys(config, ["a"])
+        with self.assertRaises(ValueError):
+            validate_config_keys(config, ["a", "c"])
+        with self.assertRaises(TypeError):
+            validate_config_keys([], ["a"])  # type: ignore
+
+    def test_validate_dataloader(self):
+        validate_dataloader(object())
+        with self.assertRaises(ValueError):
+            validate_dataloader(None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,18 +1,18 @@
 import unittest
-import pytest
+
 from fastapi.testclient import TestClient
 
 from nightmarenet.api.app import app
 from nightmarenet.utils.validation import (
-    validate_strength,
-    validate_positive_int,
-    validate_positive_float,
-    validate_ratio,
-    validate_text,
-    validate_dataset_columns,
-    validate_non_empty_dataset,
     validate_config_keys,
     validate_dataloader,
+    validate_dataset_columns,
+    validate_non_empty_dataset,
+    validate_positive_float,
+    validate_positive_int,
+    validate_ratio,
+    validate_strength,
+    validate_text,
 )
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
Replaces the 532-byte stub `tests/test_validation.py` with a complete unit test suite covering all public validator functions in `nightmarenet/utils/validation.py`.

## Linked Issue
Resolves #653

## Proposed Changes
- Expanded `tests/test_validation.py` to include tests for all public validation helpers:
  - `validate_strength`: Range checks ([0.0, 1.0]), boundary values, negative/over-range values, and type validation.
  - `validate_positive_int`: Positive integers, zero handling with `allow_zero`, floats/booleans, and negative inputs.
  - `validate_positive_float`: Positive floating point validation and type checks.
  - `validate_ratio`: Ratio checks in range [0, 1).
  - `validate_text`: Empty string allowance, empty string rejections, and type validation.
  - `validate_dataset_columns`: Verification of required column presence and missing column errors.
  - `validate_non_empty_dataset`: Validation against 0-sample datasets.
  - `validate_config_keys`: Dict type and missing key checking.
  - `validate_dataloader`: Non-null dataloader checks.

## Acceptance Criteria Checklist
- [x] `tests/test_validation.py` expanded to 10+ test functions
- [x] Covers ALL public functions in `validation.py`
- [x] Tests both valid inputs AND expected exception paths
- [x] No external dependencies required
- [x] Preserves existing API validation tests