### PR TITLE
test: add unit tests for degradation_curves and pareto_analysis

### DIFF
--- a/tests/test_degradation_curves.py
+++ b/tests/test_degradation_curves.py
@@ -1,5 +1,6 @@
-import unittest
 import math
+import unittest
+
 from nightmarenet.evaluation.degradation_curves import calculate_degradation_curves
 
 

--- a/tests/test_degradation_curves.py
+++ b/tests/test_degradation_curves.py
@@ -1,0 +1,64 @@
+import unittest
+import math
+from nightmarenet.evaluation.degradation_curves import calculate_degradation_curves
+
+
+class TestDegradationCurvesUnit(unittest.TestCase):
+    def test_calculate_degradation_curves_basic(self):
+        data = {
+            "model_a": {
+                "noise": {
+                    "strengths": [0.1, 0.5, 0.9],
+                    "accuracies": [0.9, 0.7, 0.4],
+                }
+            }
+        }
+        curves = calculate_degradation_curves(data)
+        self.assertIn("model_a", curves)
+        self.assertEqual(len(curves["model_a"]), 3)
+        self.assertEqual(curves["model_a"][0]["strength"], 0.1)
+        self.assertEqual(curves["model_a"][0]["robustness"], 0.9)
+
+    def test_empty_and_single_point(self):
+        empty_curves = calculate_degradation_curves({})
+        self.assertEqual(empty_curves, {})
+
+        single = {
+            "model_b": {
+                "blur": {
+                    "strengths": [0.0],
+                    "accuracies": [1.0],
+                }
+            }
+        }
+        res = calculate_degradation_curves(single)
+        self.assertEqual(len(res["model_b"]), 1)
+
+    def test_flat_and_extreme_values(self):
+        flat = {
+            "model_c": {
+                "flat_dist": {
+                    "strengths": [1e-5, 1e5],
+                    "accuracies": [0.5, 0.5],
+                }
+            }
+        }
+        res = calculate_degradation_curves(flat)
+        self.assertEqual(res["model_c"][0]["robustness"], 0.5)
+        self.assertEqual(res["model_c"][1]["robustness"], 0.5)
+
+    def test_nan_values(self):
+        nan_data = {
+            "model_d": {
+                "nan_dist": {
+                    "strengths": [0.1],
+                    "accuracies": [float("nan")],
+                }
+            }
+        }
+        res = calculate_degradation_curves(nan_data)
+        self.assertTrue(math.isnan(res["model_d"][0]["robustness"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pareto_analysis.py
+++ b/tests/test_pareto_analysis.py
@@ -1,4 +1,5 @@
 import unittest
+
 from nightmarenet.evaluation.pareto_analysis import get_pareto_frontier
 
 

--- a/tests/test_pareto_analysis.py
+++ b/tests/test_pareto_analysis.py
@@ -1,0 +1,38 @@
+import unittest
+from nightmarenet.evaluation.pareto_analysis import get_pareto_frontier
+
+
+class TestParetoAnalysisUnit(unittest.TestCase):
+    def test_pareto_dominance_detection(self):
+        # A dominates B (higher robustness, lower latency, lower params)
+        model_a = {"model": "A", "robustness": 0.9, "latency": 10.0, "params": 100}
+        model_b = {"model": "B", "robustness": 0.8, "latency": 12.0, "params": 120}
+
+        frontier = get_pareto_frontier([model_a, model_b])
+        self.assertEqual(len(frontier), 1)
+        self.assertEqual(frontier[0]["model"], "A")
+
+    def test_pareto_tradeoff_set(self):
+        # A has higher robustness, B has lower latency
+        model_a = {"model": "A", "robustness": 0.95, "latency": 20.0, "params": 100}
+        model_b = {"model": "B", "robustness": 0.80, "latency": 5.0, "params": 100}
+
+        frontier = get_pareto_frontier([model_a, model_b])
+        self.assertEqual(len(frontier), 2)
+
+    def test_empty_and_single_point(self):
+        self.assertEqual(get_pareto_frontier([]), [])
+        single = [{"model": "S", "robustness": 0.5, "latency": 1.0, "params": 10}]
+        self.assertEqual(get_pareto_frontier(single), single)
+
+    def test_identical_points(self):
+        m1 = {"model": "M1", "robustness": 0.8, "latency": 10.0, "params": 50}
+        m2 = {"model": "M2", "robustness": 0.8, "latency": 10.0, "params": 50}
+
+        frontier = get_pareto_frontier([m1, m2])
+        # Neither strictly dominates the other, so both remain
+        self.assertEqual(len(frontier), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds dedicated unit tests for `nightmarenet/evaluation/degradation_curves.py` and `nightmarenet/evaluation/pareto_analysis.py` to mathematically verify degradation curve generation and Pareto frontier extraction algorithms.

## Linked Issue
Resolves #655

## Proposed Changes
- Created `tests/test_degradation_curves.py`:
  - `test_calculate_degradation_curves_basic`: Verifies multi-point curve extraction (strength vs robustness).
  - `test_empty_and_single_point`: Edge case testing for empty input dicts and single-point evaluations.
  - `test_flat_and_extreme_values`: Tests extreme float scales and flat performance curves.
  - `test_nan_values`: Tests handling of `NaN` metric values.
- Created `tests/test_pareto_analysis.py`:
  - `test_pareto_dominance_detection`: Tests single dominance (higher robustness, lower latency, lower params).
  - `test_pareto_tradeoff_set`: Verifies multi-objective tradeoff preservation where no point strictly dominates.
  - `test_empty_and_single_point`: Tests empty list and single candidate boundary inputs.
  - `test_identical_points`: Verifies tie-breaking behavior when two models share identical metric values.

## Acceptance Criteria Checklist
- [x] `tests/test_degradation_curves.py` created
- [x] `tests/test_pareto_analysis.py` created
- [x] Uses synthetic analytical data with known ground truth outcomes
- [x] No GPU or real model execution required
- [x] Verifies exact numerical and structural outputs