### PR TITLE
docs: add feature guides for distributed, compression, transfer, HPO, and search (#667)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ Learn how to use, extend, and deploy NightmareNet through our step-by-step tutor
 *   [Tutorial 5: Deployment](docs/tutorials/deployment.md) — Configure, run, and scale production-grade docker containers, configure keys, and integrate alerts.
 *   [Tutorial 6: CI Robustness Check](docs/tutorials/ci-robustness-check.md) — Gate PRs with the `robustness-check` GitHub Action (threshold, score table, Marketplace branding).
 
+### Feature Guides
+
+In-depth documentation for individual features lives in [`docs/features/`](docs/features/):
+
+*   [Distributed Training](docs/features/distributed-training.md) — multi-GPU setup, per-phase DDP/DataParallel strategies, device pool config, and atomic checkpoint resume.
+*   [Model Compression](docs/features/model-compression.md) — magnitude pruning, low-rank bottlenecks, and RSLAD-style robust distillation.
+*   [Transfer Learning](docs/features/transfer-learning.md) — foundation registry, head factory, layer freezing, and transfer-efficiency measurement.
+*   [Hyperparameter Optimization](docs/features/hpo.md) — Optuna integration, search spaces, and study persistence.
+*   [Semantic Experiment Search](docs/features/search.md) — natural-language search API, indexing, and query syntax.
+*   [Webhook Notifications](docs/features/webhooks.md) — real-time alerts to Slack, Discord, and Teams.
+
 Client developers can also use the committed OpenAPI spec at [`docs/api/openapi.json`](docs/api/openapi.json) (regenerate with `make openapi`).
 
 ### GitHub Action (robustness gate)

--- a/docs/features/distributed-training.md
+++ b/docs/features/distributed-training.md
@@ -1,0 +1,187 @@
+# Distributed Training Guide
+
+NightmareNet can run the Wake → Dream → Nightmare → Compress cycle across multiple GPUs. Each phase picks the parallelism strategy best suited to its workload, and every phase boundary is checkpointed atomically so an interrupted run can resume without corruption.
+
+## Overview
+
+The distributed layer lives in `nightmarenet/distributed/` and is composed of four cooperating pieces:
+
+| Component | Source | Responsibility |
+|---|---|---|
+| `DevicePool` | `device_pool.py` | Discovers available GPUs and estimates memory requirements. |
+| `DDPWrapper` | `ddp_wrapper.py` | Manages the PyTorch `DistributedDataParallel` process group. |
+| `apply_phase_strategy` | `strategies.py` | Selects the right parallelism strategy per phase. |
+| `AtomicCheckpointer` / `ResumeManager` | `checkpoint.py`, `resume.py` | Atomic checkpoint saves and validated resume. |
+
+### Per-phase strategy
+
+`apply_phase_strategy(phase, model, device_pool, ddp_wrapper, distributed_enabled)` maps each phase to a strategy:
+
+| Phase | Strategy | Why |
+|---|---|---|
+| `wake` | `DistributedDataParallel` (DDP) | Data-parallel supervised training. |
+| `nightmare` | `DistributedDataParallel` (DDP) | Data-parallel adversarial training. |
+| `dream` | `torch.nn.DataParallel` | Embarrassingly parallel augmentation/inference. |
+| `compress` | Single GPU | Pruning and distillation run on one device. |
+
+If `distributed_enabled` is `False` or only one device is available, the model is returned unwrapped.
+
+---
+
+## Quick Start
+
+Enable multi-GPU execution by passing `--distributed` to `nightmarenet train`. Pass `auto` to use every visible GPU, or a comma-separated device list to pin specific GPUs:
+
+```bash
+# Use all available GPUs
+nightmarenet train --config configs/benchmark_sst2.yaml --distributed auto
+
+# Pin specific GPU IDs
+nightmarenet train --config configs/benchmark_sst2.yaml --distributed 0,1,2
+```
+
+DDP requires launching under `torchrun`, which sets the `RANK`, `WORLD_SIZE`, and `LOCAL_RANK` environment variables. `DDPWrapper.setup()` detects these variables and initializes the process group; if they are absent, DDP is skipped and training falls back to a single device.
+
+```bash
+torchrun --nproc_per_node=2 -m nightmarenet.cli train \
+    --config configs/benchmark_sst2.yaml --distributed auto
+```
+
+---
+
+## Configuration
+
+### Device pool
+
+`DevicePool` discovers devices automatically or accepts an explicit override list:
+
+```python
+from nightmarenet.distributed import DevicePool
+
+# Auto-discover all CUDA devices
+pool = DevicePool()
+print(pool.get_num_devices())        # e.g. 2
+print(pool.should_use_ddp())         # True when more than one device is present
+
+# Explicit device IDs
+pool = DevicePool(override_devices=[0, 1])
+
+# Estimate VRAM (GB) for a model of N parameters
+# (4 bytes/param x 3 for model+grads+optimizer x 1.2 buffer)
+print(pool.estimate_memory_requirements(num_params=66_000_000))
+```
+
+### DDP backend
+
+`DDPWrapper` defaults to the NCCL backend, which is recommended for NVIDIA GPUs:
+
+```python
+from nightmarenet.distributed import DDPWrapper
+
+ddp = DDPWrapper(backend="nccl")
+ddp.setup()                # no-op unless launched via torchrun
+if ddp.is_initialized:
+    model = ddp.wrap_model(model)
+# ... train ...
+ddp.teardown()             # destroys the process group
+```
+
+---
+
+## API Reference
+
+### `DevicePool`
+
+```python
+DevicePool(override_devices: Optional[list[int]] = None)
+```
+
+| Method | Returns | Description |
+|---|---|---|
+| `get_num_devices()` | `int` | Number of usable devices. |
+| `estimate_memory_requirements(num_params)` | `float` | Estimated VRAM in GB. |
+| `should_use_ddp()` | `bool` | `True` when more than one device is available. |
+
+### `DDPWrapper`
+
+```python
+DDPWrapper(backend: str = "nccl")
+```
+
+| Method | Description |
+|---|---|
+| `setup()` | Initializes the process group when launched via `torchrun`. |
+| `wrap_model(model)` | Wraps a model in `DistributedDataParallel`. |
+| `teardown()` | Destroys the process group. |
+| `is_initialized` | Attribute — `True` once `setup()` succeeds. |
+
+### Strategy helpers (`strategies.py`)
+
+```python
+apply_phase_strategy(phase, model, device_pool, ddp_wrapper, distributed_enabled) -> nn.Module
+unwrap_model(model) -> nn.Module   # recursively unwraps DDP / DataParallel
+```
+
+### Checkpointing (`checkpoint.py`, `resume.py`)
+
+```python
+from nightmarenet.distributed import AtomicCheckpointer, ResumeManager
+
+checkpointer = AtomicCheckpointer(base_dir="./checkpoints")
+target = checkpointer.save(
+    run_id="sst2-v1", cycle=1, phase="dream",
+    model=model, optimizer=optimizer, config=config,
+    metrics={"loss": 0.42}, devices_used=[0, 1],
+)
+
+resume = ResumeManager(resume_dir=target)
+metadata = resume.verify_and_load(model, optimizer, current_config=config)
+```
+
+`AtomicCheckpointer.save()` writes to a temporary directory, records SHA-256 hashes of every file, drops a `.complete` sentinel, and then atomically swaps the directory into place. `ResumeManager.verify_and_load()` calls `validate_checkpoint_integrity()` to confirm the sentinel, metadata, version compatibility, and checksums before loading model, optimizer, and RNG state.
+
+Module-level helpers available in `checkpoint.py`:
+
+| Function | Description |
+|---|---|
+| `load_model_weights(model, checkpoint_dir, device)` | Loads `model.pt`, `model.safetensors`, or `pytorch_model.bin`. |
+| `validate_checkpoint_integrity(checkpoint_dir, config=None)` | Structural, version, and checksum validation. |
+| `compute_config_hash(config)` | Deterministic SHA-256 of the config. |
+| `compute_file_sha256(filepath)` | SHA-256 of a single file. |
+| `compute_dir_hashes(directory)` | SHA-256 of every file in a directory. |
+| `check_version_compatibility(checkpoint_version, current_version)` | Raises on major (or 0.x minor) mismatch. |
+
+---
+
+## Examples
+
+### Resume an interrupted run
+
+Checkpoints are saved at each phase boundary. To resume, point `--resume` at the checkpoint directory:
+
+```bash
+nightmarenet train \
+    --config configs/benchmark_sst2.yaml \
+    --distributed auto \
+    --resume ./checkpoints/sst2-v1/cycle-1-dream
+```
+
+### Choosing a device count from memory
+
+```python
+from nightmarenet.distributed import DevicePool
+
+pool = DevicePool()
+required_gb = pool.estimate_memory_requirements(num_params=124_000_000)
+print(f"Estimated {required_gb:.1f} GB VRAM required per replica")
+if not pool.should_use_ddp():
+    print("Single device detected — DDP will be skipped.")
+```
+
+---
+
+## Related Documentation
+
+- [Model Compression](model-compression.md) — the single-GPU compress phase.
+- [Getting Started](../tutorials/getting-started.md) — install and run your first cycle.
+- Config reference: [`configs/benchmark_sst2.yaml`](../../configs/benchmark_sst2.yaml)

--- a/docs/features/hpo.md
+++ b/docs/features/hpo.md
@@ -1,0 +1,138 @@
+# Hyperparameter Optimization (HPO) Guide
+
+NightmareNet integrates [Optuna](https://optuna.org/) to search for the configuration that maximizes robustness. You describe a search space in YAML, and the optimizer runs repeated pipeline trials, pruning unpromising ones early and persisting results to a study database.
+
+## Overview
+
+HPO lives in `nightmarenet/optimization/hpo.py`. The `HyperparameterOptimizer` reads an `hpo` section from a standard training config, samples parameters for each trial, runs the full pipeline, and maximizes the `robustness_delta` returned by the run.
+
+| Concept | Description |
+|---|---|
+| Study | An Optuna study persisted to a storage backend (SQLite by default). |
+| Trial | One pipeline run with a sampled set of hyperparameters. |
+| Objective | Maximizes `robustness_delta` (falls back to `robustness`, `avg_robustness`, or `mean_robustness`). |
+| Pruning | Optuna's `MedianPruner` stops trials that under-perform mid-run. |
+
+> [!NOTE]
+> HPO requires the optional Optuna dependency. Install it with `pip install 'nightmarenet[hpo]'`.
+
+---
+
+## Quick Start
+
+```bash
+pip install 'nightmarenet[hpo]'
+nightmarenet optimize --config configs/examples/hpo-config.yaml
+```
+
+Override the number of trials from the command line:
+
+```bash
+nightmarenet optimize --config configs/examples/hpo-config.yaml --n-trials 50
+```
+
+---
+
+## Configuration
+
+HPO reuses your training config and adds an `hpo` section. A complete example ships at [`configs/examples/hpo-config.yaml`](../../configs/examples/hpo-config.yaml):
+
+```yaml
+hpo:
+  study_name: nightmarenet-robustness-search
+  storage: sqlite:///nightmarenet_hpo.db
+  direction: maximize
+  n_trials: 20
+  pruning: true
+  search_space:
+    training.learning_rate:
+      type: float
+      low: 1.0e-5
+      high: 1.0e-3
+      log: true
+    distortion.nightmare_strength:
+      type: float
+      low: 0.5
+      high: 0.95
+    training.batch_size:
+      type: categorical
+      choices: [4, 8, 16]
+```
+
+### `hpo` keys
+
+| Key | Default | Description |
+|---|---|---|
+| `study_name` | `nightmarenet-optimization` | Optuna study name. |
+| `storage` | `sqlite:///nightmarenet_hpo.db` | Optuna storage URL (studies resume via `load_if_exists`). |
+| `direction` | `maximize` | Optimization direction. |
+| `n_trials` | `20` | Number of trials (overridable with `--n-trials`). |
+| `pruning` | `true` | Enable `MedianPruner`; when `false`, uses `NopPruner`. |
+| `search_space` | `{}` | Map of dotted config keys to parameter definitions. |
+
+### Search-space parameter types
+
+Each entry in `search_space` is keyed by a **dotted path** into the base config (e.g. `training.learning_rate`) and supports three types:
+
+| `type` | Required fields | Optional fields |
+|---|---|---|
+| `float` | `low`, `high` | `log` (log-uniform sampling) |
+| `int` | `low`, `high` | `log` |
+| `categorical` | `choices` | — |
+
+Sampled values are written back into a deep copy of the base config using the dotted path, so any config key the pipeline reads can be tuned.
+
+---
+
+## API Reference
+
+### `HyperparameterOptimizer`
+
+```python
+from nightmarenet.optimization import HyperparameterOptimizer
+
+optimizer = HyperparameterOptimizer(config_path="configs/examples/hpo-config.yaml")
+study = optimizer.optimize()   # returns an optuna.Study
+```
+
+| Member | Description |
+|---|---|
+| `HyperparameterOptimizer(config_path)` | Loads the config, builds the Optuna study, and raises `ImportError` if Optuna is not installed. |
+| `optimize()` | Runs `n_trials` trials and returns the `optuna.Study`. |
+| `study` | The underlying Optuna study (created with `load_if_exists=True`). |
+
+Each trial builds a fresh pipeline via `nightmarenet.pipeline.Pipeline`, and — when pruning is enabled — reports intermediate `phase_loss` per cycle so Optuna can prune weak trials early.
+
+---
+
+## Examples
+
+### Inspect the best trial
+
+```python
+from nightmarenet.optimization import HyperparameterOptimizer
+
+optimizer = HyperparameterOptimizer("configs/examples/hpo-config.yaml")
+study = optimizer.optimize()
+
+print("Best value:", study.best_value)
+print("Best params:", study.best_params)
+```
+
+### Resume an existing study
+
+Because the study is created with `load_if_exists=True`, re-running the same command against the same `storage` URL continues the existing study rather than starting over:
+
+```bash
+nightmarenet optimize --config configs/examples/hpo-config.yaml --n-trials 20
+# ... later, add more trials to the same study ...
+nightmarenet optimize --config configs/examples/hpo-config.yaml --n-trials 30
+```
+
+---
+
+## Related Documentation
+
+- [Model Compression](model-compression.md) — tune `compression.pruning_ratio` as part of a search.
+- [Getting Started](../tutorials/getting-started.md) — install and run your first cycle.
+- Config reference: [`configs/examples/hpo-config.yaml`](../../configs/examples/hpo-config.yaml)

--- a/docs/features/model-compression.md
+++ b/docs/features/model-compression.md
@@ -1,0 +1,164 @@
+# Model Compression Guide
+
+The Compress phase of the NightmareNet cycle shrinks a hardened model while preserving its robustness. It combines magnitude-based pruning (or low-rank bottlenecks) with optional RSLAD-style adversarial distillation, so the compressed student inherits the robust features of its teacher rather than trading them away.
+
+## Overview
+
+Compression utilities live in `nightmarenet/compression/`:
+
+| Component | Source | Responsibility |
+|---|---|---|
+| `MagnitudePruner` | `pruning.py` | Zeros out the smallest-magnitude weights. |
+| `BottleneckWrapper` / `apply_bottleneck_to_model` | `pruning.py` | Inserts low-rank bottleneck projections. |
+| `run_distillation` / `fgsm_perturb` | `distillation.py` | RSLAD-style adversarial robust distillation. |
+
+The Compress phase (`nightmarenet/training/phases.py`) reads a `compression` config section, prunes (or bottlenecks) the model, snapshots the pre-pruning model as a teacher, and optionally distills the pruned student on adversarial inputs.
+
+---
+
+## Quick Start
+
+Compression runs automatically as the final phase of `nightmarenet train`. Control it through the `compression` section of your YAML config:
+
+```yaml
+compression:
+  pruning_ratio: 0.2          # prune the smallest 20% of weights
+  pruning_method: magnitude   # "magnitude" or "bottleneck"
+  distillation: true          # RSLAD-style robust distillation after pruning
+  finetune_after_prune: true
+  finetune_epochs: 1
+```
+
+```bash
+nightmarenet train --config configs/benchmark_sst2.yaml
+```
+
+You can also apply compression directly to any PyTorch model:
+
+```python
+from nightmarenet.compression import MagnitudePruner
+
+pruner = MagnitudePruner(pruning_ratio=0.2)
+stats = pruner.apply(model)
+print(stats)   # {'pruned_params': ..., 'total_params': ..., 'sparsity': ...}
+```
+
+---
+
+## Configuration
+
+The compress phase honours the following keys under `compression`:
+
+| Key | Default | Description |
+|---|---|---|
+| `pruning_ratio` | `0.2` | Fraction of weights to zero out, in `[0, 1)`. |
+| `pruning_method` | `magnitude` | `magnitude` (weight zeroing) or `bottleneck` (low-rank projection). |
+| `bottleneck_rank_ratio` | `0.5` | Bottleneck dim as a ratio of the hidden dim (used when `pruning_method: bottleneck`). |
+| `distillation` | `false` | Enable RSLAD-style distillation after pruning. |
+| `finetune_after_prune` | `true` | Fine-tune the pruned model to recover accuracy. |
+| `finetune_epochs` | `1` | Number of fine-tuning epochs. |
+
+---
+
+## API Reference
+
+### `MagnitudePruner`
+
+```python
+MagnitudePruner(pruning_ratio: float = 0.2)
+```
+
+`pruning_ratio` must be in `[0, 1)`; a value outside that range raises `ValueError`.
+
+| Method | Returns | Description |
+|---|---|---|
+| `apply(model)` | `dict` | Prunes weights in-place; returns `{pruned_params, total_params, sparsity}`. Parameters with fewer than 2 dimensions are skipped. |
+
+### `BottleneckWrapper`
+
+```python
+BottleneckWrapper(original_layer, bottleneck_dim: Optional[int] = None, rank_ratio: float = 0.5)
+```
+
+Wraps a layer with a down-project → up-project pair. When `bottleneck_dim` is omitted it is derived from `rank_ratio`. `rank_ratio` must be in `(0, 1]`.
+
+### `apply_bottleneck_to_model`
+
+```python
+apply_bottleneck_to_model(model, rank_ratio: float = 0.5, target_modules: Optional[list] = None) -> dict
+```
+
+Recursively wraps modules whose names match `target_modules` (default `["mlp", "attn"]`). Returns `{wrapped_count, rank_ratio}`.
+
+### `run_distillation`
+
+```python
+run_distillation(
+    teacher, student, dataloader, optimizer, device,
+    epochs: int = 1, temperature: float = 4.0, alpha: float = 0.7,
+    epsilon: float = 0.01, scaler=None,
+) -> dict
+```
+
+Runs RSLAD-style distillation: the frozen `teacher` supervises the pruned `student` on FGSM-perturbed inputs. The loss blends KL divergence (temperature-scaled) and the task loss via `alpha`. Returns `{distillation_loss}`.
+
+### `fgsm_perturb`
+
+```python
+fgsm_perturb(model, batch: dict, epsilon: float = 0.01) -> dict
+```
+
+Generates FGSM adversarial examples. For text batches it perturbs input embeddings and returns `inputs_embeds`; for vision batches (`pixel_values` present) it perturbs and clamps pixels to `[0, 1]`.
+
+---
+
+## Examples
+
+### Prune, then distill
+
+```python
+import copy
+import torch
+from nightmarenet.compression import MagnitudePruner
+from nightmarenet.compression.distillation import run_distillation
+
+# Snapshot the teacher before pruning
+teacher = copy.deepcopy(model).eval()
+for p in teacher.parameters():
+    p.requires_grad = False
+
+# Prune the student
+MagnitudePruner(pruning_ratio=0.2).apply(model)
+
+# Distill robustness back into the pruned student
+optimizer = torch.optim.AdamW(model.parameters(), lr=3e-5)
+result = run_distillation(
+    teacher=teacher, student=model, dataloader=dataloader,
+    optimizer=optimizer, device=torch.device("cuda"),
+    epochs=1, temperature=4.0, alpha=0.7, epsilon=0.01,
+)
+print(result["distillation_loss"])
+```
+
+### Low-rank bottleneck instead of pruning
+
+```yaml
+compression:
+  pruning_method: bottleneck
+  bottleneck_rank_ratio: 0.5
+```
+
+```python
+from nightmarenet.compression import apply_bottleneck_to_model
+
+stats = apply_bottleneck_to_model(model, rank_ratio=0.5, target_modules=["mlp", "attn"])
+print(stats)   # {'wrapped_count': ..., 'rank_ratio': 0.5}
+```
+
+---
+
+## Related Documentation
+
+- [Distributed Training](distributed-training.md) — the compress phase always runs on a single GPU.
+- [Getting Started](../tutorials/getting-started.md) — install and run your first cycle.
+- Config reference: [`configs/benchmark_sst2.yaml`](../../configs/benchmark_sst2.yaml)

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -1,0 +1,187 @@
+# Semantic Experiment Search Guide
+
+The hosted NightmareNet server can index every experiment run and search it with natural language. Queries are embedded into a vector space, matched against a FAISS index, and combined with lightweight structured filters parsed straight from the query text (status, model, metric thresholds, and more).
+
+## Overview
+
+Search lives in `nightmarenet_server/search/`:
+
+| Component | Source | Responsibility |
+|---|---|---|
+| `parse_query` | `query_parser.py` | Extracts structured filters from natural-language text. |
+| `ExperimentEmbedder` | `embedder.py` | Embeds runs and queries into 384-dim vectors. |
+| `SearchIndex` | `index.py` | FAISS-backed vector index with a NumPy fallback and disk persistence. |
+| `build_search_router` | `endpoints.py` | FastAPI router exposing `POST /api/v1/search`. |
+| `reindex` | `reindex.py` | Backfills the index from the hosted database. |
+
+Embeddings use `sentence-transformers/all-MiniLM-L6-v2` (384 dimensions) when `sentence-transformers` is installed. When it is not, a deterministic hashing embedder keeps search usable without downloading model weights.
+
+---
+
+## Quick Start
+
+### Query via the API
+
+The router is mounted at `POST /api/v1/search`:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/v1/search" \
+     -H "Content-Type: application/json" \
+     -d '{"query": "completed distilbert runs with robustness > 0.6 last week", "top_k": 10}'
+```
+
+The response contains ranked results plus the filters that were parsed from the query:
+
+```json
+{
+  "results": [
+    {"run_id": "...", "relevance_score": 0.87, "summary": "...", "metadata": {}}
+  ],
+  "filters": {"status": "completed", "model": "distilbert", "metrics": [{"field": "robustness", "op": ">", "value": 0.6}]},
+  "backend": "faiss"
+}
+```
+
+### Build the index
+
+Backfill the index from the hosted database:
+
+```bash
+python -m nightmarenet_server.search.reindex \
+    --database-url "$NIGHTMARENET_DATABASE_URL" \
+    --index-path .nightmarenet_search \
+    --backend faiss
+```
+
+---
+
+## Query Syntax
+
+`parse_query` recognizes the following patterns inside otherwise free-form text:
+
+| Filter | Trigger | Example phrase |
+|---|---|---|
+| `status` | `completed`, `complete`, `failed`, `running`, `queued`, `pending` | "failed runs" |
+| `model` | `model / using / used <name>` | "using distilbert-base-uncased" |
+| `metrics` | `<field> <op> <value>` where op is `>`, `>=`, `<`, `<=`, `=` | "robustness > 0.6" |
+| `created_after` | `last week` | "trained last week" |
+| `exclude_terms` | `not <term>` | "not cifar10" |
+
+Everything else becomes free-text `terms` that feed the semantic embedding. Structured filters are applied by `SearchIndex.hybrid_search`, which only ranks candidates whose metadata matches the parsed filters.
+
+---
+
+## Configuration
+
+Search behaviour is controlled through environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `NIGHTMARENET_SEARCH_BACKEND` | `faiss` | Index backend. Any value other than `faiss` uses the NumPy fallback. |
+| `NIGHTMARENET_SEARCH_INDEX` | `.nightmarenet_search` | Directory where the persisted index (`index.json`) is written. |
+| `NIGHTMARENET_DATABASE_URL` | — | Source database for `reindex` (also accepted via `--database-url`). |
+
+> [!NOTE]
+> FAISS and `sentence-transformers` are optional. Without FAISS, `SearchIndex` falls back to NumPy cosine ranking; without `sentence-transformers`, `ExperimentEmbedder` falls back to a deterministic hashing embedding. Both fallbacks keep the API functional.
+
+---
+
+## API Reference
+
+### `parse_query`
+
+```python
+from nightmarenet_server.search.query_parser import parse_query
+
+parsed = parse_query("completed distilbert runs with robustness > 0.6 last week")
+# ParsedQuery(text=..., filters={...}, terms=[...])
+```
+
+### `ExperimentEmbedder`
+
+```python
+ExperimentEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", dimension=384, model=None)
+```
+
+| Method | Returns | Description |
+|---|---|---|
+| `embed_query(query)` | `np.ndarray` | Embeds a query string. |
+| `embed_run(run)` | `np.ndarray` | Embeds an `ExperimentDocument`. |
+| `serialize_run(run)` | `str` | Flattens a run's config, metrics, events, and audit logs into text. |
+
+The module also exposes `EMBEDDING_DIM = 384` and the `ExperimentDocument` dataclass used to describe a run.
+
+### `SearchIndex`
+
+```python
+SearchIndex(backend="faiss", path=None, dimension=EMBEDDING_DIM)
+```
+
+| Method | Description |
+|---|---|
+| `add(run_id, embedding, metadata)` | Adds/updates a vector and persists the index. |
+| `delete(run_id)` | Removes a run and persists. |
+| `search(query_embedding, top_k=10)` | Pure vector search. Returns `list[SearchHit]`. |
+| `hybrid_search(query_embedding, filters=None, top_k=10)` | Vector search filtered by parsed metadata. |
+| `persist()` | Atomically writes `index.json` to `path`. |
+
+`SearchHit` is a dataclass with `run_id`, `score`, and `metadata`.
+
+### `build_search_router`
+
+```python
+from nightmarenet_server.search.endpoints import build_search_router
+
+router = build_search_router()   # returns a FastAPI APIRouter, or None if FastAPI is unavailable
+```
+
+The request body accepts `query` (1–1000 chars), `top_k` (1–50, default 10), and optional `filters`. Body filters are merged over the filters parsed from the query.
+
+### `reindex`
+
+```python
+reindex(database_url: str, index_path: str = "", backend: str = "faiss") -> int
+```
+
+Iterates over every `Run` in the database, builds an `ExperimentDocument`, embeds it, and adds it to the index. Returns the number of runs indexed.
+
+---
+
+## Examples
+
+### Programmatic search
+
+```python
+from nightmarenet_server.search.embedder import ExperimentEmbedder
+from nightmarenet_server.search.index import SearchIndex
+from nightmarenet_server.search.query_parser import parse_query
+
+embedder = ExperimentEmbedder()
+index = SearchIndex(backend="faiss")
+
+parsed = parse_query("failed runs not cifar10")
+embedding = embedder.embed_query(parsed.text)
+hits = index.hybrid_search(embedding, filters=parsed.filters, top_k=5)
+for hit in hits:
+    print(hit.run_id, hit.score)
+```
+
+### Index a single run
+
+```python
+from nightmarenet_server.search.embedder import ExperimentDocument, ExperimentEmbedder
+from nightmarenet_server.search.index import SearchIndex
+
+doc = ExperimentDocument(run_id="run-123", name="sst2-v1", model="distilbert-base-uncased",
+                         status="completed", metrics={"robustness": 0.68})
+embedder = ExperimentEmbedder()
+index = SearchIndex()
+index.add(doc.run_id, embedder.embed_run(doc), doc.metadata())
+```
+
+---
+
+## Related Documentation
+
+- [Webhook Notifications](webhooks.md) — react to run completion and regression events.
+- [Getting Started](../tutorials/getting-started.md) — install and run your first cycle.

--- a/docs/features/transfer-learning.md
+++ b/docs/features/transfer-learning.md
@@ -1,0 +1,180 @@
+# Transfer Learning Guide
+
+Robustness transfer learning lets you reuse the hardened representations from a completed NightmareNet cycle instead of re-running the full Wake → Dream → Nightmare → Compress loop for every new task. You register a hardened model as a *foundation backbone*, attach a fresh task head, and fine-tune — optionally freezing the bottom layers to preserve the robustness the foundation already learned.
+
+## Overview
+
+The transfer module lives in `nightmarenet/transfer/`:
+
+| Component | Source | Responsibility |
+|---|---|---|
+| `TransferConfig` / `load_config` | `config.py` | Dataclass config and YAML loader. |
+| `create_transfer_model` | `head_factory.py` | Attaches a task head to a foundation backbone. |
+| `FoundationRegistry` / `get_registry` | `registry.py` | Stores and loads foundation backbones. |
+| `TransferFineTuner` | `fine_tune.py` | Fine-tuning loop with layer freezing. |
+| `calculate_transfer_ratio` / `evaluate_transfer_efficiency` | `measurement.py` | Transfer efficiency metrics. |
+| `generate_transfer_report` | `report.py` | Markdown efficiency report. |
+
+---
+
+## Quick Start
+
+```bash
+# 1. Register a hardened model as a foundation backbone
+nightmarenet foundation register --model ./output/sst2-hardened --name sst2-robust
+
+# 2. List registered foundations
+nightmarenet foundation list
+
+# 3. Fine-tune the foundation on a downstream task
+nightmarenet transfer --foundation sst2-robust --config configs/transfer_ag_news.yaml
+```
+
+Registering a model extracts **only** the base backbone (no task head) via `AutoModel`, so the same robust backbone can seed many downstream tasks.
+
+---
+
+## Configuration
+
+Transfer runs are configured with a YAML file loaded into `TransferConfig`. See [`configs/transfer_ag_news.yaml`](../../configs/transfer_ag_news.yaml) for a complete example:
+
+```yaml
+task_type: "seq_classification"   # or "token_classification"
+dataset: "ag_news"
+num_labels: 4
+batch_size: 16
+num_epochs: 3
+freeze_bottom_n: 4                # freeze the bottom 4 backbone layers
+unfreeze_after_epoch: 2           # then unfreeze everything after epoch 2
+learning_rate: 0.00003
+output_dir: "./output/transfer_ag_news"
+device: "cuda"
+strict_layer_freezing: true       # error if freezable layers cannot be found
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `task_type` | `seq_classification` | `seq_classification` or `token_classification`. |
+| `dataset` | `sst2` | Downstream dataset name. |
+| `num_labels` | `2` | Number of output labels. |
+| `batch_size` | `8` | Training batch size. |
+| `num_epochs` | `3` | Fine-tuning epochs. |
+| `freeze_bottom_n` | `0` | Number of bottom backbone layers to freeze. |
+| `unfreeze_after_epoch` | `1` | Epoch (1-indexed) after which all layers unfreeze. |
+| `learning_rate` | `3e-5` | Optimizer learning rate. |
+| `output_dir` | `./output/transfer` | Where fine-tuned artifacts are written. |
+| `device` | `cuda` | Training device. |
+| `strict_layer_freezing` | `false` | Raise `RuntimeError` if freezable layers are not found. |
+
+Foundation models are stored under `~/.nightmarenet/foundation` by default; override the location with the `NIGHTMARENET_FOUNDATION_DIR` environment variable.
+
+Layer freezing supports BERT-like backbones (`encoder.layer`) and GPT-like backbones (`transformer.h`).
+
+---
+
+## API Reference
+
+### Foundation registry (`registry.py`)
+
+```python
+from nightmarenet.transfer import FoundationRegistry, get_registry
+
+registry = get_registry()                      # singleton
+registry.register(model_path="./output/hardened", name="sst2-robust",
+                  metadata={"robustness_score": 0.68})
+backbone, tokenizer, metadata = registry.load("sst2-robust")
+names = registry.list_models()
+```
+
+### Model creation (`head_factory.py`)
+
+```python
+create_transfer_model(foundation_path, task_type="seq_classification", **kwargs) -> PreTrainedModel
+```
+
+Instantiates `AutoModelForSequenceClassification` or `AutoModelForTokenClassification` on top of the foundation backbone. Extra keyword arguments (e.g. `num_labels`) are forwarded to `from_pretrained`.
+
+### Fine-tuning (`fine_tune.py`)
+
+```python
+TransferFineTuner(model, optimizer, device, scaler=None)
+
+fine_tuner.run(
+    dataloader,
+    num_epochs,
+    freeze_bottom_n=0,
+    unfreeze_after_epoch=1,
+    strict_layer_freezing=False,
+) -> dict   # {avg_loss, final_epoch_loss, per_epoch_losses, layers_frozen}
+```
+
+### Measurement (`measurement.py`)
+
+```python
+calculate_transfer_ratio(transferred_robustness, baseline_robustness) -> float
+evaluate_transfer_efficiency(transfer_ratio) -> str
+```
+
+`evaluate_transfer_efficiency` classifies the ratio as *Highly Efficient* (> 0.7), *Moderately Efficient* (> 0.3), or *Weak*.
+
+### Reporting (`report.py`)
+
+```python
+generate_transfer_report(
+    transferred_robustness, baseline_robustness,
+    clean_accuracy_transferred, clean_accuracy_baseline,
+    transferred_time_s, baseline_time_s,
+) -> str   # markdown report
+```
+
+---
+
+## Examples
+
+### End-to-end fine-tuning in Python
+
+```python
+import torch
+from torch.utils.data import DataLoader
+from nightmarenet.transfer import get_registry, create_transfer_model, TransferFineTuner
+from nightmarenet.transfer.config import load_config
+
+config = load_config("configs/transfer_ag_news.yaml")
+registry = get_registry()
+foundation_path = registry.cache_dir / "sst2-robust"
+
+model = create_transfer_model(
+    str(foundation_path),
+    task_type=config.task_type,
+    num_labels=config.num_labels,
+)
+optimizer = torch.optim.AdamW(model.parameters(), lr=config.learning_rate)
+
+fine_tuner = TransferFineTuner(model, optimizer, torch.device(config.device))
+result = fine_tuner.run(
+    dataloader,
+    num_epochs=config.num_epochs,
+    freeze_bottom_n=config.freeze_bottom_n,
+    unfreeze_after_epoch=config.unfreeze_after_epoch,
+    strict_layer_freezing=config.strict_layer_freezing,
+)
+print(result["per_epoch_losses"])
+```
+
+### Measure transfer efficiency
+
+```bash
+nightmarenet transfer --measure \
+    --transferred ./output/transfer_ag_news/eval.json \
+    --baseline ./output/full_cycle/eval.json
+```
+
+Both JSON files must contain `robustness_score` and `clean_accuracy` keys. The command prints a markdown report summarizing the transfer ratio, efficiency classification, and compute savings.
+
+---
+
+## Related Documentation
+
+- [Distributed Training](distributed-training.md) — scale the original cycle across GPUs.
+- [Getting Started](../tutorials/getting-started.md) — install and run your first cycle.
+- Config reference: [`configs/transfer_ag_news.yaml`](../../configs/transfer_ag_news.yaml)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -182,3 +182,13 @@ Now that you have run your first evaluation:
 1. Learn how to write your own custom perturbations in [Tutorial 2: Custom Distortions](custom-distortions.md).
 2. Deep dive into how metrics are calculated and how they apply to compliance frameworks in [Tutorial 3: Interpreting Results](interpreting-results.md).
 3. Hardening a model? Check out [Tutorial 5: Deployment](deployment.md) to serve the model locally or run it via the docker container.
+
+### Feature Guides
+
+For in-depth documentation of individual features, see the [`docs/features/`](../features/) directory:
+
+* [Distributed Training](../features/distributed-training.md) — run the cycle across multiple GPUs.
+* [Model Compression](../features/model-compression.md) — pruning, bottlenecks, and robust distillation.
+* [Transfer Learning](../features/transfer-learning.md) — reuse a hardened backbone on new tasks.
+* [Hyperparameter Optimization](../features/hpo.md) — tune configs with Optuna.
+* [Semantic Experiment Search](../features/search.md) — search runs with natural language.


### PR DESCRIPTION
Closes #667

## Summary
Adds five user-facing feature docs under `docs/features/`, matching the existing `webhooks.md` format. Each doc has **Overview, Quick Start, Configuration, API Reference, and Examples**, with copy-pasteable code that references real function names and links to real config files.

| Doc | Covers |
|---|---|
| `docs/features/distributed-training.md` | `DevicePool`, `DDPWrapper`, per-phase strategy (`apply_phase_strategy`), `AtomicCheckpointer`/`ResumeManager`, `--distributed` CLI, torchrun |
| `docs/features/model-compression.md` | `MagnitudePruner`, `BottleneckWrapper`/`apply_bottleneck_to_model`, `run_distillation`/`fgsm_perturb`, `compression` config keys |
| `docs/features/transfer-learning.md` | `FoundationRegistry`/`get_registry`, `create_transfer_model`, `TransferFineTuner`, `calculate_transfer_ratio`/`generate_transfer_report`, `foundation`/`transfer` CLI |
| `docs/features/hpo.md` | `HyperparameterOptimizer`, `hpo` config + search spaces, `optimize` CLI |
| `docs/features/search.md` | `parse_query`, `ExperimentEmbedder`, `SearchIndex`, `build_search_router`, `reindex` |

Also cross-links the new guides from `README.md` and `docs/tutorials/getting-started.md`.

## Acceptance criteria
- [x] 5 new markdown files in `docs/features/`
- [x] Each has Overview, Quick Start, Configuration, API Reference, Examples
- [x] Code examples reference real function names (all 20 verified against source)
- [x] Links to related config files in `configs/` and `configs/examples/`
- [x] No broken internal links (all relative links verified)
- [x] Consistent with existing `docs/features/webhooks.md` format

## Verification
- All referenced symbols confirmed to exist in source via symbol lookup.
- Referenced config files (`configs/benchmark_sst2.yaml`, `configs/transfer_ag_news.yaml`, `configs/examples/hpo-config.yaml`) and linked tutorials all exist.
- All 16 relative links inside the new docs resolve.
- No markdown linter is configured in the repo, so that lint sub-item is N/A.

## Notes
Documentation only — no code or behavior changes. This PR includes AI-assisted authoring; all API references were verified against the source.