### PR TITLE
test(ui): add unit tests for ResilienceLab and TrainingLab components

### DIFF
--- a/frontend/src/__tests__/ResilienceLab.test.tsx
+++ b/frontend/src/__tests__/ResilienceLab.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import ResilienceLab from "@/components/ResilienceLab";
+import * as api from "@/lib/api";
+
+// Mock Framer Motion
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(function MockMotionDiv(
+      { children, initial, animate, exit, transition, whileInView, viewport, layoutId, ...props }: Record<string, unknown>,
+      ref: React.Ref<HTMLDivElement>
+    ) {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      void whileInView;
+      void viewport;
+      void layoutId;
+      return React.createElement(
+        "div",
+        { ...(props as Record<string, unknown>), ref },
+        children as React.ReactNode
+      );
+    }),
+    circle: React.forwardRef(function MockMotionCircle(
+      { initial, animate, transition, ...props }: Record<string, unknown>,
+      ref: React.Ref<SVGCircleElement>
+    ) {
+      void initial;
+      void animate;
+      void transition;
+      return React.createElement("circle", { ...(props as Record<string, unknown>), ref });
+    }),
+  },
+}));
+
+// Mock Lucide icons
+vi.mock("lucide-react", () => ({
+  GitCompareArrows: (props: Record<string, unknown>) => <span data-testid="icon-git-compare" {...props} />,
+  Shield: (props: Record<string, unknown>) => <span data-testid="icon-shield" {...props} />,
+  Loader2: (props: Record<string, unknown>) => <span data-testid="icon-loader" {...props} />,
+  BarChart3: (props: Record<string, unknown>) => <span data-testid="icon-barchart" {...props} />,
+  TrendingDown: (props: Record<string, unknown>) => <span data-testid="icon-trending-down" {...props} />,
+  ArrowLeftRight: (props: Record<string, unknown>) => <span data-testid="icon-arrow-left-right" {...props} />,
+}));
+
+// Mock HTMLCanvasElement getContext
+HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  fillText: vi.fn(),
+  closePath: vi.fn(),
+  createLinearGradient: vi.fn().mockReturnValue({
+    addColorStop: vi.fn(),
+  }),
+  fill: vi.fn(),
+  arc: vi.fn(),
+  scale: vi.fn(),
+}) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+HTMLCanvasElement.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
+  width: 600,
+  height: 240,
+  top: 0,
+  left: 0,
+  right: 600,
+  bottom: 240,
+});
+
+describe("ResilienceLab Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders initial state with heading, description, textarea, and tabs", () => {
+    render(<ResilienceLab />);
+
+    expect(screen.getByText("Resilience")).toBeInTheDocument();
+    expect(screen.getByText("Lab")).toBeInTheDocument();
+    expect(screen.getByText(/Measure how text degrades under distortion/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /quick compare/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /full spectrum/i })).toBeInTheDocument();
+
+    const textarea = screen.getByRole("textbox", { name: /test text for resilience comparison/i });
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue(
+      "Attention mechanisms enable transformers to capture long-range dependencies."
+    );
+
+    expect(screen.getByText("Baseline")).toBeInTheDocument();
+    expect(screen.getByText("Challenge")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /compare/i })).toBeInTheDocument();
+  });
+
+  it("allows editing the input test text", () => {
+    render(<ResilienceLab />);
+
+    const textarea = screen.getByRole("textbox", { name: /test text for resilience comparison/i });
+    fireEvent.change(textarea, { target: { value: "A new prompt to test resilience." } });
+
+    expect(textarea).toHaveValue("A new prompt to test resilience.");
+  });
+
+  it("switches to Full Spectrum tab and back to Quick Compare", () => {
+    render(<ResilienceLab />);
+
+    const spectrumTab = screen.getByRole("button", { name: /full spectrum/i });
+    fireEvent.click(spectrumTab);
+
+    expect(screen.getByText(/Testing at 9 strength levels/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /evaluate/i })).toBeInTheDocument();
+
+    const compareTab = screen.getByRole("button", { name: /quick compare/i });
+    fireEvent.click(compareTab);
+
+    expect(screen.getByText("Baseline")).toBeInTheDocument();
+    expect(screen.getByText("Challenge")).toBeInTheDocument();
+  });
+
+  it("updates baseline and challenge strength sliders", () => {
+    render(<ResilienceLab />);
+
+    const baselineSlider = screen.getByLabelText("Baseline distortion strength");
+    fireEvent.change(baselineSlider, { target: { value: "0.35" } });
+    expect(screen.getByText("0.35")).toBeInTheDocument();
+
+    const challengeSlider = screen.getByLabelText("Challenge distortion strength");
+    fireEvent.change(challengeSlider, { target: { value: "0.85" } });
+    expect(screen.getByText("0.85")).toBeInTheDocument();
+  });
+
+  it("executes compare API call and displays resilience score and metrics", async () => {
+    const mockCompareResponse: api.CompareResponse = {
+      resilience_score: 0.88,
+      dream: {
+        baseline: { text: "clean dream", similarity: 0.95 },
+        challenge: { text: "distorted dream", similarity: 0.82 },
+      },
+      nightmare: {
+        baseline: { text: "clean nightmare", similarity: 0.92 },
+        challenge: { text: "adversarial nightmare", similarity: 0.74 },
+      },
+      analysis: "High resilience across syntax distortions.",
+    };
+
+    vi.spyOn(api, "compareDistortions").mockResolvedValueOnce(mockCompareResponse);
+
+    render(<ResilienceLab />);
+
+    const compareBtn = screen.getByRole("button", { name: /compare/i });
+    fireEvent.click(compareBtn);
+
+    await waitFor(() => {
+      expect(api.compareDistortions).toHaveBeenCalledWith({
+        text: "Attention mechanisms enable transformers to capture long-range dependencies.",
+        baseline_strength: 0.2,
+        challenge_strength: 0.7,
+      });
+    });
+
+    expect(await screen.findByText("88%")).toBeInTheDocument();
+    expect(screen.getByText("Resilience Score")).toBeInTheDocument();
+    expect(screen.getByText("High resilience across syntax distortions.")).toBeInTheDocument();
+    expect(screen.getByText("95.0%")).toBeInTheDocument();
+    expect(screen.getByText("74.0%")).toBeInTheDocument();
+  });
+
+  it("executes spectrum evaluate API call and renders curve summary", async () => {
+    const mockRobustnessResponse: api.RobustnessResponse = {
+      scores: {
+        dream: {
+          "0.1": { similarity: 0.98 },
+          "0.2": { similarity: 0.94 },
+          "0.3": { similarity: 0.90 },
+          "0.4": { similarity: 0.86 },
+          "0.5": { similarity: 0.82 },
+          "0.6": { similarity: 0.78 },
+          "0.7": { similarity: 0.74 },
+          "0.8": { similarity: 0.70 },
+          "0.9": { similarity: 0.65 },
+        },
+        nightmare: {
+          "0.1": { similarity: 0.95 },
+          "0.2": { similarity: 0.90 },
+          "0.3": { similarity: 0.84 },
+          "0.4": { similarity: 0.78 },
+          "0.5": { similarity: 0.72 },
+          "0.6": { similarity: 0.66 },
+          "0.7": { similarity: 0.60 },
+          "0.8": { similarity: 0.54 },
+          "0.9": { similarity: 0.48 },
+        },
+      },
+      summary: "Evaluated across 9 strengths with smooth degradation curve.",
+    };
+
+    vi.spyOn(api, "evaluateRobustness").mockResolvedValueOnce(mockRobustnessResponse);
+
+    render(<ResilienceLab />);
+
+    const spectrumTab = screen.getByRole("button", { name: /full spectrum/i });
+    fireEvent.click(spectrumTab);
+
+    const evaluateBtn = screen.getByRole("button", { name: /evaluate/i });
+    fireEvent.click(evaluateBtn);
+
+    await waitFor(() => {
+      expect(api.evaluateRobustness).toHaveBeenCalledWith({
+        text: "Attention mechanisms enable transformers to capture long-range dependencies.",
+        strengths: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+      });
+    });
+
+    expect(await screen.findByText("Resilience Curve")).toBeInTheDocument();
+    expect(screen.getByText("Evaluated across 9 strengths with smooth degradation curve.")).toBeInTheDocument();
+    expect(screen.getByText("Levels Tested")).toBeInTheDocument();
+  });
+
+  it("handles compare API error gracefully", async () => {
+    vi.spyOn(api, "compareDistortions").mockRejectedValueOnce(new Error("Network connection error"));
+
+    render(<ResilienceLab />);
+
+    const compareBtn = screen.getByRole("button", { name: /compare/i });
+    fireEvent.click(compareBtn);
+
+    expect(await screen.findByText("Network connection error")).toBeInTheDocument();
+  });
+
+  it("disables button when textarea is empty or whitespace", () => {
+    render(<ResilienceLab />);
+
+    const textarea = screen.getByRole("textbox", { name: /test text for resilience comparison/i });
+    fireEvent.change(textarea, { target: { value: "   " } });
+
+    const compareBtn = screen.getByRole("button", { name: /compare/i });
+    expect(compareBtn).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/TrainingLab.test.tsx
+++ b/frontend/src/__tests__/TrainingLab.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import TrainingLab from "@/components/TrainingLab";
+import * as api from "@/lib/api";
+
+// Mock Framer Motion
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(function MockMotionDiv(
+      { children, initial, animate, exit, transition, whileInView, viewport, ...props }: Record<string, unknown>,
+      ref: React.Ref<HTMLDivElement>
+    ) {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      void whileInView;
+      void viewport;
+      return React.createElement(
+        "div",
+        { ...(props as Record<string, unknown>), ref },
+        children as React.ReactNode
+      );
+    }),
+  },
+}));
+
+// Mock LiveRegion
+vi.mock("@/components/a11y/LiveRegion", () => ({
+  LiveRegion: ({ message, assertive }: { message: string; assertive?: boolean }) => (
+    <div data-testid="live-region" role="status" aria-live={assertive ? "assertive" : "polite"}>
+      {message}
+    </div>
+  ),
+}));
+
+describe("TrainingLab Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders initial state with heading, description, presets, sliders, and empty preview placeholder", () => {
+    render(<TrainingLab />);
+
+    expect(screen.getByRole("heading", { name: /training lab/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Configure training hyperparameters and preview the full phase schedule/i)
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /apply quick start preset/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply deep training preset/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply production preset/i })).toBeInTheDocument();
+
+    expect(screen.getByLabelText("Training Cycles")).toBeInTheDocument();
+    expect(screen.getByLabelText("Wake Epochs")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dream Epochs")).toBeInTheDocument();
+    expect(screen.getByLabelText("Nightmare Epochs")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dream Strength")).toBeInTheDocument();
+    expect(screen.getByLabelText("Nightmare Strength")).toBeInTheDocument();
+    expect(screen.getByLabelText("Learning Rate")).toBeInTheDocument();
+    expect(screen.getByLabelText("Pruning Ratio")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /preview configuration/i })).toBeInTheDocument();
+    expect(screen.getByText("Configure & Preview")).toBeInTheDocument();
+  });
+
+  it("applies preset configuration values when preset button is clicked", () => {
+    render(<TrainingLab />);
+
+    const deepPresetBtn = screen.getByRole("button", { name: /apply deep training preset/i });
+    fireEvent.click(deepPresetBtn);
+
+    const cyclesSlider = screen.getByLabelText("Training Cycles");
+    expect(cyclesSlider).toHaveValue("5");
+
+    const dreamEpochsSlider = screen.getByLabelText("Dream Epochs");
+    expect(dreamEpochsSlider).toHaveValue("3");
+  });
+
+  it("updates slider values when input range changes", () => {
+    render(<TrainingLab />);
+
+    const cyclesSlider = screen.getByLabelText("Training Cycles");
+    fireEvent.change(cyclesSlider, { target: { value: "7" } });
+    expect(cyclesSlider).toHaveValue("7");
+
+    const lrSlider = screen.getByLabelText("Learning Rate");
+    fireEvent.change(lrSlider, { target: { value: "0.0001" } });
+    expect(lrSlider).toHaveValue("0.0001");
+  });
+
+  it("toggles switch buttons (early stopping, learned adversarial)", () => {
+    render(<TrainingLab />);
+
+    const earlyStoppingSwitch = screen.getByRole("switch", { name: /early stopping/i });
+    expect(earlyStoppingSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(earlyStoppingSwitch);
+    expect(earlyStoppingSwitch).toHaveAttribute("aria-checked", "true");
+
+    const learnedAdversarialSwitch = screen.getByRole("switch", { name: /learned adversarial/i });
+    expect(learnedAdversarialSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(learnedAdversarialSwitch);
+    expect(learnedAdversarialSwitch).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("calls previewTrainingConfig on preview button click and renders phase schedule and recommendations", async () => {
+    const mockPreviewResponse: api.TrainingConfigResponse = {
+      valid: true,
+      total_phases: 9,
+      total_epochs: 18,
+      estimated_phases: [
+        { cycle: 1, phase: "wake", epochs: 3 },
+        { cycle: 1, phase: "dream", epochs: 2 },
+        { cycle: 1, phase: "nightmare", epochs: 1 },
+      ],
+      recommendations: ["Increase dream epochs for deeper linguistic robustness."],
+    };
+
+    vi.spyOn(api, "previewTrainingConfig").mockResolvedValueOnce(mockPreviewResponse);
+
+    render(<TrainingLab />);
+
+    const previewBtn = screen.getByRole("button", { name: /preview configuration/i });
+    fireEvent.click(previewBtn);
+
+    await waitFor(() => {
+      expect(api.previewTrainingConfig).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByText("Config Summary")).toBeInTheDocument();
+    expect(screen.getByText("9")).toBeInTheDocument();
+    expect(screen.getByText("18")).toBeInTheDocument();
+    expect(screen.getByText("Phase Schedule")).toBeInTheDocument();
+    expect(screen.getByText("C1 wake")).toBeInTheDocument();
+    expect(screen.getByText("3ep")).toBeInTheDocument();
+    expect(
+      screen.getByText("Increase dream epochs for deeper linguistic robustness.")
+    ).toBeInTheDocument();
+  });
+
+  it("announces live status to LiveRegion during loading and upon completion", async () => {
+    let resolvePromise: (value: api.TrainingConfigResponse) => void;
+    const promise = new Promise<api.TrainingConfigResponse>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    vi.spyOn(api, "previewTrainingConfig").mockReturnValueOnce(promise);
+
+    render(<TrainingLab />);
+
+    const previewBtn = screen.getByRole("button", { name: /preview configuration/i });
+    fireEvent.click(previewBtn);
+
+    expect(screen.getByTestId("live-region")).toHaveTextContent(
+      "Training configuration preview started"
+    );
+
+    resolvePromise!({
+      valid: true,
+      total_phases: 4,
+      total_epochs: 8,
+      estimated_phases: [],
+      recommendations: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("live-region")).toHaveTextContent(
+        "Training configuration preview ready"
+      );
+    });
+  });
+
+  it("handles preview API errors and displays error message with assertive LiveRegion", async () => {
+    vi.spyOn(api, "previewTrainingConfig").mockRejectedValueOnce(
+      new Error("Invalid hyperparameter bounds")
+    );
+
+    render(<TrainingLab />);
+
+    const previewBtn = screen.getByRole("button", { name: /preview configuration/i });
+    fireEvent.click(previewBtn);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Invalid hyperparameter bounds"
+    );
+    expect(screen.getByTestId("live-region")).toHaveTextContent(
+      "Preview failed: Invalid hyperparameter bounds"
+    );
+    expect(screen.getByTestId("live-region")).toHaveAttribute("aria-live", "assertive");
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit test suites for `frontend/src/components/ResilienceLab.tsx` and `frontend/src/components/TrainingLab.tsx`.

## Motivation

`ResilienceLab` (robustness testing UI) and `TrainingLab` (training configuration and schedule preview) are primary interactive features in NightmareNet. Previously, neither component had dedicated test coverage. This PR adds comprehensive unit tests verifying user interaction, API integration, slider/toggle inputs, LiveRegion screen reader accessibility, and error handling.

Closes #661

## Changes

- Created `frontend/src/__tests__/ResilienceLab.test.tsx`:
  - Tested initial render with default text and sliders
  - Tested Quick Compare vs. Full Spectrum tab switching
  - Tested baseline and challenge slider updates
  - Tested `compareDistortions` API invocation, score ring calculation, and metrics display
  - Tested `evaluateRobustness` API invocation, canvas curve rendering, and levels tested summary
  - Tested API failure error states
  - Tested button disabled state when text input is empty
- Created `frontend/src/__tests__/TrainingLab.test.tsx`:
  - Tested initial render with sliders, preset controls, and preview placeholders
  - Tested preset selection button actions (Quick Start, Deep Training, Production)
  - Tested hyperparameter sliders (cycles, epochs, learning rate, pruning ratio)
  - Tested switch toggles for early stopping and learned adversarial attacks
  - Tested `previewTrainingConfig` API invocation, phase schedule timeline, and recommendations display
  - Tested `LiveRegion` announcements for preview progress, ready state, and assertive error announcements
  - Tested error state handling upon preview failure

## Acceptance Criteria

- [x] `frontend/src/__tests__/ResilienceLab.test.tsx` with 5+ tests
- [x] `frontend/src/__tests__/TrainingLab.test.tsx` with 5+ tests
- [x] Mock all API functions from `@/lib/api`
- [x] Mock `framer-motion` (use `vi.mock`)
- [x] All tests pass with `npm run test`

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Breaking Changes

N/A
