### PR TITLE
feat: add layout-aware multilingual keyboard typo engine (#698)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Learn how to use, extend, and deploy NightmareNet through our step-by-step tutor
 
 *   [Tutorial 1: Getting Started](docs/tutorials/getting-started.md) — Install NightmareNet, configure your first project, and run your first model robustness evaluation in under 5 minutes.
 *   [Tutorial 2: Custom Distortions](docs/tutorials/custom-distortions.md) — Implement class-based or decorator-based custom perturbation engines and plug them into the registry.
+*   [Multilingual keyboard typos](docs/features/multilingual-keyboard-typo.md) — Layout-aware `keyboard_typo` for English, German, French, Russian, Hindi, Arabic.
 *   [Tutorial 3: Interpreting Results & Compliance](docs/tutorials/interpreting-results.md) — Understand robustness curves (AUC), generalization metrics, and generate signed EU AI Act compliance reports.
 *   [Tutorial 4: Vision Pipeline](docs/tutorials/vision-pipeline.md) — Load images, apply vision distortions (color jitter, noise, FGSM/PGD attacks), and evaluate vision models.
 *   [Tutorial 5: Deployment](docs/tutorials/deployment.md) — Configure, run, and scale production-grade docker containers, configure keys, and integrate alerts.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -50,7 +50,7 @@ distortion:
   dream_dp_delta: 1.0e-5
   dream_dp_sensitivity: 1.0
   language: english           # Default language for keyboard_typo
-  keyboard_layout: qwerty     # Override layout; null uses language default
+  keyboard_layout: null       # Override layout; null uses language default (english → qwerty)
   strength_schedule: uniform # uniform|linear|cosine|step (within-epoch scheduling for nightmare phase)
   schedule_across_cycles: false # Enable/disable per-cycle strength scheduling (paper formula)
   strength_min: 0.2 # Min strength for non-uniform schedules

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -49,6 +49,8 @@ distortion:
   dream_dp_epsilon: null  # null = off; float enables ε-calibrated Gaussian DP noise in Dream
   dream_dp_delta: 1.0e-5
   dream_dp_sensitivity: 1.0
+  language: english           # Default language for keyboard_typo
+  keyboard_layout: qwerty     # Override layout; null uses language default
   strength_schedule: uniform # uniform|linear|cosine|step (within-epoch scheduling for nightmare phase)
   schedule_across_cycles: false # Enable/disable per-cycle strength scheduling (paper formula)
   strength_min: 0.2 # Min strength for non-uniform schedules

--- a/docs/features/multilingual-keyboard-typo.md
+++ b/docs/features/multilingual-keyboard-typo.md
@@ -33,3 +33,7 @@ print(distort("hello", strength=0.5, seed=1, keyboard_layout="dvorak"))
 
 Error types: replace (nearby key), insert (double press), delete, transpose.
 `strength` maps to character error rate in `[0, 1]`.
+
+### Known Limitations
+
+- **Complex grapheme clusters:** Hindi/Arabic combining characters (vowel signs, virama) are split using Unicode `\X` grapheme segmentation, which handles most cases correctly. However, some edge cases with deeply nested combining sequences may produce unexpected results. Grapheme cluster preservation improvements are planned for v2.

--- a/docs/features/multilingual-keyboard-typo.md
+++ b/docs/features/multilingual-keyboard-typo.md
@@ -1,0 +1,35 @@
+# Multilingual Keyboard Typo Distortion
+
+Layout-aware typographical noise for English, German, French, Russian, Hindi,
+and Arabic. Neighbors are taken from QWERTY / QWERTZ / AZERTY / Cyrillic /
+Arabic / Devanagari grids (horizontal neighbors weighted higher than vertical).
+
+## CLI
+
+```bash
+nightmarenet distort --type keyboard_typo --language german --text "Hallo Welt" --strength 0.5 --seed 42
+nightmarenet distort --list-engines   # includes keyboard_typo
+```
+
+Optional `--keyboard-layout` overrides the language default (`qwertz` for German,
+`azerty` for French, etc.).
+
+## Config
+
+```yaml
+distortion:
+  language: german
+  keyboard_layout: qwertz   # optional override
+```
+
+## Custom layouts
+
+```python
+from nightmarenet.distortions.multilingual import register_layout, distort
+
+register_layout("dvorak", ("pyfgcrl", "aoeuidhtns", "qjkxbmwvz"))
+print(distort("hello", strength=0.5, seed=1, keyboard_layout="dvorak"))
+```
+
+Error types: replace (nearby key), insert (double press), delete, transpose.
+`strength` maps to character error rate in `[0, 1]`.

--- a/docs/research/paper-draft.md
+++ b/docs/research/paper-draft.md
@@ -104,7 +104,11 @@ remain the dominant defenses but trade clean for adversarial accuracy.
 **Curriculum Adversarial Training (CAT)** [Cai et al., 2018] schedules
 perturbation budgets from small to large, with follow-up dynamic-strength work
 [Wang et al., 2019; Zhang et al., 2020]. **FreeLB** [Zhu et al., 2020]
-amortizes adversarial cost via free large-batch updates. NightmareNet
+amortizes adversarial cost via free large-batch updates. Multilingual typo
+robustness work such as MulTypo [Zhao et al., ACL 2026] shows that
+keyboard-layout noise hits low-resource languages hardest; NightmareNet
+exposes a clean-room layout-aware `keyboard_typo` engine for the same
+evaluation setting. NightmareNet
 inherits curriculum scheduling inside its Nightmare phase, but the surrounding
 Dream and Compress phases address two failure modes that curriculum training
 alone cannot: (a) distribution-shift sensitivity (handled by Dream) and

--- a/nightmarenet/cli.py
+++ b/nightmarenet/cli.py
@@ -532,7 +532,15 @@ def cmd_distort(args: argparse.Namespace) -> int:
             logger.error("Available: %s", ", ".join(registry.engine_names))
             return 1
 
-        result = registry.apply(args.engine, text, strength=strength, seed=args.seed)
+        apply_kwargs = {}
+        if getattr(args, "language", None):
+            apply_kwargs["language"] = args.language
+        if getattr(args, "keyboard_layout", None):
+            apply_kwargs["keyboard_layout"] = args.keyboard_layout
+
+        result = registry.apply(
+            args.engine, text, strength=strength, seed=args.seed, **apply_kwargs
+        )
         engine_meta = registry.get_engine_metadata(args.engine)
         print(f"Original:  {text}")
         print(f"Distorted: {result}")
@@ -543,18 +551,30 @@ def cmd_distort(args: argparse.Namespace) -> int:
     else:
         # Legacy behavior for backward compatibility
         from nightmarenet.distortions import dream, nightmare
+        from nightmarenet.distortions.multilingual.typo_engine import keyboard_typo
 
         if args.type == "dream":
             result = dream.distort(text, strength=strength, seed=args.seed)
         elif args.type == "nightmare":
             result = nightmare.distort(text, strength=strength, seed=args.seed)
+        elif args.type == "keyboard_typo":
+            result = keyboard_typo(
+                text,
+                strength=strength,
+                seed=args.seed,
+                language=getattr(args, "language", None),
+                keyboard_layout=getattr(args, "keyboard_layout", None),
+            )
         else:
             logger.error("Unknown distortion type: %s", args.type)
             return 1
 
         print(f"Original:  {text}")
         print(f"Distorted: {result}")
-        print(f"  Type: {args.type}, Strength: {strength}")
+        extra = ""
+        if args.type == "keyboard_typo" and getattr(args, "language", None):
+            extra = f", Language: {args.language}"
+        print(f"  Type: {args.type}, Strength: {strength}{extra}")
 
     return 0
 
@@ -900,7 +920,7 @@ def build_parser() -> argparse.ArgumentParser:
     distort_parser = subparsers.add_parser("distort", help="Apply distortion to text")
     distort_parser.add_argument(
         "--type",
-        choices=["dream", "nightmare"],
+        choices=["dream", "nightmare", "keyboard_typo"],
         help="Single engine type (mutually exclusive with --preset)",
     )
     distort_parser.add_argument(
@@ -909,6 +929,17 @@ def build_parser() -> argparse.ArgumentParser:
     distort_parser.add_argument("--text", required=True, help="Input text to distort")
     distort_parser.add_argument(
         "--seed", type=int, default=None, help="Random seed for reproducibility"
+    )
+    distort_parser.add_argument(
+        "--language",
+        default=None,
+        help="Language for keyboard_typo (english, german, french, russian, hindi, arabic)",
+    )
+    distort_parser.add_argument(
+        "--keyboard-layout",
+        dest="keyboard_layout",
+        default=None,
+        help="Override keyboard layout (qwerty, qwertz, azerty, cyrillic, arabic, devanagari)",
     )
     distort_parser.add_argument("--preset", help="Name of preset chain to apply")
     distort_parser.add_argument(

--- a/nightmarenet/distortions/__init__.py
+++ b/nightmarenet/distortions/__init__.py
@@ -7,6 +7,12 @@ from nightmarenet.distortions.base import BaseDistortion as BaseDistortion
 from nightmarenet.distortions.loader import (
     load_custom_engine as load_custom_engine,
 )
+from nightmarenet.distortions.multilingual import (
+    keyboard_typo as keyboard_typo,
+)
+from nightmarenet.distortions.multilingual import (
+    register_layout as register_layout,
+)
 from nightmarenet.distortions.registry import (
     DistortionRegistry as DistortionRegistry,
 )
@@ -36,4 +42,6 @@ __all__ = [
     "apply_semantic_distortions",
     "apply_adversarial_distortions",
     "load_custom_engine",
+    "keyboard_typo",
+    "register_layout",
 ]

--- a/nightmarenet/distortions/multilingual/__init__.py
+++ b/nightmarenet/distortions/multilingual/__init__.py
@@ -1,0 +1,24 @@
+"""Multilingual keyboard-layout typo distortions."""
+
+from nightmarenet.distortions.multilingual.keyboard_layouts import (
+    LANGUAGE_LAYOUTS,
+    default_layout_for_language,
+    get_layout,
+    list_layouts,
+    normalize_language,
+    register_layout,
+    unregister_layout,
+)
+from nightmarenet.distortions.multilingual.typo_engine import distort, keyboard_typo
+
+__all__ = [
+    "LANGUAGE_LAYOUTS",
+    "default_layout_for_language",
+    "distort",
+    "get_layout",
+    "keyboard_typo",
+    "list_layouts",
+    "normalize_language",
+    "register_layout",
+    "unregister_layout",
+]

--- a/nightmarenet/distortions/multilingual/keyboard_layouts.py
+++ b/nightmarenet/distortions/multilingual/keyboard_layouts.py
@@ -1,0 +1,173 @@
+"""Builtin and custom keyboard layouts for multilingual typo noise.
+
+Layouts store weighted neighbors (horizontal vs vertical). Inspired by
+layout-aware typo models such as MulTypo (Zhao et al., ACL 2026), but
+implemented clean-room without that package.
+"""
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+NeighborList = List[Tuple[str, float]]
+
+
+# Default weights: adjacent keys on the same row beat vertical neighbors.
+DEFAULT_H_WEIGHT = 1.0
+DEFAULT_V_WEIGHT = 0.65
+
+
+def _neighbors_from_rows(
+    rows: Sequence[str],
+    h_weight: float = DEFAULT_H_WEIGHT,
+    v_weight: float = DEFAULT_V_WEIGHT,
+) -> Dict[str, NeighborList]:
+    """Build adjacency from physical keyboard rows (left-to-right)."""
+    grid = [list(r) for r in rows]
+    coords: Dict[str, List[Tuple[int, int]]] = {}
+    for r, row in enumerate(grid):
+        for c, ch in enumerate(row):
+            coords.setdefault(ch, []).append((r, c))
+
+    neighbors: Dict[str, NeighborList] = {}
+    for ch, positions in coords.items():
+        weighted: Dict[str, float] = {}
+        for r, c in positions:
+            for dc, w in ((-1, h_weight), (1, h_weight)):
+                nc = c + dc
+                if 0 <= nc < len(grid[r]):
+                    other = grid[r][nc]
+                    if other != ch:
+                        weighted[other] = max(weighted.get(other, 0.0), w)
+            for dr, w in ((-1, v_weight), (1, v_weight)):
+                nr = r + dr
+                if 0 <= nr < len(grid) and 0 <= c < len(grid[nr]):
+                    other = grid[nr][c]
+                    if other != ch:
+                        weighted[other] = max(weighted.get(other, 0.0), w)
+        neighbors[ch] = [(k, v) for k, v in sorted(weighted.items())]
+    return neighbors
+
+
+# Physical rows (lowercase / base letters only).
+_LAYOUT_ROWS: Dict[str, Tuple[str, ...]] = {
+    "qwerty": ("qwertyuiop", "asdfghjkl", "zxcvbnm"),
+    "qwertz": ("qwertzuiop", "asdfghjkl", "yxcvbnm"),
+    "azerty": ("azertyuiop", "qsdfghjklm", "wxcvbn"),
+    # ЙЦУКЕН (Russian)
+    "cyrillic": (
+        "йцукенгшщзхъ",
+        "фывапролджэ",
+        "ячсмитьбю",
+    ),
+    # Simplified Arabic PC (common letter block)
+    "arabic": (
+        "ضصثقفغعهخح",
+        "شسيبلاتنمك",
+        "ئءؤرلاىةوزظ",
+    ),
+    # Simplified InScript-style Devanagari letter block
+    "devanagari": (
+        "कखगघङचछजझञ",
+        "टठडढणतथदधन",
+        "पफबभमयरलवशषसह",
+    ),
+}
+
+
+_CUSTOM_LAYOUTS: Dict[str, Dict[str, NeighborList]] = {}
+
+
+def list_layouts() -> List[str]:
+    names = set(_LAYOUT_ROWS) | set(_CUSTOM_LAYOUTS)
+    return sorted(names)
+
+
+def register_layout(
+    name: str,
+    rows: Sequence[str],
+    *,
+    h_weight: float = DEFAULT_H_WEIGHT,
+    v_weight: float = DEFAULT_V_WEIGHT,
+    overwrite: bool = False,
+) -> None:
+    """Register a custom keyboard layout from row strings.
+
+    Args:
+        name: Layout id (e.g. ``dvorak``).
+        rows: Physical key rows, left-to-right.
+        h_weight: Weight for same-row neighbors.
+        v_weight: Weight for vertical neighbors.
+        overwrite: Replace an existing custom layout with the same name.
+    """
+    key = name.strip().lower()
+    if not key:
+        raise ValueError("layout name must be non-empty")
+    if key in _LAYOUT_ROWS and not overwrite:
+        raise ValueError(f"cannot overwrite builtin layout '{key}'")
+    if key in _CUSTOM_LAYOUTS and not overwrite:
+        raise ValueError(f"layout '{key}' already registered")
+    _CUSTOM_LAYOUTS[key] = _neighbors_from_rows(rows, h_weight=h_weight, v_weight=v_weight)
+
+
+def unregister_layout(name: str) -> None:
+    """Remove a previously registered custom layout (builtins are kept)."""
+    _CUSTOM_LAYOUTS.pop(name.strip().lower(), None)
+
+
+def get_layout(
+    name: str,
+    *,
+    h_weight: float = DEFAULT_H_WEIGHT,
+    v_weight: float = DEFAULT_V_WEIGHT,
+) -> Dict[str, NeighborList]:
+    """Return neighbor map for a layout name."""
+    key = name.strip().lower()
+    if key in _CUSTOM_LAYOUTS:
+        return _CUSTOM_LAYOUTS[key]
+    if key not in _LAYOUT_ROWS:
+        available = ", ".join(list_layouts())
+        raise KeyError(f"Unknown keyboard layout '{name}'. Available: {available}")
+    return _neighbors_from_rows(_LAYOUT_ROWS[key], h_weight=h_weight, v_weight=v_weight)
+
+
+# Language code / name -> default layout
+LANGUAGE_LAYOUTS: Dict[str, str] = {
+    "english": "qwerty",
+    "en": "qwerty",
+    "german": "qwertz",
+    "de": "qwertz",
+    "french": "azerty",
+    "fr": "azerty",
+    "russian": "cyrillic",
+    "ru": "cyrillic",
+    "hindi": "devanagari",
+    "hi": "devanagari",
+    "arabic": "arabic",
+    "ar": "arabic",
+}
+
+
+def normalize_language(language: Optional[str]) -> str:
+    if not language:
+        return "english"
+    key = language.strip().lower()
+    if key not in LANGUAGE_LAYOUTS:
+        supported = ", ".join(sorted({k for k in LANGUAGE_LAYOUTS if len(k) > 2}))
+        raise ValueError(f"Unsupported language '{language}'. Supported: {supported}")
+    return key
+
+
+def default_layout_for_language(language: Optional[str]) -> str:
+    key = normalize_language(language)
+    # Prefer canonical names over ISO codes for lookups that already passed normalize
+    if key in LANGUAGE_LAYOUTS:
+        return LANGUAGE_LAYOUTS[key]
+    return "qwerty"
+
+
+def resolve_layout_name(
+    language: Optional[str] = None,
+    keyboard_layout: Optional[str] = None,
+) -> str:
+    if keyboard_layout:
+        return keyboard_layout.strip().lower()
+    return default_layout_for_language(language)

--- a/nightmarenet/distortions/multilingual/keyboard_layouts.py
+++ b/nightmarenet/distortions/multilingual/keyboard_layouts.py
@@ -101,7 +101,7 @@ def register_layout(
     key = name.strip().lower()
     if not key:
         raise ValueError("layout name must be non-empty")
-    if key in _LAYOUT_ROWS and not overwrite:
+    if key in _LAYOUT_ROWS:
         raise ValueError(f"cannot overwrite builtin layout '{key}'")
     if key in _CUSTOM_LAYOUTS and not overwrite:
         raise ValueError(f"layout '{key}' already registered")

--- a/nightmarenet/distortions/multilingual/typo_engine.py
+++ b/nightmarenet/distortions/multilingual/typo_engine.py
@@ -7,12 +7,16 @@ Four error classes on layout neighbors:
   transpose — swap with next character
 
 ``strength`` in [0, 1] is treated as a character error rate target.
+Edits operate on Unicode grapheme clusters so Devanagari matras / viramas
+stay attached to their base letters.
 """
 
 from __future__ import annotations
 
 import random
 from typing import List, Optional, Sequence, Tuple
+
+import regex
 
 from nightmarenet.distortions.multilingual.keyboard_layouts import (
     get_layout,
@@ -23,6 +27,18 @@ from nightmarenet.distortions.multilingual.keyboard_layouts import (
 ERROR_TYPES = ("replace", "insert", "delete", "transpose")
 
 
+def _graphemes(text: str) -> List[str]:
+    """Split into user-perceived characters (keeps combining marks attached)."""
+    return regex.findall(r"\X", text)
+
+
+def _layout_key(cluster: str) -> str:
+    """Map a grapheme cluster to a layout key (first code point, lowercased)."""
+    if not cluster:
+        return ""
+    return cluster[0].lower()
+
+
 def _pick_neighbor(neighbors: Sequence[Tuple[str, float]], rng: random.Random) -> str:
     chars, weights = zip(*neighbors)
     return rng.choices(list(chars), weights=list(weights), k=1)[0]
@@ -30,8 +46,8 @@ def _pick_neighbor(neighbors: Sequence[Tuple[str, float]], rng: random.Random) -
 
 def _eligible_indices(chars: List[str], layout) -> List[int]:
     out = []
-    for i, ch in enumerate(chars):
-        key = ch.lower() if ch.isascii() and ch.isalpha() else ch
+    for i, cluster in enumerate(chars):
+        key = _layout_key(cluster)
         if key in layout and layout[key]:
             out.append(i)
     return out
@@ -67,7 +83,7 @@ def distort(
     layout = get_layout(layout_name, h_weight=h_weight, v_weight=v_weight)
     rng = random.Random(seed)
 
-    chars = list(text)
+    chars = _graphemes(text)
     # Cap edits so short strings still change under moderate strength.
     n_edits = max(1, int(round(len(chars) * min(strength, 1.0)))) if strength > 0 else 0
     # At very low strength, probabilistic single-pass CER is enough.
@@ -93,14 +109,15 @@ def distort(
         if not eligible:
             continue
         idx = rng.choice(eligible)
-        ch = chars[idx]
-        key = ch.lower() if ch.isascii() and ch.isalpha() else ch
+        cluster = chars[idx]
+        key = _layout_key(cluster)
         neighbors = layout.get(key) or []
         if not neighbors:
             continue
 
         replacement = _pick_neighbor(neighbors, rng)
-        if ch.isascii() and ch.isupper() and replacement.isalpha():
+        # Preserve case for Latin / Cyrillic (and any cased script).
+        if cluster[0].isupper() and replacement.isalpha():
             replacement = replacement.upper()
 
         if err == "insert":

--- a/nightmarenet/distortions/multilingual/typo_engine.py
+++ b/nightmarenet/distortions/multilingual/typo_engine.py
@@ -1,0 +1,128 @@
+"""Keyboard-layout-aware typo distortion (MulTypo-style, clean-room).
+
+Four error classes on layout neighbors:
+  replace  — nearby key
+  insert   — accidental double press
+  delete   — skipped key
+  transpose — swap with next character
+
+``strength`` in [0, 1] is treated as a character error rate target.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import List, Optional, Sequence, Tuple
+
+from nightmarenet.distortions.multilingual.keyboard_layouts import (
+    get_layout,
+    normalize_language,
+    resolve_layout_name,
+)
+
+ERROR_TYPES = ("replace", "insert", "delete", "transpose")
+
+
+def _pick_neighbor(neighbors: Sequence[Tuple[str, float]], rng: random.Random) -> str:
+    chars, weights = zip(*neighbors)
+    return rng.choices(list(chars), weights=list(weights), k=1)[0]
+
+
+def _eligible_indices(chars: List[str], layout) -> List[int]:
+    out = []
+    for i, ch in enumerate(chars):
+        key = ch.lower() if ch.isascii() and ch.isalpha() else ch
+        if key in layout and layout[key]:
+            out.append(i)
+    return out
+
+
+def distort(
+    text: str,
+    strength: float = 0.3,
+    seed: Optional[int] = None,
+    language: Optional[str] = None,
+    keyboard_layout: Optional[str] = None,
+    h_weight: float = 1.0,
+    v_weight: float = 0.65,
+) -> str:
+    """Apply layout-aware typos to ``text``.
+
+    Args:
+        text: Input string.
+        strength: Character error rate in [0, 1]. ``0`` is a no-op.
+        seed: Optional RNG seed for determinism.
+        language: english / german / french / russian / hindi / arabic (or ISO codes).
+        keyboard_layout: Override layout id (qwerty, qwertz, azerty, ...).
+        h_weight: Horizontal neighbor weight.
+        v_weight: Vertical neighbor weight.
+    """
+    if not text:
+        return text
+    if strength <= 0.0:
+        return text
+
+    lang = normalize_language(language)
+    layout_name = resolve_layout_name(lang, keyboard_layout)
+    layout = get_layout(layout_name, h_weight=h_weight, v_weight=v_weight)
+    rng = random.Random(seed)
+
+    chars = list(text)
+    # Cap edits so short strings still change under moderate strength.
+    n_edits = max(1, int(round(len(chars) * min(strength, 1.0)))) if strength > 0 else 0
+    # At very low strength, probabilistic single-pass CER is enough.
+    if strength < 0.15:
+        n_edits = sum(1 for _ in chars if rng.random() < strength)
+
+    for _ in range(n_edits):
+        eligible = _eligible_indices(chars, layout)
+        if not eligible and len(chars) < 2:
+            break
+        err = rng.choice(ERROR_TYPES)
+
+        if err == "delete" and chars:
+            idx = rng.randrange(len(chars))
+            del chars[idx]
+            continue
+
+        if err == "transpose" and len(chars) >= 2:
+            idx = rng.randrange(len(chars) - 1)
+            chars[idx], chars[idx + 1] = chars[idx + 1], chars[idx]
+            continue
+
+        if not eligible:
+            continue
+        idx = rng.choice(eligible)
+        ch = chars[idx]
+        key = ch.lower() if ch.isascii() and ch.isalpha() else ch
+        neighbors = layout.get(key) or []
+        if not neighbors:
+            continue
+
+        replacement = _pick_neighbor(neighbors, rng)
+        if ch.isascii() and ch.isupper() and replacement.isalpha():
+            replacement = replacement.upper()
+
+        if err == "insert":
+            chars.insert(idx + 1, replacement)
+        else:  # replace
+            chars[idx] = replacement
+
+    return "".join(chars)
+
+
+def keyboard_typo(
+    text: str,
+    strength: float = 0.3,
+    seed: Optional[int] = None,
+    language: Optional[str] = None,
+    keyboard_layout: Optional[str] = None,
+) -> str:
+    """Registry / CLI entry point for the ``keyboard_typo`` engine."""
+    return distort(
+        text,
+        strength=strength,
+        seed=seed,
+        language=language,
+        keyboard_layout=keyboard_layout,
+    )

--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import importlib.metadata
+import inspect
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -145,9 +146,10 @@ class DistortionRegistry:
         fn = self._engines[name]
         if kwargs:
             try:
-                return fn(text, strength, seed, **kwargs)
+                inspect.signature(fn).bind(text, strength, seed, **kwargs)
             except TypeError:
                 return fn(text, strength, seed)
+            return fn(text, strength, seed, **kwargs)
         return fn(text, strength, seed)
 
     def list_engines(self) -> List[Dict[str, Any]]:

--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -46,6 +46,7 @@ class DistortionRegistry:
     def _register_builtins(self) -> None:
         from nightmarenet.distortions import dream as dream_mod
         from nightmarenet.distortions import nightmare as nightmare_mod
+        from nightmarenet.distortions.multilingual.typo_engine import keyboard_typo
 
         self.register(
             "dream",
@@ -62,6 +63,15 @@ class DistortionRegistry:
             metadata={
                 "phase": "nightmare",
                 "description": "Adversarial perturbation",
+                "source": "builtin",
+            },
+        )
+        self.register(
+            "keyboard_typo",
+            keyboard_typo,
+            metadata={
+                "phase": "dream",
+                "description": "Layout-aware multilingual keyboard typos",
                 "source": "builtin",
             },
         )
@@ -122,12 +132,23 @@ class DistortionRegistry:
         text: str,
         strength: float = 0.3,
         seed: Optional[int] = None,
+        **kwargs: Any,
     ) -> str:
-        """Apply a named distortion to text."""
+        """Apply a named distortion to text.
+
+        Extra keyword arguments (e.g. ``language``, ``keyboard_layout``) are
+        forwarded when the registered function accepts them.
+        """
         if name not in self._engines:
             available = ", ".join(sorted(self._engines.keys()))
             raise KeyError(f"Unknown distortion '{name}'. Available: {available}")
-        return self._engines[name](text, strength, seed)
+        fn = self._engines[name]
+        if kwargs:
+            try:
+                return fn(text, strength, seed, **kwargs)
+            except TypeError:
+                return fn(text, strength, seed)
+        return fn(text, strength, seed)
 
     def list_engines(self) -> List[Dict[str, Any]]:
         """List all registered distortion engines with metadata."""

--- a/nightmarenet/distortions/registry.py
+++ b/nightmarenet/distortions/registry.py
@@ -145,11 +145,10 @@ class DistortionRegistry:
             raise KeyError(f"Unknown distortion '{name}'. Available: {available}")
         fn = self._engines[name]
         if kwargs:
-            try:
-                inspect.signature(fn).bind(text, strength, seed, **kwargs)
-            except TypeError:
-                return fn(text, strength, seed)
-            return fn(text, strength, seed, **kwargs)
+            sig = inspect.signature(fn)
+            supported = set(sig.parameters.keys())
+            filtered = {k: v for k, v in kwargs.items() if k in supported}
+            return fn(text, strength, seed, **filtered)
         return fn(text, strength, seed)
 
     def list_engines(self) -> List[Dict[str, Any]]:

--- a/nightmarenet/distortions/validators.py
+++ b/nightmarenet/distortions/validators.py
@@ -132,6 +132,37 @@ def validate_base_distortion(engine_cls: type) -> List[str]:
     return failures
 
 
+def validate_language(language: Any) -> List[str]:
+    """Validate a distortion language name or ISO code."""
+    from nightmarenet.distortions.multilingual.keyboard_layouts import LANGUAGE_LAYOUTS
+
+    failures: List[str] = []
+    if not isinstance(language, str) or not language.strip():
+        failures.append("language must be a non-empty string")
+        return failures
+    key = language.strip().lower()
+    if key not in LANGUAGE_LAYOUTS:
+        supported = ", ".join(sorted({k for k in LANGUAGE_LAYOUTS if len(k) > 2}))
+        failures.append(f"unsupported language '{language}' (supported: {supported})")
+    return failures
+
+
+def validate_keyboard_layout(layout: Any) -> List[str]:
+    """Validate that a keyboard layout id is known (builtin or custom)."""
+    from nightmarenet.distortions.multilingual.keyboard_layouts import list_layouts
+
+    failures: List[str] = []
+    if not isinstance(layout, str) or not layout.strip():
+        failures.append("keyboard_layout must be a non-empty string")
+        return failures
+    key = layout.strip().lower()
+    if key not in list_layouts():
+        failures.append(
+            f"unknown keyboard_layout '{layout}' (available: {', '.join(list_layouts())})"
+        )
+    return failures
+
+
 def validate_plugin_package(
     package_name: str,
 ) -> List[str]:

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -98,7 +98,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "dream_dp_delta": 1e-5,
         "dream_dp_sensitivity": 1.0,
         "language": "english",
-        "keyboard_layout": "qwerty",
+        "keyboard_layout": None,
         "strength_schedule": "uniform",
         "schedule_across_cycles": False,
         "strength_min": 0.2,

--- a/nightmarenet/utils/config.py
+++ b/nightmarenet/utils/config.py
@@ -97,6 +97,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "dream_dp_epsilon": None,
         "dream_dp_delta": 1e-5,
         "dream_dp_sensitivity": 1.0,
+        "language": "english",
+        "keyboard_layout": "qwerty",
         "strength_schedule": "uniform",
         "schedule_across_cycles": False,
         "strength_min": 0.2,

--- a/tests/test_multilingual_keyboard.py
+++ b/tests/test_multilingual_keyboard.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import unicodedata
+
 import pytest
+import regex
 
 from nightmarenet.distortions.multilingual import (
     distort,
@@ -14,6 +17,7 @@ from nightmarenet.distortions.multilingual import (
 from nightmarenet.distortions.multilingual.keyboard_layouts import (
     LANGUAGE_LAYOUTS,
     default_layout_for_language,
+    resolve_layout_name,
 )
 from nightmarenet.distortions.registry import DistortionRegistry
 from nightmarenet.distortions.validators import (
@@ -38,7 +42,7 @@ def test_language_produces_output(language: str) -> None:
     out = keyboard_typo(text, strength=0.6, seed=7, language=language)
     assert isinstance(out, str)
     assert out != ""
-    # High strength should usually change something; if not, still a valid string.
+    assert out != text
     assert len(out) >= max(1, len(text) - 5)
 
 
@@ -68,6 +72,9 @@ def test_language_selects_default_layout() -> None:
     assert default_layout_for_language("german") == "qwertz"
     assert default_layout_for_language("french") == "azerty"
     assert default_layout_for_language("russian") == "cyrillic"
+    # null / omitted keyboard_layout follows language
+    assert resolve_layout_name("german", None) == "qwertz"
+    assert resolve_layout_name("english", None) == "qwerty"
 
 
 def test_validate_language_and_layout() -> None:
@@ -87,6 +94,29 @@ def test_custom_layout_registerable() -> None:
         assert isinstance(out, str)
     finally:
         unregister_layout(name)
+
+
+def test_cannot_overwrite_builtin_layout() -> None:
+    with pytest.raises(ValueError, match="cannot overwrite builtin"):
+        register_layout("qwerty", ("abc",), overwrite=True)
+
+
+def test_uppercase_cyrillic_is_eligible() -> None:
+    text = "ПРИВЕТ МИР"
+    out = keyboard_typo(text, strength=0.8, seed=3, language="russian")
+    assert out != text
+    # Distorted letters should stay uppercase when the source cluster was.
+    assert any(ch.isupper() for ch in out)
+
+
+def test_hindi_grapheme_clusters_stay_intact() -> None:
+    # Includes matras (vowel signs) and a virama conjunct in नमस्ते
+    text = "नमस्ते दुनिया परीक्षा"
+    out = keyboard_typo(text, strength=0.9, seed=5, language="hindi")
+    assert out != text
+    for cluster in regex.findall(r"\X", out):
+        if len(cluster) > 1:
+            assert unicodedata.combining(cluster[0]) == 0
 
 
 def test_contract_and_registry() -> None:

--- a/tests/test_multilingual_keyboard.py
+++ b/tests/test_multilingual_keyboard.py
@@ -1,0 +1,113 @@
+"""Tests for layout-aware multilingual keyboard typo distortion (#698)."""
+
+from __future__ import annotations
+
+import pytest
+
+from nightmarenet.distortions.multilingual import (
+    distort,
+    keyboard_typo,
+    list_layouts,
+    register_layout,
+    unregister_layout,
+)
+from nightmarenet.distortions.multilingual.keyboard_layouts import (
+    LANGUAGE_LAYOUTS,
+    default_layout_for_language,
+)
+from nightmarenet.distortions.registry import DistortionRegistry
+from nightmarenet.distortions.validators import (
+    validate_distortion_contract,
+    validate_keyboard_layout,
+    validate_language,
+)
+
+SAMPLES = {
+    "english": "The quick brown fox jumps over the lazy dog",
+    "german": "Hallo Welt das ist ein Test",
+    "french": "Bonjour le monde ceci est un test",
+    "russian": "привет мир это простой тест",
+    "hindi": "नमस्ते दुनिया यह एक परीक्षा है",
+    "arabic": "مرحبا بالعالم هذا اختبار",
+}
+
+
+@pytest.mark.parametrize("language", list(SAMPLES))
+def test_language_produces_output(language: str) -> None:
+    text = SAMPLES[language]
+    out = keyboard_typo(text, strength=0.6, seed=7, language=language)
+    assert isinstance(out, str)
+    assert out != ""
+    # High strength should usually change something; if not, still a valid string.
+    assert len(out) >= max(1, len(text) - 5)
+
+
+def test_german_cli_style_call() -> None:
+    out = keyboard_typo("Hallo Welt", strength=0.5, seed=42, language="german")
+    assert isinstance(out, str)
+    assert out != ""
+
+
+def test_strength_zero_is_noop() -> None:
+    text = SAMPLES["english"]
+    assert keyboard_typo(text, strength=0.0, seed=1, language="english") == text
+
+
+def test_empty_input() -> None:
+    assert keyboard_typo("", strength=0.8, seed=1, language="french") == ""
+
+
+def test_deterministic_with_seed() -> None:
+    text = SAMPLES["english"]
+    a = keyboard_typo(text, strength=0.5, seed=99, language="english")
+    b = keyboard_typo(text, strength=0.5, seed=99, language="english")
+    assert a == b
+
+
+def test_language_selects_default_layout() -> None:
+    assert default_layout_for_language("german") == "qwertz"
+    assert default_layout_for_language("french") == "azerty"
+    assert default_layout_for_language("russian") == "cyrillic"
+
+
+def test_validate_language_and_layout() -> None:
+    assert validate_language("german") == []
+    assert validate_language("zz") != []
+    assert validate_keyboard_layout("qwerty") == []
+    assert validate_keyboard_layout("nope") != []
+
+
+def test_custom_layout_registerable() -> None:
+    name = "test_dvorak_698"
+    try:
+        register_layout(name, ("pyfgcrl", "aoeuidhtns", "qjkxbmwvz"), overwrite=True)
+        assert name in list_layouts()
+        assert validate_keyboard_layout(name) == []
+        out = distort("piano", strength=0.8, seed=3, keyboard_layout=name)
+        assert isinstance(out, str)
+    finally:
+        unregister_layout(name)
+
+
+def test_contract_and_registry() -> None:
+    failures = validate_distortion_contract(keyboard_typo)
+    assert failures == [], failures
+
+    registry = DistortionRegistry()
+    assert "keyboard_typo" in registry
+    a = registry.apply("keyboard_typo", SAMPLES["english"], strength=0.4, seed=11)
+    b = registry.apply(
+        "keyboard_typo",
+        SAMPLES["english"],
+        strength=0.4,
+        seed=11,
+        language="english",
+    )
+    assert a == b
+    assert isinstance(a, str)
+
+
+def test_supported_languages_cover_six() -> None:
+    names = {k for k in LANGUAGE_LAYOUTS if len(k) > 2}
+    for lang in ("english", "german", "french", "russian", "hindi", "arabic"):
+        assert lang in names


### PR DESCRIPTION
## Summary
- Adds `nightmarenet/distortions/multilingual/` with layout neighbor maps and a clean-room MulTypo-style typo engine (replace / insert / delete / transpose)
- Registers builtin `keyboard_typo`; CLI: `--type keyboard_typo --language … --keyboard-layout …`
- Config: `distortion.language` / `distortion.keyboard_layout`; validators for both; `register_layout()` API
- Docs + `tests/test_multilingual_keyboard.py` (6 languages + config/contract/registry)
Closes #698
## Acceptance criteria
- [x] `nightmarenet distort --type keyboard_typo --language german --text "Hallo Welt"` works
- [x] ≥6 languages with layout-plausible typos
- [x] Strength maps to character error rate; strength `0` is no-op
- [x] Custom layouts via `register_layout`
- [x] 8+ unit tests; `validate_distortion_contract` passes
- [x] No MulTypo package dependency
## Test plan
- [x] `pytest tests/test_multilingual_keyboard.py -v`
- [x] `ruff check` on touched modules
- [x] CLI smoke: german `Hallo Welt`
- [x] Registry contains `keyboard_typo` (`--list-engines`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multilingual keyboard-typo distortion for English, German, French, Russian, Hindi, and Arabic layouts.
  * Added replacement, insertion, deletion, and transposition effects with configurable strength and deterministic seeding.
  * Added CLI options for language and keyboard-layout selection.
  * Added support for registering and managing custom keyboard layouts, with automatic language-based layout selection.
* **Documentation**
  * Added feature documentation, configuration guidance, CLI examples, supported layouts, validation details, and research references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->