### PR TITLE
feat(frontend): add Sentry-compatible error reporting (#682)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ NIGHTMARENET_CELERY_INCLUDE=nightmarenet.tasks
 # Device selection (auto, cpu, cuda)
 NIGHTMARENET_DEVICE=auto
 
+# Frontend error reporting (optional Sentry-compatible DSN)
+NEXT_PUBLIC_SENTRY_DSN=
+
 # Hosted auth (JWT + social OAuth + enterprise SSO)
 NIGHTMARENET_JWT_SECRET=
 NIGHTMARENET_SESSION_SECRET=

--- a/docs/development/local-stack.md
+++ b/docs/development/local-stack.md
@@ -42,6 +42,10 @@ macOS, and Linux. Makefile targets (`make check`, `make test`, …) still work.
 Copy `.env.example` to `.env` at the repo root. Frontend rewrites in
 `frontend/next.config.ts` proxy `/api/v1/*` to the backend.
 
+Optional production error reporting: set `NEXT_PUBLIC_SENTRY_DSN` to a
+Sentry-compatible DSN (see `.env.example`). When unset, the frontend skips
+remote reporting and logs errors locally during development.
+
 ## Docker Compose
 
 ```bash

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,13 +11,20 @@ const apiOrigin = process.env.NEXT_PUBLIC_API_URL
   ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
   : "";
 
+const sentryConnectOrigin = (() => {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN?.trim();
+  if (!dsn) return "";
+  const match = dsn.match(/@([^/]+)/);
+  return match ? ` https://${match[1]}` : "";
+})();
+
 const cspHeader = `
   default-src 'self';
   script-src 'self' 'unsafe-eval' 'unsafe-inline';
   style-src 'self' 'unsafe-inline';
   img-src 'self' blob: data:;
   font-src 'self';
-  connect-src 'self'${apiOrigin ? ` ${apiOrigin}` : ""};
+  connect-src 'self'${apiOrigin ? ` ${apiOrigin}` : ""}${sentryConnectOrigin};
   object-src 'none';
   base-uri 'self';
   form-action 'self';

--- a/frontend/src/__tests__/error-reporting.test.ts
+++ b/frontend/src/__tests__/error-reporting.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const DSN = "https://public@o123.ingest.sentry.io/456";
+
+describe("error-reporting", () => {
+  let reportError: typeof import("@/lib/error-reporting").reportError;
+  let initErrorReporting: typeof import("@/lib/error-reporting").initErrorReporting;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    vi.stubGlobal("sessionStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/dashboard", search: "?tab=runs" },
+    });
+    const mod = await import("@/lib/error-reporting");
+    reportError = mod.reportError;
+    initErrorReporting = mod.initErrorReporting;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("logs to console in development without calling fetch", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", DSN);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportError(new Error("panel blew up"), { source: "ErrorBoundary" });
+
+    expect(consoleError).toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops in production when DSN is missing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", "");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportError(new Error("silent fail"));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("posts to the Sentry store endpoint in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", DSN);
+
+    reportError(new Error("prod crash"), {
+      source: "ErrorBoundary",
+      componentStack: "at Panel",
+    });
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe("https://o123.ingest.sentry.io/api/456/store/");
+    expect((init as RequestInit).headers).toMatchObject({
+      "X-Sentry-Auth": expect.stringContaining("sentry_key=public"),
+    });
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.message.formatted).toBe("prod crash");
+    expect(body.extra.route).toBe("/dashboard?tab=runs");
+    expect(body.extra.component_stack).toBe("at Panel");
+  });
+
+  it("rate limits reports to ten per minute", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", DSN);
+
+    for (let i = 0; i < 12; i++) {
+      reportError(new Error(`err-${i}`));
+    }
+
+    await vi.waitFor(() => {
+      expect((fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(10);
+    });
+  });
+
+  it("registers an unhandledrejection handler once", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    initErrorReporting();
+    initErrorReporting();
+
+    expect(addSpy).toHaveBeenCalledWith("unhandledrejection", expect.any(Function));
+    expect(addSpy.mock.calls.filter(([evt]) => evt === "unhandledrejection")).toHaveLength(1);
+  });
+
+  it("does not throw when the network request fails", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", DSN);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    expect(() => reportError(new Error("still safe"))).not.toThrow();
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { ThemeProvider } from "@/lib/theme";
 import SkipLink from "@/components/a11y/SkipLink";
+import { ErrorReportingInit } from "@/components/ErrorReportingInit";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { OfflineBanner } from "@/components/ui/OfflineBanner";
 import "./globals.css";
@@ -72,6 +73,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
       <OfflineBanner />
+      <ErrorReportingInit />
 
   <ErrorBoundary
     fallbackTitle="NightmareNet encountered an unexpected error"

--- a/frontend/src/components/ErrorReportingInit.tsx
+++ b/frontend/src/components/ErrorReportingInit.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+import { initErrorReporting } from "@/lib/error-reporting";
+
+/** Registers global client-side error handlers once per page load. */
+export function ErrorReportingInit() {
+  useEffect(() => {
+    initErrorReporting();
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import {
   type ErrorInfo,
   type ReactNode,
 } from "react";
+import { reportError } from "@/lib/error-reporting";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -33,9 +34,10 @@ export class ErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    if (process.env.NODE_ENV !== "test") {
-      console.error("NightmareNet UI error:", error, errorInfo);
-    }
+    reportError(error, {
+      componentStack: errorInfo.componentStack ?? undefined,
+      source: "ErrorBoundary",
+    });
 
     this.props.onError?.(error, errorInfo);
   }

--- a/frontend/src/lib/error-reporting.ts
+++ b/frontend/src/lib/error-reporting.ts
@@ -1,0 +1,176 @@
+/**
+ * Lightweight Sentry-compatible error reporting.
+ *
+ * When NEXT_PUBLIC_SENTRY_DSN is unset, all calls are no-ops (no SDK bundled).
+ * In development, errors are logged to the console only.
+ */
+
+const MAX_REPORTS_PER_MINUTE = 10;
+const SESSION_KEY = "nn-error-session";
+
+let sessionId: string | null = null;
+let reportTimes: number[] = [];
+let initialized = false;
+
+export type ErrorReportContext = {
+  componentStack?: string;
+  source?: string;
+};
+
+type ParsedDsn = {
+  publicKey: string;
+  host: string;
+  projectId: string;
+};
+
+function getDsn(): string {
+  return process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() ?? "";
+}
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function getSessionId(): string {
+  if (typeof window === "undefined") {
+    return "server";
+  }
+  if (sessionId) {
+    return sessionId;
+  }
+  try {
+    const existing = sessionStorage.getItem(SESSION_KEY);
+    if (existing) {
+      sessionId = existing;
+      return existing;
+    }
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `sess-${Date.now()}`;
+    sessionStorage.setItem(SESSION_KEY, id);
+    sessionId = id;
+    return id;
+  } catch {
+    return "anonymous";
+  }
+}
+
+function getRoute(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function parseDsn(dsn: string): ParsedDsn | null {
+  const match = dsn.match(/^https?:\/\/([^@]+)@([^/]+)\/(.+)$/);
+  if (!match) {
+    return null;
+  }
+  return {
+    publicKey: match[1],
+    host: match[2],
+    projectId: match[3],
+  };
+}
+
+function withinRateLimit(): boolean {
+  const now = Date.now();
+  reportTimes = reportTimes.filter((t) => now - t < 60_000);
+  if (reportTimes.length >= MAX_REPORTS_PER_MINUTE) {
+    return false;
+  }
+  reportTimes.push(now);
+  return true;
+}
+
+async function sendToSentry(error: Error, context?: ErrorReportContext): Promise<void> {
+  const dsn = getDsn();
+  const parsed = parseDsn(dsn);
+  if (!parsed || !withinRateLimit()) {
+    return;
+  }
+
+  const eventId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID().replace(/-/g, "")
+      : String(Date.now());
+
+  const event = {
+    event_id: eventId,
+    timestamp: new Date().toISOString(),
+    platform: "javascript",
+    level: "error",
+    logger: "nightmarenet.frontend",
+    message: { formatted: error.message },
+    exception: {
+      values: [
+        {
+          type: error.name,
+          value: error.message,
+          stacktrace: error.stack
+            ? {
+                frames: error.stack.split("\n").slice(1, 6).map((line) => ({
+                  filename: line.trim(),
+                })),
+              }
+            : undefined,
+        },
+      ],
+    },
+    tags: {
+      source: context?.source ?? "unknown",
+    },
+    extra: {
+      route: getRoute(),
+      session_id: getSessionId(),
+      component_stack: context?.componentStack,
+    },
+  };
+
+  const url = `https://${parsed.host}/api/${parsed.projectId}/store/`;
+  const auth = `Sentry sentry_version=7, sentry_key=${parsed.publicKey}, sentry_client=nightmarenet-frontend/1.0`;
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sentry-Auth": auth,
+      },
+      body: JSON.stringify(event),
+      keepalive: true,
+    });
+  } catch {
+    // Reporting must never throw back to callers.
+  }
+}
+
+export function reportError(error: unknown, context?: ErrorReportContext): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+
+  if (!isProduction()) {
+    if (process.env.NODE_ENV !== "test") {
+      console.error("[NightmareNet]", err.message, context ?? {});
+    }
+    return;
+  }
+
+  if (!getDsn()) {
+    return;
+  }
+
+  void sendToSentry(err, context);
+}
+
+export function initErrorReporting(): void {
+  if (initialized || typeof window === "undefined") {
+    return;
+  }
+  initialized = true;
+
+  window.addEventListener("unhandledrejection", (event) => {
+    reportError(event.reason ?? event, { source: "unhandledrejection" });
+  });
+}


