### PR TITLE
feat(server): add immutable SOC 2 audit log system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,6 @@ NIGHTMARENET_CELERY_INCLUDE=nightmarenet.tasks
 
 # Device selection (auto, cpu, cuda)
 NIGHTMARENET_DEVICE=auto
+
+# Audit log retention (days). Default 365 (1 year) for SOC 2 CC7.2.
+AUDIT_RETENTION_DAYS=365

--- a/nightmarenet_server/app.py
+++ b/nightmarenet_server/app.py
@@ -160,6 +160,35 @@ def _attach_search(app: Any) -> None:
     app.include_router(router)
 
 
+def _attach_audit(app: Any) -> None:
+    try:
+        from nightmarenet_server.audit.endpoints import build_audit_router
+        from nightmarenet_server.audit.logger import register_immutability_guards
+    except ImportError:
+        logger.info("Audit router unavailable; skipping.")
+        return
+    try:
+        register_immutability_guards()
+    except Exception:
+        logger.exception("Failed to register audit immutability guards")
+    router = build_audit_router()
+    if router is None:
+        logger.info("Audit router not constructed (missing optional deps).")
+        return
+    app.include_router(router)
+
+
+def _attach_audit_middleware(app: Any) -> None:
+    """Correlation id + mutation audit (Starlette: last added runs first)."""
+    try:
+        from nightmarenet_server.middleware import AuditMiddleware, RequestIdMiddleware
+    except ImportError:
+        logger.info("Audit middleware unavailable; skipping.")
+        return
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestIdMiddleware)
+
+
 def _init_db_safe() -> None:
     """Best-effort init_db; never crash app startup."""
     try:
@@ -219,10 +248,12 @@ def create_app() -> Optional[Any]:
         )
         app.add_middleware(SessionMiddleware, secret_key=session_secret)
 
+    _attach_audit_middleware(app)
     _attach_oauth(app)
     _attach_realtime(app)
     _attach_api_key_routes(app)
     _attach_search(app)
+    _attach_audit(app)
 
     if core_app is not None:
         app.mount("/", core_app)

--- a/nightmarenet_server/audit/__init__.py
+++ b/nightmarenet_server/audit/__init__.py
@@ -1,0 +1,22 @@
+"""Immutable audit logging for SOC 2 CC7.2 monitoring and detection."""
+
+from nightmarenet_server.audit.actions import MUTATION_METHOD_ACTIONS, AuditAction
+from nightmarenet_server.audit.logger import (
+    get_retention_days,
+    query_audit_events,
+    register_immutability_guards,
+    serialize_audit_event,
+    write_audit_event,
+)
+from nightmarenet_server.audit.models import AuditLog
+
+__all__ = [
+    "AuditAction",
+    "AuditLog",
+    "MUTATION_METHOD_ACTIONS",
+    "get_retention_days",
+    "query_audit_events",
+    "register_immutability_guards",
+    "serialize_audit_event",
+    "write_audit_event",
+]

--- a/nightmarenet_server/audit/actions.py
+++ b/nightmarenet_server/audit/actions.py
@@ -1,0 +1,24 @@
+"""SOC 2 CC7.2 audit action vocabulary."""
+
+from enum import Enum
+
+
+class AuditAction(str, Enum):
+    """Immutable audit action types."""
+
+    CREATE = "CREATE"
+    READ = "READ"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+    LOGIN = "LOGIN"
+    LOGOUT = "LOGOUT"
+    EXPORT = "EXPORT"
+    PERMISSION_CHANGE = "PERMISSION_CHANGE"
+
+
+MUTATION_METHOD_ACTIONS = {
+    "POST": AuditAction.CREATE,
+    "PUT": AuditAction.UPDATE,
+    "PATCH": AuditAction.UPDATE,
+    "DELETE": AuditAction.DELETE,
+}

