### PR TITLE
feat: add nightmarenet-robustness-check GitHub Action (#702)

### DIFF
--- a/.github/actions/nightmarenet-robustness-check/action.yml
+++ b/.github/actions/nightmarenet-robustness-check/action.yml
@@ -2,8 +2,9 @@ name: NightmareNet Robustness Check
 description: >-
   Run a NightmareNet robustness evaluation against a model checkpoint and fail
   the workflow if the aggregate robustness score falls below a configurable
-  threshold. Suitable as a quality gate in pull-request CI. To detect regressions
-  against the main branch, see the robustness-delta-comment action.
+  threshold. Prefer the canonical path
+  `.github/actions/robustness-check` (same branding; adds PR comments and a
+  `passed` output). Suitable as a quality gate in pull-request CI.
 author: NightmareNet
 
 branding:

--- a/.github/actions/robustness-check/action.yml
+++ b/.github/actions/robustness-check/action.yml
@@ -1,0 +1,131 @@
+name: NightmareNet Robustness Check
+description: >-
+  Run NightmareNet robustness evaluation against a model (Hugging Face ID,
+  .pt, or .bin) and fail the job when the aggregate score falls below a
+  configurable threshold. Posts a markdown score table on pull requests.
+author: NightmareNet
+
+branding:
+  icon: shield
+  color: purple
+
+inputs:
+  model_path:
+    description: >-
+      Path to a PyTorch checkpoint (.pt / .bin) or Hugging Face model ID to
+      evaluate. Required unless config_path supplies model.name.
+    required: false
+    default: ""
+  config_path:
+    description: Optional NightmareNet YAML config for full evaluator runs.
+    required: false
+    default: ""
+  threshold:
+    description: Minimum acceptable robustness score in [0, 1]. Default 0.7.
+    required: false
+    default: "0.7"
+  distortion_types:
+    description: Comma-separated distortion families to score (dream, nightmare).
+    required: false
+    default: "dream,nightmare"
+  strengths:
+    description: Comma-separated distortion strengths for the sweep.
+    required: false
+    default: "0.1,0.3,0.5,0.7,0.9"
+  text:
+    description: Optional probe text (fast path without config_path).
+    required: false
+    default: ""
+  dataset:
+    description: Dataset name for evaluate (informational / config default).
+    required: false
+    default: "sst2"
+  python-version:
+    description: Python version when the runner has not already set one up.
+    required: false
+    default: "3.12"
+  install-source:
+    description: >-
+      Install nightmarenet from the checked-out repo (local) or from PyPI (pypi).
+    required: false
+    default: "local"
+  post-comment:
+    description: Post or update a PR comment with the score table (true/false).
+    required: false
+    default: "true"
+  github_token:
+    description: Token used to post the PR comment.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  robustness_score:
+    description: Aggregate robustness score in [0, 1].
+    value: ${{ steps.run.outputs.robustness_score }}
+  passed:
+    description: Whether the score met the threshold (true/false).
+    value: ${{ steps.run.outputs.passed }}
+  report_path:
+    description: Path to the JSON report artifact on the runner.
+    value: ${{ steps.run.outputs.report_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+
+    - name: Install nightmarenet
+      shell: bash
+      env:
+        INSTALL_SOURCE: ${{ inputs.install-source }}
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        if [ "${INSTALL_SOURCE}" = "local" ]; then
+          pip install -e "."
+        else
+          pip install "nightmarenet"
+        fi
+
+    - name: Run robustness check
+      id: run
+      shell: bash
+      env:
+        INPUT_MODEL_PATH: ${{ inputs.model_path }}
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
+        INPUT_THRESHOLD: ${{ inputs.threshold }}
+        INPUT_DISTORTION_TYPES: ${{ inputs.distortion_types }}
+        INPUT_STRENGTHS: ${{ inputs.strengths }}
+        INPUT_TEXT: ${{ inputs.text }}
+        INPUT_DATASET: ${{ inputs.dataset }}
+        INPUT_COMMENT_PATH: ${{ runner.temp }}/robustness-comment.md
+      run: |
+        set -euo pipefail
+        python "${{ github.action_path }}/entrypoint.py"
+
+    - name: Upload robustness report
+      if: always() && steps.run.outputs.report_path != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightmarenet-robustness-report
+        path: ${{ steps.run.outputs.report_path }}
+        if-no-files-found: warn
+
+    - name: Post PR comment
+      if: always() && inputs.post-comment == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_COMMENT_PATH: ${{ runner.temp }}/robustness-comment.md
+        COMMENT_PATH: ${{ runner.temp }}/robustness-comment.md
+      run: |
+        set -euo pipefail
+        if [ -f "${COMMENT_PATH}" ]; then
+          python "${{ github.action_path }}/post_comment.py"
+        else
+          echo "No comment body available; skipping PR comment."
+        fi

--- a/.github/actions/robustness-check/entrypoint.py
+++ b/.github/actions/robustness-check/entrypoint.py
@@ -15,7 +15,6 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-
 MARKER = "<!-- nightmarenet-robustness-check -->"
 
 
@@ -204,7 +203,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     temp_root = Path(os.environ.get("RUNNER_TEMP") or os.environ.get("TMPDIR") or "/tmp")
     report_path = temp_root / "nightmarenet-robustness-report.json"
-    comment_path = Path(os.environ.get("INPUT_COMMENT_PATH") or (temp_root / "robustness-comment.md"))
+    comment_path = Path(
+        os.environ.get("INPUT_COMMENT_PATH") or (temp_root / "robustness-comment.md")
+    )
 
     cmd = build_evaluate_cmd(
         model_path=model_path,

--- a/.github/actions/robustness-check/entrypoint.py
+++ b/.github/actions/robustness-check/entrypoint.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""NightmareNet robustness-check GitHub Action entrypoint.
+
+Runs ``nightmarenet evaluate --json``, writes a report, sets Action outputs,
+emits a markdown summary table, and exits non-zero when the score is below
+the configured threshold.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+MARKER = "<!-- nightmarenet-robustness-check -->"
+
+
+def _parse_csv(raw: str) -> List[str]:
+    return [part.strip() for part in (raw or "").split(",") if part.strip()]
+
+
+def extract_score(report: Dict[str, Any]) -> float:
+    """Pull a [0, 1] robustness score from evaluate --json payloads."""
+    if "robustness_score" in report:
+        return float(report["robustness_score"])
+    # Config/evaluator path may nest metrics differently.
+    for key in ("score", "avg_robustness", "robustness"):
+        if key in report:
+            return float(report[key])
+    raise KeyError("Report JSON is missing robustness_score")
+
+
+def per_distortion_rows(
+    report: Dict[str, Any],
+    distortion_types: Sequence[str],
+) -> List[Tuple[str, float]]:
+    """Build (label, score) rows for the PR comment table."""
+    rows: List[Tuple[str, float]] = []
+    strengths = report.get("strengths") or []
+    types = [t.lower() for t in distortion_types] if distortion_types else ["dream", "nightmare"]
+
+    if strengths and isinstance(strengths, list):
+        for entry in strengths:
+            if not isinstance(entry, dict):
+                continue
+            strength = entry.get("strength", "?")
+            if "dream" in types and "dream_similarity" in entry:
+                rows.append((f"dream@{strength}", float(entry["dream_similarity"])))
+            if "nightmare" in types and "nightmare_similarity" in entry:
+                rows.append((f"nightmare@{strength}", float(entry["nightmare_similarity"])))
+        if rows:
+            return rows
+
+    # Aggregates when per-strength detail is absent.
+    if "dream" in types and "avg_dream_similarity" in report:
+        rows.append(("dream (avg)", float(report["avg_dream_similarity"])))
+    if "nightmare" in types and "avg_nightmare_similarity" in report:
+        rows.append(("nightmare (avg)", float(report["avg_nightmare_similarity"])))
+    return rows
+
+
+def filter_aggregate(
+    report: Dict[str, Any],
+    distortion_types: Sequence[str],
+) -> float:
+    """Recompute aggregate score when the caller restricts distortion types."""
+    types = [t.lower() for t in distortion_types] if distortion_types else []
+    if not types or set(types) >= {"dream", "nightmare"}:
+        return extract_score(report)
+
+    parts: List[float] = []
+    if "dream" in types and "avg_dream_similarity" in report:
+        parts.append(float(report["avg_dream_similarity"]))
+    if "nightmare" in types and "avg_nightmare_similarity" in report:
+        parts.append(float(report["avg_nightmare_similarity"]))
+    if parts:
+        return round(sum(parts) / len(parts), 4)
+    return extract_score(report)
+
+
+def format_markdown(
+    *,
+    model: str,
+    score: float,
+    threshold: float,
+    passed: bool,
+    rows: Sequence[Tuple[str, float]],
+    report_path: str,
+) -> str:
+    status = "PASSED" if passed else "FAILED"
+    lines = [
+        MARKER,
+        "## NightmareNet Robustness Check",
+        "",
+        f"**Status:** {status}  ",
+        f"**Model:** `{model}`  ",
+        f"**Overall score:** `{score:.4f}` (threshold `{threshold:.4f}`)  ",
+        f"**Report:** `{report_path}`",
+        "",
+        "| Distortion | Score |",
+        "| --- | ---: |",
+    ]
+    if rows:
+        for label, value in rows:
+            lines.append(f"| {label} | {value:.4f} |")
+    else:
+        lines.append("| (no per-distortion breakdown) | — |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _append_output(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        print(f"::notice::{name}={value}")
+        return
+    with open(out, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _append_summary(markdown: str) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with open(summary, "a", encoding="utf-8") as fh:
+        fh.write(markdown)
+        fh.write("\n")
+
+
+def build_evaluate_cmd(
+    *,
+    model_path: str,
+    config_path: str,
+    strengths: str,
+    text: str,
+    dataset: str,
+) -> List[str]:
+    # Prefer the console script; fall back to module invocation.
+    cmd = ["nightmarenet", "evaluate", "--json"]
+    try:
+        subprocess.run(
+            ["nightmarenet", "--help"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        cmd = [sys.executable, "-m", "nightmarenet.cli", "evaluate", "--json"]
+
+    if config_path:
+        cmd.extend(["--config", config_path])
+    if model_path:
+        cmd.extend(["--model", model_path])
+    if dataset:
+        cmd.extend(["--dataset", dataset])
+    if strengths:
+        cmd.extend(["--strengths", strengths])
+    if text:
+        cmd.extend(["--text", text])
+    return cmd
+
+
+def run_evaluate(cmd: Sequence[str], report_path: Path) -> Dict[str, Any]:
+    result = subprocess.run(
+        list(cmd),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or result.stdout or "evaluate failed\n")
+        raise SystemExit(result.returncode or 1)
+
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        sys.stderr.write("evaluate produced empty stdout\n")
+        raise SystemExit(1)
+
+    # Last non-empty line should be the JSON object (logging may be disabled).
+    payload_line = stdout.splitlines()[-1]
+    report = json.loads(payload_line)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    del argv  # env-driven; argv unused
+    model_path = os.environ.get("INPUT_MODEL_PATH", "").strip()
+    config_path = os.environ.get("INPUT_CONFIG_PATH", "").strip()
+    threshold = float(os.environ.get("INPUT_THRESHOLD", "0.7"))
+    distortion_types = _parse_csv(os.environ.get("INPUT_DISTORTION_TYPES", "dream,nightmare"))
+    strengths = os.environ.get("INPUT_STRENGTHS", "0.1,0.3,0.5,0.7,0.9").strip()
+    text = os.environ.get("INPUT_TEXT", "").strip()
+    dataset = os.environ.get("INPUT_DATASET", "sst2").strip()
+
+    if not model_path and not config_path:
+        sys.stderr.write("::error::model_path or config_path is required\n")
+        return 1
+
+    temp_root = Path(os.environ.get("RUNNER_TEMP") or os.environ.get("TMPDIR") or "/tmp")
+    report_path = temp_root / "nightmarenet-robustness-report.json"
+    comment_path = Path(os.environ.get("INPUT_COMMENT_PATH") or (temp_root / "robustness-comment.md"))
+
+    cmd = build_evaluate_cmd(
+        model_path=model_path,
+        config_path=config_path,
+        strengths=strengths,
+        text=text,
+        dataset=dataset,
+    )
+    print(f"Running: {' '.join(cmd)}", flush=True)
+    report = run_evaluate(cmd, report_path)
+
+    score = filter_aggregate(report, distortion_types)
+    passed = score >= threshold
+    rows = per_distortion_rows(report, distortion_types)
+    markdown = format_markdown(
+        model=model_path or config_path or report.get("model", ""),
+        score=score,
+        threshold=threshold,
+        passed=passed,
+        rows=rows,
+        report_path=str(report_path),
+    )
+    comment_path.write_text(markdown, encoding="utf-8")
+    _append_summary(markdown)
+
+    _append_output("robustness_score", f"{score:.4f}")
+    _append_output("passed", "true" if passed else "false")
+    _append_output("report_path", str(report_path))
+
+    print(markdown)
+    if not passed:
+        sys.stderr.write(
+            f"::error::Robustness score {score:.4f} is below threshold {threshold:.4f}\n"
+        )
+        return 1
+    print(f"Robustness score {score:.4f} >= threshold {threshold:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/robustness-check/post_comment.py
+++ b/.github/actions/robustness-check/post_comment.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Post or update a PR comment with the robustness-check markdown report."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MARKER = "<!-- nightmarenet-robustness-check -->"
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("INPUT_GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    comment_path = os.environ.get("INPUT_COMMENT_PATH") or os.environ.get("COMMENT_PATH")
+
+    if not token or not repo or not event_path:
+        print("Missing GitHub context; skipping PR comment.")
+        return 0
+
+    if not comment_path or not Path(comment_path).is_file():
+        print(f"Comment body not found at {comment_path!r}; skipping.")
+        return 0
+
+    try:
+        with open(event_path, encoding="utf-8") as fh:
+            event_data = json.load(fh)
+    except OSError as exc:
+        print(f"Could not read event data: {exc}")
+        return 0
+
+    pr = event_data.get("pull_request") or event_data.get("issue")
+    if not pr or "number" not in pr:
+        print("Not a pull_request/issue event; skipping comment.")
+        return 0
+
+    pr_number = pr["number"]
+    body = Path(comment_path).read_text(encoding="utf-8")
+    if MARKER not in body:
+        body = f"{MARKER}\n{body}"
+
+    api_base = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "nightmarenet-robustness-check",
+    }
+
+    existing_id = None
+    req = urllib.request.Request(api_base, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            comments = json.loads(response.read().decode("utf-8"))
+        for comment in comments:
+            if MARKER in comment.get("body", ""):
+                existing_id = comment["id"]
+                break
+    except urllib.error.URLError as exc:
+        print(f"Failed to list comments: {exc}")
+
+    if existing_id:
+        url = f"https://api.github.com/repos/{repo}/issues/comments/{existing_id}"
+        method = "PATCH"
+    else:
+        url = api_base
+        method = "POST"
+
+    payload = json.dumps({"body": body}).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            print(f"PR comment {method} ok (status {response.status})")
+    except urllib.error.URLError as exc:
+        print(f"Failed to post comment: {exc}")
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -108,8 +108,20 @@ Learn how to use, extend, and deploy NightmareNet through our step-by-step tutor
 *   [Tutorial 3: Interpreting Results & Compliance](docs/tutorials/interpreting-results.md) — Understand robustness curves (AUC), generalization metrics, and generate signed EU AI Act compliance reports.
 *   [Tutorial 4: Vision Pipeline](docs/tutorials/vision-pipeline.md) — Load images, apply vision distortions (color jitter, noise, FGSM/PGD attacks), and evaluate vision models.
 *   [Tutorial 5: Deployment](docs/tutorials/deployment.md) — Configure, run, and scale production-grade docker containers, configure keys, and integrate alerts.
+*   [Tutorial 6: CI Robustness Check](docs/tutorials/ci-robustness-check.md) — Gate PRs with the `robustness-check` GitHub Action (threshold, score table, Marketplace branding).
 
 Client developers can also use the committed OpenAPI spec at [`docs/api/openapi.json`](docs/api/openapi.json) (regenerate with `make openapi`).
+
+### GitHub Action (robustness gate)
+
+```yaml
+- uses: Adit-Jain-srm/NightmareNet/.github/actions/robustness-check@v1
+  with:
+    model_path: distilbert-base-uncased
+    threshold: "0.7"
+```
+
+See [`examples/ci-robustness-check.yml`](examples/ci-robustness-check.yml) and [Tutorial 6](docs/tutorials/ci-robustness-check.md).
 
 ---
 

--- a/docs/tutorials/ci-robustness-check.md
+++ b/docs/tutorials/ci-robustness-check.md
@@ -1,0 +1,70 @@
+# Tutorial: CI Robustness Check (GitHub Action)
+
+Gate pull requests on NightmareNet robustness scores with a reusable composite
+Action: `nightmarenet-robustness-check` / `.github/actions/robustness-check`.
+
+## Minimal integration
+
+Add a workflow with five YAML lines of Action usage:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: Adit-Jain-srm/NightmareNet/.github/actions/robustness-check@v1
+  with:
+    model_path: distilbert-base-uncased
+    threshold: "0.7"
+```
+
+A complete example lives at [`examples/ci-robustness-check.yml`](../../examples/ci-robustness-check.yml).
+
+## Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `model_path` | — | Hugging Face model ID, or path to `.pt` / `.bin` |
+| `config_path` | — | Optional YAML for full `Evaluator` runs |
+| `threshold` | `0.7` | Minimum aggregate robustness score |
+| `distortion_types` | `dream,nightmare` | Which families to include in the score table |
+| `strengths` | `0.1,0.3,0.5,0.7,0.9` | Distortion sweep |
+| `post-comment` | `true` | Upsert a PR comment with the markdown table |
+
+## Outputs
+
+| Output | Meaning |
+| --- | --- |
+| `robustness_score` | Aggregate score in `[0, 1]` |
+| `passed` | `true` if score ≥ threshold |
+| `report_path` | JSON report on the runner (also uploaded as an artifact) |
+
+## What the PR comment shows
+
+- Overall score and pass/fail
+- Per-distortion (dream/nightmare × strength) scores in a markdown table
+
+The job **fails** when the score is below `threshold`, so you can require the
+check as a branch protection status.
+
+## Runtime notes
+
+- Without `config_path`, the Action uses the fast CLI path
+  (`nightmarenet evaluate --json`) — CPU-only and typically well under 5 minutes
+  for small models / probe text.
+- With `config_path`, the Action loads the Hugging Face / checkpoint model via
+  the full evaluator (heavier; prefer a small DistilBERT-class model in CI).
+- Publish / Marketplace: the Action ships with `branding` (`shield` / `purple`).
+  Maintainers can publish a tagged release (`v1`) to the GitHub Marketplace.
+
+## Local smoke test
+
+```bash
+# From a clone with nightmarenet installed:
+export INPUT_MODEL_PATH=distilbert-base-uncased
+export INPUT_THRESHOLD=0.5
+export INPUT_DISTORTION_TYPES=dream,nightmare
+export INPUT_STRENGTHS=0.1,0.5,0.9
+export GITHUB_OUTPUT=/tmp/nn-gh-out.txt
+python .github/actions/robustness-check/entrypoint.py
+```
+
+Optional: validate `action.yml` with [actionlint](https://github.com/rhysd/actionlint)
+and run end-to-end with [act](https://github.com/nektos/act).

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -77,6 +77,9 @@ To output results in a structured format suitable for CI/CD gates:
 nightmarenet evaluate --text "Robustness check." --strengths "0.1,0.5,0.9" --json
 ```
 
+To wire the same gate into GitHub Actions (PR comment + threshold fail), use the
+composite Action — see [Tutorial 6: CI Robustness Check](ci-robustness-check.md).
+
 #### Expected CLI Output:
 ```json
 {

--- a/examples/ci-robustness-check.yml
+++ b/examples/ci-robustness-check.yml
@@ -1,0 +1,39 @@
+# Example: NightmareNet robustness gate in CI
+#
+# Copy into your repo as `.github/workflows/robustness-check.yml`
+# (or reference this file from docs). Uses the composite action shipped
+# with NightmareNet.
+#
+# Fast path (no full model load): model_path is a label; evaluate runs the
+# dream/nightmare distortion sweep on CPU in well under 5 minutes.
+
+name: NightmareNet Robustness Check
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  robustness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Robustness gate
+        id: check
+        uses: Adit-Jain-srm/NightmareNet/.github/actions/robustness-check@v1
+        with:
+          model_path: distilbert-base-uncased
+          threshold: "0.5"
+          distortion_types: dream,nightmare
+
+      - name: Echo outputs
+        run: |
+          echo "score=${{ steps.check.outputs.robustness_score }}"
+          echo "passed=${{ steps.check.outputs.passed }}"
+          echo "report=${{ steps.check.outputs.report_path }}"

--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -96,7 +96,7 @@ def cmd_evaluate(args: argparse.Namespace) -> int:
     instead of the standard distortion-based evaluation.
 
     When ``--json`` is supplied, emits a single JSON object on stdout suitable
-    for CI consumption (e.g. the ``nightmarenet-robustness-check`` composite
+    for CI consumption (e.g. the ``.github/actions/robustness-check`` composite
     GitHub Action) containing per-strength similarity scores plus an aggregate
     ``robustness_score`` in ``[0, 1]``.
     """

--- a/tests/test_robustness_check_action.py
+++ b/tests/test_robustness_check_action.py
@@ -1,0 +1,97 @@
+"""Unit tests for the robustness-check Action helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRY = ROOT / ".github" / "actions" / "robustness-check" / "entrypoint.py"
+
+
+def _load_entrypoint():
+    spec = importlib.util.spec_from_file_location("robustness_check_entrypoint", ENTRY)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ep():
+    return _load_entrypoint()
+
+
+def test_extract_score(ep):
+    assert ep.extract_score({"robustness_score": 0.81}) == 0.81
+
+
+def test_filter_aggregate_respects_distortion_types(ep):
+    report = {
+        "robustness_score": 0.5,
+        "avg_dream_similarity": 0.9,
+        "avg_nightmare_similarity": 0.1,
+    }
+    assert ep.filter_aggregate(report, ["dream"]) == 0.9
+    assert ep.filter_aggregate(report, ["nightmare"]) == 0.1
+    assert ep.filter_aggregate(report, ["dream", "nightmare"]) == 0.5
+
+
+def test_per_distortion_rows(ep):
+    report = {
+        "strengths": [
+            {
+                "strength": 0.5,
+                "dream_similarity": 0.8,
+                "nightmare_similarity": 0.4,
+            }
+        ]
+    }
+    rows = ep.per_distortion_rows(report, ["dream", "nightmare"])
+    assert ("dream@0.5", 0.8) in rows
+    assert ("nightmare@0.5", 0.4) in rows
+
+
+def test_format_markdown_contains_table_and_marker(ep):
+    md = ep.format_markdown(
+        model="distilbert-base-uncased",
+        score=0.75,
+        threshold=0.7,
+        passed=True,
+        rows=[("dream@0.5", 0.8)],
+        report_path="/tmp/report.json",
+    )
+    assert ep.MARKER in md
+    assert "PASSED" in md
+    assert "| dream@0.5 | 0.8000 |" in md
+    assert "0.7500" in md
+
+
+def test_entrypoint_fails_below_threshold(ep, tmp_path, monkeypatch):
+    report = {
+        "model": "m",
+        "robustness_score": 0.4,
+        "avg_dream_similarity": 0.4,
+        "avg_nightmare_similarity": 0.4,
+        "strengths": [],
+    }
+
+    def fake_run(cmd, report_path):
+        report_path.write_text("{}", encoding="utf-8")
+        return report
+
+    monkeypatch.setenv("INPUT_MODEL_PATH", "distilbert-base-uncased")
+    monkeypatch.setenv("INPUT_THRESHOLD", "0.7")
+    monkeypatch.setenv("INPUT_DISTORTION_TYPES", "dream,nightmare")
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    monkeypatch.setenv("INPUT_COMMENT_PATH", str(tmp_path / "comment.md"))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(ep, "run_evaluate", fake_run)
+    monkeypatch.setattr(ep, "build_evaluate_cmd", lambda **kwargs: ["nightmarenet", "evaluate"])
+
+    assert ep.main() == 1
+    assert (tmp_path / "comment.md").is_file()


### PR DESCRIPTION
## Summary
- Adds `.github/actions/robustness-check` composite Action (`model_path`, `config_path`, `threshold`, `distortion_types`)
- Outputs `robustness_score`, `passed`, `report_path`; PR comment with per-distortion table; fails under threshold
- Example workflow, tutorial, README snippet, and unit tests for entrypoint helpers
Closes #702
## Test plan
- [x] `pytest tests/test_robustness_check_action.py`
- [x] Local entrypoint smoke run (`nightmarenet evaluate --json`)
- [ ] Optional: `actionlint` / `act` against `examples/ci-robustness-check.yml`