### PR DESCRIPTION
Closes #682
## Summary
- Add `frontend/src/lib/error-reporting.ts` with `reportError()` and `initErrorReporting()`
- Wire `ErrorBoundary` and a global `unhandledrejection` handler (via `ErrorReportingInit` in root layout)
- Use a lightweight Sentry store API client (no `@sentry/nextjs` dependency) so there is zero bundle impact when `NEXT_PUBLIC_SENTRY_DSN` is unset
- Include session ID, route, and component stack in reports; rate-limit to 10/min per session
- Extend CSP `connect-src` when a DSN is configured; document the env var in `.env.example` and `docs/development/local-stack.md`

## Test plan
- [x] `npm run test -- error-reporting` (6 tests)
- [x] `npm run test -- ErrorBoundary` (4 tests, no regression)
- [x] `npm run lint`
- [ ] Set `NEXT_PUBLIC_SENTRY_DSN` in production and confirm events appear in Sentry (or compatible backend)
- [ ] Confirm app loads normally with DSN unset (no console noise in prod build)

## Notes
This PR includes AI-assisted code generation. I reviewed and tested all changes locally.
No UI/layout changes — infrastructure only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional frontend error reporting through Sentry-compatible services.
  * Automatically captures unhandled errors, promise rejections, and application error-boundary failures.
  * Includes relevant diagnostic context such as the current route and component details.
  * Limits repeated reports and continues functioning when reporting services are unavailable.

* **Documentation**
  * Added setup instructions for enabling error reporting locally and in production.
  * Documented local console logging when remote reporting is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->