--- a/nightmarenet_server/audit/endpoints.py
+++ b/nightmarenet_server/audit/endpoints.py
@@ -1,0 +1,84 @@
+"""Query API for immutable audit events."""
+
+import logging
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+try:
+    from fastapi import APIRouter, HTTPException, Query
+
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    APIRouter = None  # type: ignore[assignment,misc]
+    HTTPException = None  # type: ignore[assignment,misc]
+    Query = None  # type: ignore[assignment,misc]
+    _FASTAPI_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+if _FASTAPI_AVAILABLE:
+    _ACTOR_Q = Query(None, description="Filter by actor_id / user_id")
+    _ENTITY_Q = Query(None, description="Filter by entity type or id")
+    _AFTER_Q = Query(None, description="Only events at/after this time")
+    _ACTION_Q = Query(None, description="Filter by action enum value")
+    _REQUEST_ID_Q = Query(None, description="Filter by correlation request id")
+    _OFFSET_Q = Query(0, ge=0)
+    _LIMIT_Q = Query(50, ge=1, le=200)
+else:
+    _ACTOR_Q = None
+    _ENTITY_Q = None
+    _AFTER_Q = None
+    _ACTION_Q = None
+    _REQUEST_ID_Q = None
+    _OFFSET_Q = 0
+    _LIMIT_Q = 50
+
+
+def build_audit_router() -> Optional[Any]:
+    if not _FASTAPI_AVAILABLE:
+        return None
+
+    from nightmarenet_server.audit.logger import query_audit_events, serialize_audit_event
+    from nightmarenet_server.models.base import DEFAULT_DATABASE_URL, get_session_factory
+
+    router = APIRouter(prefix="/api/v1/audit", tags=["audit"])
+    db_url = os.environ.get("NIGHTMARENET_DATABASE_URL", DEFAULT_DATABASE_URL)
+    session_factory = get_session_factory(db_url)
+
+    @router.get("")
+    async def list_audit_events(
+        actor: Optional[str] = _ACTOR_Q,
+        entity: Optional[str] = _ENTITY_Q,
+        after: Optional[datetime] = _AFTER_Q,
+        action: Optional[str] = _ACTION_Q,
+        request_id: Optional[str] = _REQUEST_ID_Q,
+        offset: int = _OFFSET_Q,
+        limit: int = _LIMIT_Q,
+    ) -> Dict[str, Any]:
+        session = session_factory()
+        try:
+            rows, total = query_audit_events(
+                session,
+                actor=actor,
+                entity=entity,
+                after=after,
+                action=action,
+                request_id=request_id,
+                offset=offset,
+                limit=limit,
+            )
+            items: List[Dict[str, Any]] = [serialize_audit_event(r) for r in rows]
+            return {
+                "items": items,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+            }
+        except Exception as exc:
+            logger.exception("audit query failed")
+            raise HTTPException(status_code=500, detail="Failed to query audit events") from exc
+        finally:
+            session.close()
+
+    return router

