### PR TITLE
test: add unit tests for distributed/device_pool.py and strategies.py

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4,7 +4,7 @@
       "Body_upload_text_file_api_v1_upload_text_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -1485,6 +1485,13 @@
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [

--- a/tests/test_device_pool.py
+++ b/tests/test_device_pool.py
@@ -1,0 +1,90 @@
+"""Unit tests for nightmarenet.distributed.device_pool."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import unittest
+from unittest import mock
+
+from nightmarenet.distributed.device_pool import DevicePool
+
+
+class TestDevicePoolUnit(unittest.TestCase):
+    @mock.patch("torch.cuda.is_available", return_value=True)
+    @mock.patch("torch.cuda.device_count", return_value=4)
+    def test_pool_creation_with_mocked_cuda_devices(
+        self, mock_count: mock.MagicMock, mock_avail: mock.MagicMock
+    ) -> None:
+        """Test DevicePool auto-discovery when CUDA is available."""
+        pool = DevicePool()
+        self.assertEqual(pool.available_devices, [0, 1, 2, 3])
+        self.assertEqual(pool.get_num_devices(), 4)
+        self.assertTrue(pool.should_use_ddp())
+
+    def test_pool_creation_with_override_devices(self) -> None:
+        """Test DevicePool initialization with explicit override device list."""
+        pool = DevicePool(override_devices=[1, 3])
+        self.assertEqual(pool.available_devices, [1, 3])
+        self.assertEqual(pool.get_num_devices(), 2)
+        self.assertTrue(pool.should_use_ddp())
+
+    def test_pool_creation_empty_override(self) -> None:
+        """Test DevicePool with empty override list."""
+        pool = DevicePool(override_devices=[])
+        self.assertEqual(pool.available_devices, [])
+        self.assertEqual(pool.get_num_devices(), 0)
+        self.assertFalse(pool.should_use_ddp())
+
+    @mock.patch("torch.cuda.is_available", return_value=False)
+    def test_no_gpu_cpu_fallback(self, mock_avail: mock.MagicMock) -> None:
+        """Test DevicePool behavior in CPU-only environments."""
+        pool = DevicePool()
+        self.assertEqual(pool.available_devices, [])
+        self.assertEqual(pool.get_num_devices(), 0)
+        self.assertFalse(pool.should_use_ddp())
+
+    @mock.patch("torch.cuda.is_available", return_value=True)
+    @mock.patch("torch.cuda.device_count", return_value=1)
+    def test_single_gpu_should_not_use_ddp(
+        self, mock_count: mock.MagicMock, mock_avail: mock.MagicMock
+    ) -> None:
+        """Test single GPU setup does not trigger DDP recommendation."""
+        pool = DevicePool()
+        self.assertEqual(pool.get_num_devices(), 1)
+        self.assertFalse(pool.should_use_ddp())
+
+    def test_memory_requirements_estimation(self) -> None:
+        """Test VRAM memory requirements estimation accuracy and scaling."""
+        pool = DevicePool(override_devices=[0])
+        num_params = 100_000_000
+        # 100M * 4 bytes * 3 (model+grads+optimizer) * 1.2 (buffer) / (1024^3)
+        expected_gb = (100_000_000 * 4 * 3 * 1.2) / (1024**3)
+        calculated_gb = pool.estimate_memory_requirements(num_params)
+        self.assertAlmostEqual(calculated_gb, expected_gb, places=5)
+        self.assertGreater(calculated_gb, 1.0)
+        self.assertEqual(pool.estimate_memory_requirements(0), 0.0)
+
+    def test_concurrent_device_pool_access_safety(self) -> None:
+        """Test concurrent multi-threaded inspection of DevicePool properties."""
+        pool = DevicePool(override_devices=[0, 1, 2, 3])
+
+        def worker(thread_id: int) -> tuple[int, bool, float]:
+            return (
+                pool.get_num_devices(),
+                pool.should_use_ddp(),
+                pool.estimate_memory_requirements(10_000 * thread_id),
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(worker, i) for i in range(1, 20)]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+        self.assertEqual(len(results), 19)
+        for num_devs, ddp, mem in results:
+            self.assertEqual(num_devs, 4)
+            self.assertTrue(ddp)
+            self.assertGreater(mem, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_distributed_strategies.py
+++ b/tests/test_distributed_strategies.py
@@ -1,0 +1,171 @@
+"""Unit tests for nightmarenet.distributed.strategies."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import torch.nn as nn
+
+from nightmarenet.distributed.ddp_wrapper import DDPWrapper
+from nightmarenet.distributed.device_pool import DevicePool
+from nightmarenet.distributed.strategies import apply_phase_strategy, unwrap_model
+
+
+class SimpleModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(4, 2)
+
+
+class MockWrapperModule(nn.Module):
+    def __init__(self, inner: nn.Module) -> None:
+        super().__init__()
+        self.module = inner
+
+
+class TestDistributedStrategiesUnit(unittest.TestCase):
+    def setUp(self) -> None:
+        self.model = SimpleModel()
+        self.device_pool_multi = DevicePool(override_devices=[0, 1])
+        self.device_pool_single = DevicePool(override_devices=[0])
+        self.device_pool_empty = DevicePool(override_devices=[])
+
+    def test_unwrap_model_unwrapped(self) -> None:
+        """Test unwrap_model returns the module directly if not wrapped."""
+        unwrapped = unwrap_model(self.model)
+        self.assertIs(unwrapped, self.model)
+
+    def test_unwrap_model_single_wrapper(self) -> None:
+        """Test unwrap_model strips a single module wrapper layer."""
+        wrapped = MockWrapperModule(self.model)
+        unwrapped = unwrap_model(wrapped)
+        self.assertIs(unwrapped, self.model)
+
+    def test_unwrap_model_nested_wrapper(self) -> None:
+        """Test unwrap_model recursively unwraps multiple nested wrapper layers."""
+        wrapped = MockWrapperModule(MockWrapperModule(MockWrapperModule(self.model)))
+        unwrapped = unwrap_model(wrapped)
+        self.assertIs(unwrapped, self.model)
+
+    def test_apply_phase_strategy_distributed_disabled(self) -> None:
+        """Test apply_phase_strategy returns unwrapped model when distributed is disabled."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        result = apply_phase_strategy(
+            phase="wake",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=False,
+        )
+        self.assertIs(result, self.model)
+        mock_ddp.wrap_model.assert_not_called()
+
+    def test_apply_phase_strategy_single_device_fallback(self) -> None:
+        """Test apply_phase_strategy falls back to unwrapped model with <= 1 device."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        result = apply_phase_strategy(
+            phase="wake",
+            model=self.model,
+            device_pool=self.device_pool_single,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result, self.model)
+
+        result_empty = apply_phase_strategy(
+            phase="nightmare",
+            model=self.model,
+            device_pool=self.device_pool_empty,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result_empty, self.model)
+
+    def test_apply_phase_strategy_wake_and_nightmare_ddp_initialized(self) -> None:
+        """Test apply_phase_strategy applies DDP wrapping for wake and nightmare phases."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        mock_ddp.is_initialized = True
+        wrapped_target = SimpleModel()
+        mock_ddp.wrap_model.return_value = wrapped_target
+
+        result_wake = apply_phase_strategy(
+            phase="wake",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result_wake, wrapped_target)
+        mock_ddp.wrap_model.assert_called_with(self.model)
+
+        mock_ddp.wrap_model.reset_mock()
+        result_nightmare = apply_phase_strategy(
+            phase="nightmare",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result_nightmare, wrapped_target)
+        mock_ddp.wrap_model.assert_called_with(self.model)
+
+    def test_apply_phase_strategy_ddp_uninitialized_fallback(self) -> None:
+        """Test fallback when DDP is requested in wake phase but DDPWrapper is uninitialized."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        mock_ddp.is_initialized = False
+
+        result = apply_phase_strategy(
+            phase="wake",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result, self.model)
+        mock_ddp.wrap_model.assert_not_called()
+
+    @mock.patch("torch.nn.DataParallel")
+    def test_apply_phase_strategy_dream_dataparallel(self, mock_dp_cls: mock.MagicMock) -> None:
+        """Test apply_phase_strategy wraps model with DataParallel for dream phase."""
+        mock_dp_instance = mock.Mock()
+        mock_dp_cls.return_value = mock_dp_instance
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+
+        result = apply_phase_strategy(
+            phase="dream",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result, mock_dp_instance)
+        mock_dp_cls.assert_called_once_with(self.model, device_ids=[0, 1])
+
+    def test_apply_phase_strategy_compress_phase_single_device(self) -> None:
+        """Test compress phase always runs unwrapped on a single device."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        result = apply_phase_strategy(
+            phase="compress",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result, self.model)
+
+    def test_apply_phase_strategy_unknown_phase(self) -> None:
+        """Test unknown phase returns the unwrapped model safely."""
+        mock_ddp = mock.Mock(spec=DDPWrapper)
+        result = apply_phase_strategy(
+            phase="unrecognized_phase",
+            model=self.model,
+            device_pool=self.device_pool_multi,
+            ddp_wrapper=mock_ddp,
+            distributed_enabled=True,
+        )
+        self.assertIs(result, self.model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Introduces dedicated unit test suites `tests/test_device_pool.py` and `tests/test_distributed_strategies.py` to validate GPU discovery, device pool resource management, and phase-specific distributed strategies on CPU without requiring physical CUDA hardware.

## Related Issues
Closes #657

## Motivation
`nightmarenet/distributed/device_pool.py` and `nightmarenet/distributed/strategies.py` orchestrate multi-device execution and determine strategy wrappers (DDP, DataParallel, Single-Device) across training phases. Dedicated unit test coverage ensures device pooling logic, CPU fallbacks, memory calculations, and recursive model unwrapping execute reliably in all environments.

## Changes Made
- Created `tests/test_device_pool.py` with 7 unit tests:
  - Auto-discovery with mocked CUDA devices (`torch.cuda.device_count=4`, `torch.cuda.is_available=True`).
  - Explicit override device list (`override_devices=[1, 3]`).
  - Empty override list and single-GPU setups (`should_use_ddp` evaluation).
  - CPU-only fallback when CUDA is unavailable.
  - VRAM memory estimation formula verification (`estimate_memory_requirements`).
  - Multi-threaded concurrent inspection safety.
- Created `tests/test_distributed_strategies.py` with 10 unit tests:
  - `unwrap_model`: Direct unwrapped models, single-layer wrappers, and deeply nested recursive wrappers.
  - `apply_phase_strategy`: Disabled distributed execution, single-device fallback, wake & nightmare DDP wrapping, uninitialized DDP fallback, dream phase `DataParallel` wrapping with available device IDs, compress phase single-device enforcement, and unknown phase fallbacks.
- Synchronized `docs/api/openapi.json` to prevent OpenAPI drift.

## Testing & Verification
- Ran all unit tests on CPU:
  ```bash
  uv run pytest tests/test_device_pool.py tests/test_distributed_strategies.py
