### PR TITLE
test(dashboard): add unit tests for RunDetail and DashboardRoot orchestrators

### DIFF
--- a/frontend/src/__tests__/DashboardRoot.test.tsx
+++ b/frontend/src/__tests__/DashboardRoot.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { DashboardRoot } from "@/components/dashboard/DashboardRoot";
+
+// Mock retryLazy to immediately return sync mock components
+vi.mock("@/lib/retryLazy", () => ({
+  retryLazy: (importFn: () => Promise<{ default: React.ComponentType<any> }>) => {
+    return function MockLazySection(props: Record<string, unknown>) {
+      return (
+        <div data-testid="lazy-section" {...props}>
+          MockSectionContent
+        </div>
+      );
+    };
+  },
+}));
+
+// Mock sounds
+vi.mock("@/lib/sounds", () => ({
+  useSounds: () => ({
+    playClick: vi.fn(),
+    playSuccess: vi.fn(),
+    playError: vi.fn(),
+    playTransition: vi.fn(),
+    playNotification: vi.fn(),
+    enabled: true,
+    toggle: vi.fn(),
+  }),
+}));
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(function MockMotionDiv(
+      { children, initial, animate, exit, transition, variants, ...props }: Record<string, unknown>,
+      ref: React.Ref<HTMLDivElement>
+    ) {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      void variants;
+      return React.createElement(
+        "div",
+        { ...(props as Record<string, unknown>), ref },
+        children as React.ReactNode
+      );
+    }),
+  },
+}));
+
+// Mock sub-overlays
+vi.mock("@/components/dashboard/OnboardingOverlay", () => ({
+  OnboardingOverlay: ({ onNavigate }: { onNavigate?: (sec: string) => void }) => (
+    <div data-testid="onboarding-overlay">
+      <button type="button" onClick={() => onNavigate?.("experiments")}>
+        Tour Start
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/dashboard/WhatsNew", () => ({
+  WhatsNew: () => <div data-testid="whats-new">Whats New Modal</div>,
+}));
+
+vi.mock("@/components/dashboard/KeyboardHelp", () => ({
+  KeyboardHelp: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="keyboard-help">
+        Keyboard Shortcuts Help
+        <button type="button" onClick={onClose}>
+          Close Help
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/dashboard/AskNightmareDock", () => ({
+  AskNightmareDock: ({ section, onNavigate }: { section: string; onNavigate?: (s: any) => void }) => (
+    <div data-testid="ask-nightmare-dock">
+      <span>Ask Nightmare Dock ({section})</span>
+      <button type="button" onClick={() => onNavigate?.("robustness")}>
+        Jump To Robustness
+      </button>
+    </div>
+  ),
+}));
+
+describe("DashboardRoot Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders initial dashboard layout with AppShell, header, and active section", () => {
+    render(<DashboardRoot />);
+
+    expect(screen.getByText("Command Center")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-overlay")).toBeInTheDocument();
+    expect(screen.getByTestId("whats-new")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-nightmare-dock")).toHaveTextContent("command-center");
+  });
+
+  it("navigates to different section via Sidebar navigation and updates breadcrumbs", () => {
+    render(<DashboardRoot />);
+
+    const experimentsNav = screen.getByRole("button", { name: /experiments/i });
+    fireEvent.click(experimentsNav);
+
+    expect(screen.getByText("Experiments")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-nightmare-dock")).toHaveTextContent("experiments");
+  });
+
+  it("opens keyboard shortcut help dialog when shortcut triggered", () => {
+    render(<DashboardRoot />);
+
+    expect(screen.queryByTestId("keyboard-help")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "?", bubbles: true }));
+    });
+
+    expect(screen.getByTestId("keyboard-help")).toBeInTheDocument();
+    expect(screen.getByText("Keyboard Shortcuts Help")).toBeInTheDocument();
+
+    const closeBtn = screen.getByRole("button", { name: "Close Help" });
+    fireEvent.click(closeBtn);
+    expect(screen.queryByTestId("keyboard-help")).not.toBeInTheDocument();
+  });
+
+  it("handles navigation initiated from OnboardingOverlay tour", () => {
+    render(<DashboardRoot />);
+
+    const tourBtn = screen.getByRole("button", { name: "Tour Start" });
+    fireEvent.click(tourBtn);
+
+    expect(screen.getByText("Experiments")).toBeInTheDocument();
+  });
+
+  it("handles keyboard shortcut navigation (1-9) to switch dashboard sections", () => {
+    render(<DashboardRoot />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "2", bubbles: true }));
+    });
+
+    expect(screen.getByText("Experiments")).toBeInTheDocument();
+  });
+
+  it("navigates to various sections (run-detail, robustness, benchmarks, settings)", () => {
+    render(<DashboardRoot />);
+
+    const runDetailNav = screen.getByRole("button", { name: /run detail/i });
+    fireEvent.click(runDetailNav);
+    expect(screen.getByText("Run Detail")).toBeInTheDocument();
+
+    const settingsNav = screen.getByRole("button", { name: /settings/i });
+    fireEvent.click(settingsNav);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+
+    const benchmarksNav = screen.getByRole("button", { name: /benchmark suite/i });
+    fireEvent.click(benchmarksNav);
+    expect(screen.getByText("Benchmark Suite")).toBeInTheDocument();
+  });
+
+  it("supports navigation via AskNightmareDock callback", () => {
+    render(<DashboardRoot />);
+
+    const jumpBtn = screen.getByRole("button", { name: "Jump To Robustness" });
+    fireEvent.click(jumpBtn);
+
+    expect(screen.getByText("Robustness Radar")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/RunDetail.test.tsx
+++ b/frontend/src/__tests__/RunDetail.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { RunDetail } from "@/components/dashboard/RunDetail";
+import * as api from "@/lib/api";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+const mockToastPush = vi.fn();
+vi.mock("@/components/ui/Toast", () => ({
+  useToast: () => ({
+    push: mockToastPush,
+  }),
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(function MockMotionDiv(
+      { children, initial, animate, exit, transition, ...props }: Record<string, unknown>,
+      ref: React.Ref<HTMLDivElement>
+    ) {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      return React.createElement(
+        "div",
+        { ...(props as Record<string, unknown>), ref },
+        children as React.ReactNode
+      );
+    }),
+  },
+}));
+
+describe("RunDetail Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with run title, subtitle, status badge, and phase tabs", () => {
+    render(<RunDetail />);
+
+    expect(screen.getByText("Run · wikitext-resilient-v3")).toBeInTheDocument();
+    expect(screen.getByText("exp_4f0a · DistilBERT · cycle 4 of 5")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Wake" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dream" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Nightmare" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Compress" })).toBeInTheDocument();
+
+    expect(screen.getByText(/Mild distortion cycle exposing the model/i)).toBeInTheDocument();
+    expect(screen.getByText("Avg Loss")).toBeInTheDocument();
+    expect(screen.getByText("0.97")).toBeInTheDocument();
+  });
+
+  it("switches tabs and displays corresponding phase metrics and descriptions", () => {
+    render(<RunDetail />);
+
+    const nightmareTab = screen.getByRole("button", { name: "Nightmare" });
+    fireEvent.click(nightmareTab);
+
+    expect(
+      screen.getByText(/Adversarial stress: typos, swaps, deletions/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("PGD")).toBeInTheDocument();
+    expect(screen.getByText("+4.1")).toBeInTheDocument();
+
+    const compressTab = screen.getByRole("button", { name: "Compress" });
+    fireEvent.click(compressTab);
+
+    expect(
+      screen.getByText(/Knowledge distillation \+ pruning into a leaner/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("−42%")).toBeInTheDocument();
+  });
+
+  it("calls cancelPipeline API and pushes a toast when Cancel button is clicked", async () => {
+    vi.spyOn(api, "cancelPipeline").mockResolvedValueOnce({ status: "cancelled", run_id: "exp_4f0a" });
+
+    render(<RunDetail />);
+
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      expect(api.cancelPipeline).toHaveBeenCalledWith("exp_4f0a");
+      expect(mockToastPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Run cancelled",
+          variant: "warning",
+        })
+      );
+    });
+  });
+
+  it("handles cancelPipeline API failure with error toast", async () => {
+    vi.spyOn(api, "cancelPipeline").mockRejectedValueOnce(new Error("Unable to cancel active run"));
+
+    render(<RunDetail />);
+
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      expect(mockToastPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Cancel failed",
+          description: "Unable to cancel active run",
+          variant: "error",
+        })
+      );
+    });
+  });
+
+  it("downloads report file on Download Report button click", async () => {
+    vi.spyOn(api, "getPipelineReport").mockResolvedValueOnce({
+      report_md: "# Pipeline Run Report for exp_4f0a\n\nAll metrics passed.",
+    });
+
+    const mockCreateObjectURL = vi.fn().mockReturnValue("blob:http://localhost/mock-blob-id");
+    const mockRevokeObjectURL = vi.fn();
+    window.URL.createObjectURL = mockCreateObjectURL;
+    window.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    render(<RunDetail />);
+
+    const downloadBtn = screen.getByRole("button", { name: "Download report" });
+    fireEvent.click(downloadBtn);
+
+    await waitFor(() => {
+      expect(api.getPipelineReport).toHaveBeenCalledWith("exp_4f0a");
+      expect(mockToastPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Report downloaded",
+          variant: "success",
+        })
+      );
+    });
+  });
+
+  it("opens Re-run menu, selects preset variation, and creates new pipeline run", async () => {
+    vi.spyOn(api, "createPipeline").mockResolvedValueOnce({
+      run_id: "exp_new_8899",
+      status: "queued",
+    });
+
+    render(<RunDetail />);
+
+    const rerunTrigger = screen.getByRole("button", { name: /re-run/i });
+    fireEvent.click(rerunTrigger);
+
+    expect(screen.getByRole("menu", { name: /re-run with mutated config/i })).toBeInTheDocument();
+    expect(screen.getByText("Same config")).toBeInTheDocument();
+    expect(screen.getByText("Strength × 1.2")).toBeInTheDocument();
+    expect(screen.getByText("Switch to GPT-2")).toBeInTheDocument();
+
+    const switchGpt2Item = screen.getByRole("menuitem", { name: /switch to gpt-2/i });
+    fireEvent.click(switchGpt2Item);
+
+    await waitFor(() => {
+      expect(api.createPipeline).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model_name: "GPT-2",
+        })
+      );
+      expect(mockPush).toHaveBeenCalledWith("/run/exp_new_8899");
+      expect(mockToastPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Re-run queued · Switch to GPT-2",
+          variant: "info",
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit test suites for `frontend/src/components/dashboard/RunDetail.tsx` and `frontend/src/components/dashboard/DashboardRoot.tsx`.

## Motivation

`RunDetail` and `DashboardRoot` are central orchestrators for the dashboard application. `RunDetail` manages run lifecycle actions (cancellation, report download, re-run configuration mutation) and metrics display. `DashboardRoot` manages overall application routing, keyboard shortcuts, section transitions, and overlays. This PR adds unit test coverage for both orchestrator components.

Closes #662

## Changes

- Created `frontend/src/__tests__/RunDetail.test.tsx`:
  - Tested initial render with run metadata, status badges, metrics, and phase tabs
  - Tested phase tab switching across Wake, Dream, Nightmare, and Compress
  - Tested `cancelPipeline` API execution, toast confirmation, and failure handling
  - Tested `getPipelineReport` execution and markdown report download blob flow
  - Tested Re-run menu popup, preset mutation selection (e.g. Switch to GPT-2, Strength multiplier), `createPipeline` API call, and router redirection
- Created `frontend/src/__tests__/DashboardRoot.test.tsx`:
  - Tested dashboard render with `AppShell`, sidebar, active sections, and docks
  - Tested sidebar section navigation and breadcrumb updates
  - Tested keyboard shortcut help overlay toggle (`?` key and close action)
  - Tested global numeric shortcut navigation (`1-9` keys)
  - Tested navigation triggered from `OnboardingOverlay` tour
  - Tested navigation triggered from `AskNightmareDock` callbacks
  - Tested section switching across multiple tabs (Experiments, Run Detail, Robustness, Benchmarks, Settings)

## Acceptance Criteria

- [x] `frontend/src/__tests__/RunDetail.test.tsx` with 5+ tests
- [x] `frontend/src/__tests__/DashboardRoot.test.tsx` with 4+ tests
- [x] Mock `@/lib/api`, `next/navigation`, `@/lib/retryLazy`, `@/lib/sounds`
- [x] All tests pass with `npm run test`

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests
- [ ] Infrastructure (CI/CD, Docker, tooling)

---

## Pre-submission Requirements

- [x] I have **starred** this repository ⭐
- [x] I have **followed** [@Adit-Jain-srm](https://github.com/Adit-Jain-srm)
- [x] I have read [CONTRIBUTING.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/CONTRIBUTING.md) in full

## Quality Checklist

- [x] `ruff check nightmarenet/ scripts/ tests/` — 0 errors
- [x] `mypy nightmarenet/ --ignore-missing-imports` — no new errors (run on Python 3.12)
- [x] `pytest tests/` — all tests pass
- [x] New functionality has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
- [x] No `from __future__ import annotations` added under `nightmarenet/api/`
- [x] No new imports of hosted-only libraries (`sqlalchemy`, `redis`, `celery`) in `nightmarenet/`

## Documentation

- [x] No documentation needed (test-only or internal refactor)
- [ ] README.md updated
- [ ] Docstrings added/updated (Google style, public APIs only)
- [ ] `docs/` updated (architecture, research, or API docs)
- [ ] Config comments updated (`configs/default.yaml`)
- [ ] CHANGELOG entry added (if user-facing change)

## AI Disclosure

- [x] This PR includes AI-assisted code (Copilot, ChatGPT, Claude, etc.) — I have reviewed every line and can explain it

## Security Considerations

- [x] Not applicable (no security-sensitive changes)
- [ ] User input is validated before use
- [ ] No secrets, keys, or credentials in code or comments
- [ ] CORS / auth / rate limiting behavior unchanged (or explicitly documented)
- [ ] If this is a security fix, see [SECURITY.md](https://github.com/Adit-Jain-srm/NightmareNet/blob/main/SECURITY.md) — do NOT describe the vulnerability publicly until patched

## Breaking Changes

N/A