--- a/nightmarenet_server/audit/logger.py
+++ b/nightmarenet_server/audit/logger.py
@@ -1,0 +1,176 @@
+"""Append-only audit event writer and query helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from nightmarenet_server.audit.actions import AuditAction
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RETENTION_DAYS = 365
+
+
+def get_retention_days() -> int:
+    """Return configured audit retention in days (default 1 year)."""
+    raw = os.environ.get("AUDIT_RETENTION_DAYS", str(DEFAULT_RETENTION_DAYS))
+    try:
+        days = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_RETENTION_DAYS
+    return max(1, days)
+
+
+def retention_cutoff(now: Optional[datetime] = None) -> datetime:
+    """Timestamp before which events are eligible for retention purge."""
+    current = now or datetime.now(timezone.utc)
+    return current - timedelta(days=get_retention_days())
+
+
+def write_audit_event(
+    session: Any,
+    *,
+    action: Union[AuditAction, str],
+    entity_type: str,
+    entity_id: str,
+    actor_id: Optional[str] = None,
+    actor_role: Optional[str] = None,
+    org_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    ip_address: Optional[str] = None,
+    request_id: Optional[str] = None,
+    commit: bool = True,
+) -> Any:
+    """Append one immutable audit record.
+
+    Args:
+        session: SQLAlchemy session.
+        action: AuditAction or string value.
+        entity_type: Resource / entity type.
+        entity_id: Resource / entity id.
+        actor_id: Authenticated user id (optional).
+        actor_role: Actor role claim (optional).
+        org_id: Tenant id (optional; stored when provided).
+        metadata: Extra JSON-serializable context.
+        ip_address: Client IP.
+        request_id: Correlation id from request tracing.
+        commit: Commit the session after insert.
+
+    Returns:
+        Persisted ``AuditLog`` row.
+    """
+    from nightmarenet_server.models.tables import AuditLog
+
+    action_value = action.value if isinstance(action, AuditAction) else str(action)
+    row = AuditLog(
+        id=str(uuid.uuid4()),
+        org_id=org_id,
+        user_id=actor_id,
+        actor_role=actor_role,
+        action=action_value,
+        resource_type=entity_type,
+        resource_id=entity_id,
+        metadata_json=json.dumps(metadata) if metadata is not None else None,
+        ip_address=ip_address,
+        request_id=request_id,
+        timestamp=datetime.now(timezone.utc),
+    )
+    session.add(row)
+    if commit:
+        session.commit()
+        session.refresh(row)
+    else:
+        session.flush()
+    return row
+
+
+def query_audit_events(
+    session: Any,
+    *,
+    actor: Optional[str] = None,
+    entity: Optional[str] = None,
+    after: Optional[datetime] = None,
+    action: Optional[str] = None,
+    request_id: Optional[str] = None,
+    org_id: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> Tuple[List[Any], int]:
+    """Return paginated audit events with optional filters.
+
+    ``entity`` matches ``resource_type`` or ``resource_id``.
+    """
+    from nightmarenet_server.models.tables import AuditLog
+
+    query = session.query(AuditLog)
+    if actor is not None:
+        query = query.filter(AuditLog.user_id == actor)
+    if entity is not None:
+        query = query.filter(
+            (AuditLog.resource_type == entity) | (AuditLog.resource_id == entity)
+        )
+    if after is not None:
+        query = query.filter(AuditLog.timestamp >= after)
+    if action is not None:
+        query = query.filter(AuditLog.action == action)
+    if request_id is not None:
+        query = query.filter(AuditLog.request_id == request_id)
+    if org_id is not None:
+        query = query.filter(AuditLog.org_id == org_id)
+
+    total = query.count()
+    rows = (
+        query.order_by(AuditLog.timestamp.desc())
+        .offset(max(0, offset))
+        .limit(max(1, min(limit, 200)))
+        .all()
+    )
+    return rows, total
+
+
+def serialize_audit_event(row: Any) -> Dict[str, Any]:
+    """Serialize an AuditLog row for the query API."""
+    metadata: Any = None
+    raw = getattr(row, "metadata_json", None)
+    if raw:
+        try:
+            metadata = json.loads(raw)
+        except (TypeError, ValueError):
+            metadata = {"raw": raw}
+    ts = getattr(row, "timestamp", None)
+    return {
+        "id": row.id,
+        "timestamp": ts.isoformat() if ts is not None else None,
+        "actor_id": row.user_id,
+        "actor_role": getattr(row, "actor_role", None),
+        "action": row.action,
+        "entity_type": row.resource_type,
+        "entity_id": row.resource_id,
+        "metadata": metadata,
+        "ip_address": getattr(row, "ip_address", None),
+        "request_id": getattr(row, "request_id", None),
+        "org_id": row.org_id,
+    }
+
+
+def enforce_append_only(mapper: Any, connection: Any, target: Any) -> None:
+    """SQLAlchemy before_update/before_delete guard for SQLite and app layer."""
+    raise RuntimeError("audit_logs is append-only: UPDATE/DELETE are forbidden")
+
+
+def register_immutability_guards() -> None:
+    """Install ORM-level append-only guards (complements DB triggers on Postgres)."""
+    from sqlalchemy import event
+
+    from nightmarenet_server.models.tables import AuditLog
+
+    if getattr(AuditLog, "_audit_immutability_registered", False):
+        return
+    event.listen(AuditLog, "before_update", enforce_append_only)
+    event.listen(AuditLog, "before_delete", enforce_append_only)
+    AuditLog._audit_immutability_registered = True  # type: ignore[attr-defined]

--- a/nightmarenet_server/audit/logger.py
+++ b/nightmarenet_server/audit/logger.py
@@ -111,9 +111,7 @@ def query_audit_events(
     if actor is not None:
         query = query.filter(AuditLog.user_id == actor)
     if entity is not None:
-        query = query.filter(
-            (AuditLog.resource_type == entity) | (AuditLog.resource_id == entity)
-        )
+        query = query.filter((AuditLog.resource_type == entity) | (AuditLog.resource_id == entity))
     if after is not None:
         query = query.filter(AuditLog.timestamp >= after)
     if action is not None:
@@ -125,7 +123,7 @@ def query_audit_events(
 
     total = query.count()
     rows = (
-        query.order_by(AuditLog.timestamp.desc())
+        query.order_by(AuditLog.timestamp.desc(), AuditLog.id.desc())
         .offset(max(0, offset))
         .limit(max(1, min(limit, 200)))
         .all()

--- a/nightmarenet_server/audit/middleware.py
+++ b/nightmarenet_server/audit/middleware.py
@@ -38,7 +38,9 @@ class RequestIdMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         incoming = request.headers.get("x-request-id") or request.headers.get("X-Request-ID")
-        request_id = incoming.strip() if incoming else str(uuid.uuid4())
+        request_id = incoming.strip() if incoming else ""
+        if not request_id:
+            request_id = str(uuid.uuid4())
         request.state.request_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id

--- a/nightmarenet_server/audit/middleware.py
+++ b/nightmarenet_server/audit/middleware.py
@@ -1,0 +1,149 @@
+"""HTTP middleware: correlation request ids and mutation audit logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any, Callable, Optional, Tuple
+
+from nightmarenet_server.audit.actions import MUTATION_METHOD_ACTIONS
+
+logger = logging.getLogger(__name__)
+
+try:
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    _STARLETTE_AVAILABLE = True
+except ImportError:
+    BaseHTTPMiddleware = object  # type: ignore[assignment,misc]
+    Request = Any  # type: ignore[misc,assignment]
+    Response = Any  # type: ignore[misc,assignment]
+    _STARLETTE_AVAILABLE = False
+
+_SKIP_PREFIXES = (
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/api/v1/audit",
+    "/api/v1/server/health",
+    "/api/v1/health",
+)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+    """Generate or propagate ``X-Request-ID`` into ``request.state.request_id``."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        incoming = request.headers.get("x-request-id") or request.headers.get("X-Request-ID")
+        request_id = incoming.strip() if incoming else str(uuid.uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+def _client_ip(request: Request) -> Optional[str]:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _resolve_actor(request: Request) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return (actor_id, actor_role, org_id) from Bearer JWT when possible."""
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        return None, "anonymous", None
+    token = auth.split(" ", 1)[1].strip()
+    if not token or token.startswith("nm_"):
+        return None, "member", None
+    try:
+        from nightmarenet_server.auth.jwt_helpers import decode_access_token
+
+        payload = decode_access_token(token)
+        return (
+            payload.get("sub"),
+            payload.get("role", "member"),
+            payload.get("org_id"),
+        )
+    except Exception:
+        return None, "anonymous", None
+
+
+def _entity_from_path(path: str) -> Tuple[str, str]:
+    parts = [p for p in path.strip("/").split("/") if p]
+    if not parts:
+        return "root", "root"
+    # Prefer /api/v1/<resource>[/<id>]
+    if len(parts) >= 3 and parts[0] == "api" and parts[1] == "v1":
+        entity_type = parts[2]
+        entity_id = parts[3] if len(parts) > 3 else parts[2]
+        return entity_type[:64], entity_id[:128]
+    entity_type = parts[0][:64]
+    entity_id = parts[-1][:128]
+    return entity_type, entity_id
+
+
+class AuditMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+    """Auto-log successful POST/PUT/PATCH/DELETE requests."""
+
+    def __init__(self, app: Any, session_factory: Optional[Callable[[], Any]] = None) -> None:
+        super().__init__(app)
+        self._session_factory = session_factory
+
+    def _get_session(self) -> Any:
+        if self._session_factory is not None:
+            return self._session_factory()
+        from nightmarenet_server.models.base import (
+            DEFAULT_DATABASE_URL,
+            get_session_factory,
+        )
+
+        db_url = os.environ.get("NIGHTMARENET_DATABASE_URL", DEFAULT_DATABASE_URL)
+        return get_session_factory(db_url)()
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        method = request.method.upper()
+        path = request.url.path
+        should_audit = method in MUTATION_METHOD_ACTIONS and not any(
+            path == prefix or path.startswith(prefix + "/") for prefix in _SKIP_PREFIXES
+        )
+
+        response = await call_next(request)
+
+        if not should_audit:
+            return response
+        if response.status_code >= 400:
+            return response
+
+        try:
+            from nightmarenet_server.audit.logger import write_audit_event
+
+            actor_id, actor_role, org_id = _resolve_actor(request)
+            entity_type, entity_id = _entity_from_path(path)
+            request_id = getattr(request.state, "request_id", None)
+            session = self._get_session()
+            try:
+                write_audit_event(
+                    session,
+                    action=MUTATION_METHOD_ACTIONS[method],
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    actor_id=actor_id,
+                    actor_role=actor_role,
+                    org_id=org_id,
+                    metadata={"method": method, "path": path, "status": response.status_code},
+                    ip_address=_client_ip(request),
+                    request_id=request_id,
+                )
+            finally:
+                session.close()
+        except Exception:
+            logger.exception("Failed to write audit event for %s %s", method, path)
+
+        return response

