### PR TITLE
test: add KeyboardHelp component tests

### DIFF
--- a/frontend/src/__tests__/KeyboardHelp.test.tsx
+++ b/frontend/src/__tests__/KeyboardHelp.test.tsx
@@ -24,10 +24,10 @@ describe("KeyboardHelp", () => {
     render(<KeyboardHelp open={true} onClose={onClose} />);
 
     fireEvent.click(
-    screen.getAllByRole("button", {
-    name: /close keyboard shortcuts/i,
-    })[0],
-   );
+      screen.getAllByRole("button", {
+        name: /close keyboard shortcuts/i,
+      })[0],
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/__tests__/KeyboardHelp.test.tsx
+++ b/frontend/src/__tests__/KeyboardHelp.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { KeyboardHelp } from "@/components/dashboard/KeyboardHelp";
+
+vi.mock("@/components/dashboard/../a11y/useDialogFocus", () => ({
+  useDialogFocus: vi.fn(),
+}));
+
+describe("KeyboardHelp", () => {
+  it("renders the keyboard shortcuts modal when open", () => {
+    render(<KeyboardHelp open={true} onClose={vi.fn()} />);
+
+    expect(
+      screen.getByRole("dialog", { name: /keyboard shortcuts/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Global")).toBeInTheDocument();
+    expect(screen.getByText("Navigation (press g, then …)")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+
+    render(<KeyboardHelp open={true} onClose={onClose} />);
+
+    fireEvent.click(
+    screen.getAllByRole("button", {
+    name: /close keyboard shortcuts/i,
+    })[0],
+   );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the modal when closed", () => {
+    render(<KeyboardHelp open={false} onClose={vi.fn()} />);
+
+    expect(
+      screen.queryByRole("dialog", { name: /keyboard shortcuts/i }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the KeyboardHelp component.

## Changes
- Tests rendering when the modal is open
- Tests the close button callback
- Tests that the modal is not rendered when closed

## Testing
- KeyboardHelp tests: 3/3 passed
- `npx vitest run src/__tests__/KeyboardHelp.test.tsx`

## Notes
This PR only adds tests and does not modify the existing KeyboardHelp component behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the keyboard help dialog’s open and closed states.
  * Verified shortcut section visibility and close-button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->