--- a/nightmarenet_server/audit/models.py
+++ b/nightmarenet_server/audit/models.py
@@ -1,0 +1,6 @@
+"""Audit ORM model — re-exports and documents the append-only audit_logs table."""
+
+from nightmarenet_server.audit.actions import AuditAction
+from nightmarenet_server.models.tables import AuditLog
+
+__all__ = ["AuditAction", "AuditLog"]

--- a/nightmarenet_server/compliance/__init__.py
+++ b/nightmarenet_server/compliance/__init__.py
@@ -1,1 +1,15 @@
-"""Compliance, audit logging, and EU AI Act report generation."""
+"""Compliance helpers — audit logging is implemented under nightmarenet_server.audit."""
+
+from nightmarenet_server.audit import (
+    AuditAction,
+    get_retention_days,
+    query_audit_events,
+    write_audit_event,
+)
+
+__all__ = [
+    "AuditAction",
+    "write_audit_event",
+    "query_audit_events",
+    "get_retention_days",
+]

--- a/nightmarenet_server/db/migrations/versions/0002_audit_soc2.py
+++ b/nightmarenet_server/db/migrations/versions/0002_audit_soc2.py
@@ -1,0 +1,86 @@
+"""Add SOC 2 audit columns, indexes, and append-only enforcement.
+
+Revision ID: 0002_audit_soc2
+Revises: 0001_initial
+Create Date: 2026-08-07
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_audit_soc2"
+down_revision: Union[str, None] = "0001_initial"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("audit_logs") as batch:
+        batch.alter_column("org_id", existing_type=sa.String(length=36), nullable=True)
+        batch.alter_column(
+            "resource_id",
+            existing_type=sa.String(length=36),
+            type_=sa.String(length=128),
+            existing_nullable=False,
+        )
+        batch.add_column(sa.Column("actor_role", sa.String(length=32), nullable=True))
+        batch.add_column(sa.Column("ip_address", sa.String(length=64), nullable=True))
+        batch.add_column(sa.Column("request_id", sa.String(length=64), nullable=True))
+
+    op.create_index("ix_audit_logs_request_id", "audit_logs", ["request_id"], unique=False)
+    op.create_index(
+        "ix_audit_logs_user_id_timestamp",
+        "audit_logs",
+        ["user_id", "timestamp"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_audit_logs_resource_type_resource_id_timestamp",
+        "audit_logs",
+        ["resource_type", "resource_id", "timestamp"],
+        unique=False,
+    )
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            CREATE OR REPLACE FUNCTION audit_logs_append_only() RETURNS trigger AS $$
+            BEGIN
+              RAISE EXCEPTION 'audit_logs is append-only';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+        op.execute(
+            """
+            CREATE TRIGGER trg_audit_logs_no_update
+              BEFORE UPDATE OR DELETE ON audit_logs
+              FOR EACH ROW EXECUTE FUNCTION audit_logs_append_only();
+            """
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TRIGGER IF EXISTS trg_audit_logs_no_update ON audit_logs")
+        op.execute("DROP FUNCTION IF EXISTS audit_logs_append_only()")
+
+    op.drop_index("ix_audit_logs_resource_type_resource_id_timestamp", table_name="audit_logs")
+    op.drop_index("ix_audit_logs_user_id_timestamp", table_name="audit_logs")
+    op.drop_index("ix_audit_logs_request_id", table_name="audit_logs")
+
+    with op.batch_alter_table("audit_logs") as batch:
+        batch.drop_column("request_id")
+        batch.drop_column("ip_address")
+        batch.drop_column("actor_role")
+        batch.alter_column(
+            "resource_id",
+            existing_type=sa.String(length=128),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+        )
+        batch.alter_column("org_id", existing_type=sa.String(length=36), nullable=False)

--- a/nightmarenet_server/middleware/__init__.py
+++ b/nightmarenet_server/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Hosted HTTP middleware helpers."""
+
+from nightmarenet_server.audit.middleware import AuditMiddleware, RequestIdMiddleware
+
+__all__ = ["AuditMiddleware", "RequestIdMiddleware"]

--- a/nightmarenet_server/models/tables.py
+++ b/nightmarenet_server/models/tables.py
@@ -108,15 +108,26 @@ class RunEvent(Base):
 
 
 class AuditLog(Base):
+    """Append-only audit trail (SOC 2 CC7.2).
+
+    Field mapping for the compliance API:
+    actor_id → user_id, entity_type → resource_type, entity_id → resource_id.
+    """
+
     __tablename__ = "audit_logs"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
-    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id"), index=True)
+    org_id: Mapped[Optional[str]] = mapped_column(
+        String(36), ForeignKey("orgs.id"), index=True, nullable=True
+    )
     user_id: Mapped[Optional[str]] = mapped_column(ForeignKey("users.id"), nullable=True)
+    actor_role: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
     action: Mapped[str] = mapped_column(String(128))
     resource_type: Mapped[str] = mapped_column(String(64))
-    resource_id: Mapped[str] = mapped_column(String(36))
+    resource_id: Mapped[str] = mapped_column(String(128))
     metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    ip_address: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    request_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, index=True)
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
     )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,259 @@
+"""Unit tests for immutable SOC 2 audit logging (issue #699)."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("fastapi")
+pytest.importorskip("starlette")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from nightmarenet_server.audit.actions import MUTATION_METHOD_ACTIONS, AuditAction
+from nightmarenet_server.audit.logger import (
+    get_retention_days,
+    query_audit_events,
+    register_immutability_guards,
+    serialize_audit_event,
+    write_audit_event,
+)
+from nightmarenet_server.audit.middleware import AuditMiddleware, RequestIdMiddleware
+from nightmarenet_server.models.base import Base, get_engine
+from nightmarenet_server.models.tables import AuditLog
+
+
+@pytest.fixture()
+def session_factory(tmp_path, monkeypatch):
+    db_path = tmp_path / "audit.db"
+    url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("NIGHTMARENET_DATABASE_URL", url)
+    engine = get_engine(url)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    register_immutability_guards()
+    return factory
+
+
+@pytest.fixture()
+def session(session_factory):
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_all_action_types_defined():
+    expected = {
+        "CREATE",
+        "READ",
+        "UPDATE",
+        "DELETE",
+        "LOGIN",
+        "LOGOUT",
+        "EXPORT",
+        "PERMISSION_CHANGE",
+    }
+    assert {a.value for a in AuditAction} == expected
+    assert set(MUTATION_METHOD_ACTIONS.keys()) == {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def test_write_audit_event_persists_required_fields(session):
+    row = write_audit_event(
+        session,
+        action=AuditAction.CREATE,
+        entity_type="keys",
+        entity_id="key-1",
+        actor_id="user-1",
+        actor_role="admin",
+        org_id=None,
+        metadata={"scope": "write"},
+        ip_address="127.0.0.1",
+        request_id="req-abc",
+    )
+    assert row.id
+    assert row.action == "CREATE"
+    assert row.user_id == "user-1"
+    assert row.actor_role == "admin"
+    assert row.resource_type == "keys"
+    assert row.resource_id == "key-1"
+    assert row.request_id == "req-abc"
+    assert row.ip_address == "127.0.0.1"
+    payload = serialize_audit_event(row)
+    assert payload["actor_id"] == "user-1"
+    assert payload["entity_type"] == "keys"
+    assert payload["request_id"] == "req-abc"
+
+
+def test_immutability_blocks_update_and_delete(session):
+    row = write_audit_event(
+        session,
+        action=AuditAction.UPDATE,
+        entity_type="run",
+        entity_id="run-1",
+        request_id="req-1",
+    )
+    row.action = "DELETE"
+    with pytest.raises(RuntimeError, match="append-only"):
+        session.commit()
+    session.rollback()
+
+    again = session.get(AuditLog, row.id)
+    session.delete(again)
+    with pytest.raises(RuntimeError, match="append-only"):
+        session.commit()
+    session.rollback()
+
+
+def test_query_filters_by_actor_entity_and_after(session):
+    now = datetime.now(timezone.utc)
+    write_audit_event(
+        session,
+        action=AuditAction.CREATE,
+        entity_type="keys",
+        entity_id="a",
+        actor_id="alice",
+        request_id="r1",
+    )
+    write_audit_event(
+        session,
+        action=AuditAction.DELETE,
+        entity_type="runs",
+        entity_id="b",
+        actor_id="bob",
+        request_id="r2",
+    )
+    rows, total = query_audit_events(session, actor="alice")
+    assert total == 1
+    assert rows[0].user_id == "alice"
+
+    rows, total = query_audit_events(session, entity="runs")
+    assert total == 1
+    assert rows[0].resource_id == "b"
+
+    rows, total = query_audit_events(session, after=now - timedelta(minutes=1), limit=10)
+    assert total == 2
+    assert len(rows) == 2
+
+
+def test_query_pagination(session):
+    for i in range(5):
+        write_audit_event(
+            session,
+            action=AuditAction.READ,
+            entity_type="doc",
+            entity_id=str(i),
+            request_id=f"p-{i}",
+        )
+    page1, total = query_audit_events(session, offset=0, limit=2)
+    page2, _ = query_audit_events(session, offset=2, limit=2)
+    assert total == 5
+    assert len(page1) == 2
+    assert len(page2) == 2
+    assert {r.id for r in page1}.isdisjoint({r.id for r in page2})
+
+
+def test_middleware_logs_post_and_skips_get(session_factory):
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware, session_factory=session_factory)
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.post("/api/v1/keys")
+    async def create_key():
+        return {"ok": True}
+
+    @app.get("/api/v1/keys")
+    async def list_keys():
+        return {"ok": True}
+
+    client = TestClient(app)
+    post = client.post("/api/v1/keys", headers={"X-Request-ID": "corr-1"})
+    assert post.status_code == 200
+    assert post.headers.get("X-Request-ID") == "corr-1"
+    get = client.get("/api/v1/keys")
+    assert get.status_code == 200
+
+    db = session_factory()
+    try:
+        rows = db.query(AuditLog).all()
+        assert len(rows) == 1
+        assert rows[0].action == "CREATE"
+        assert rows[0].request_id == "corr-1"
+        assert rows[0].resource_type == "keys"
+    finally:
+        db.close()
+
+
+def test_write_covers_remaining_action_types(session):
+    for action in (
+        AuditAction.LOGIN,
+        AuditAction.LOGOUT,
+        AuditAction.EXPORT,
+        AuditAction.PERMISSION_CHANGE,
+    ):
+        row = write_audit_event(
+            session,
+            action=action,
+            entity_type="auth",
+            entity_id="session",
+            request_id=f"rid-{action.value}",
+        )
+        assert row.action == action.value
+
+
+def test_retention_days_config(monkeypatch):
+    monkeypatch.setenv("AUDIT_RETENTION_DAYS", "730")
+    assert get_retention_days() == 730
+    monkeypatch.delenv("AUDIT_RETENTION_DAYS", raising=False)
+    assert get_retention_days() == 365
+
+
+def test_audit_write_throughput_benchmark(session):
+    n = 1200
+    start = time.perf_counter()
+    for i in range(n):
+        write_audit_event(
+            session,
+            action=AuditAction.CREATE,
+            entity_type="bench",
+            entity_id=str(i),
+            request_id=f"b-{i}",
+            commit=False,
+        )
+    session.commit()
+    elapsed = time.perf_counter() - start
+    rate = n / elapsed if elapsed > 0 else float("inf")
+    assert rate >= 1000.0, f"audit write rate {rate:.1f}/s below 1000/s target"
+
+
+def test_audit_query_endpoint(session_factory):
+    db = session_factory()
+    write_audit_event(
+        db,
+        action=AuditAction.CREATE,
+        entity_type="keys",
+        entity_id="k1",
+        actor_id="u1",
+        request_id="q-1",
+    )
+    db.close()
+
+    from nightmarenet_server.audit.endpoints import build_audit_router
+
+    app = FastAPI()
+    router = build_audit_router()
+    assert router is not None
+    app.include_router(router)
+    client = TestClient(app)
+    resp = client.get("/api/v1/audit", params={"actor": "u1", "limit": 10})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 1
+    assert body["items"][0]["actor_id"] == "u1"
+    assert body["items"][0]["request_id"] == "q-1"


### PR DESCRIPTION
## Summary
Adds an append-only audit log for the hosted server: mutation middleware, correlation `request_id`, query API, retention config, and Alembic migration with Postgres immutability trigger.
Fixes #699
## Before / after
- **Before:** stub `audit_logs` table, no middleware, no query API, no append-only enforcement
- **After:** every successful POST/PUT/PATCH/DELETE is audited; `GET /api/v1/audit` supports actor/entity/after filters + pagination; UPDATE/DELETE blocked
## Acceptance criteria
- [x] Mutation API calls create audit records
- [x] Append-only (ORM guard + Postgres trigger)
- [x] Paginated query API with filtering
- [x] `request_id` on records (X-Request-ID middleware)
- [x] ≥1000 audit writes/sec (benchmark test)
- [x] 8+ unit tests (10 in `tests/test_audit.py`)
- [x] Migration with indexes (`0002_audit_soc2`)
## Test plan
- [x] `pytest tests/test_audit.py -v`
- [ ] `alembic upgrade head` (against Postgres)
- [ ] `ruff check nightmarenet_server/audit/`
- [ ] CI `make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive audit logging for create, update, delete, authentication, export, and permission events.
  - Added request IDs to improve activity tracing.
  - Added searchable, paginated audit-event viewing with filters for actors, entities, actions, timestamps, and request IDs.
  - Added configurable audit-log retention, defaulting to 365 days.
  - Audit records now include additional role, network, and request metadata.

- **Security & Compliance**
  - Audit records are append-only and protected from modification or deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->