### PR TITLE
docs: add developer workflow guides (testing, distortions, metrics, architecture) (#668)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,6 +300,18 @@ NightmareNet has a strict OSS / hosted boundary. Treat it as a hard constraint w
 - [`docs/research/paper-draft.md`](docs/research/paper-draft.md) — academic paper draft (cite this in PRs that touch the algorithm)
 - [`docs/research/benchmark-v1.md`](docs/research/benchmark-v1.md) — reproducible benchmark methodology
 
+### Developer guides
+
+Contributor workflow docs live in [`docs/development/`](docs/development/):
+
+- [`docs/development/testing.md`](docs/development/testing.md) — running and writing tests, markers, coverage, and CI steps
+- [`docs/development/adding-distortions.md`](docs/development/adding-distortions.md) — the in-tree distortion engine workflow
+- [`docs/development/adding-metrics.md`](docs/development/adding-metrics.md) — adding and wiring an evaluation metric
+- [`docs/development/architecture.md`](docs/development/architecture.md) — module dependency and pipeline-flow diagrams
+- [`docs/development/code-style.md`](docs/development/code-style.md) — lint, format, mypy baseline policy, and commit conventions
+- [`docs/development/local-stack.md`](docs/development/local-stack.md) — running the API + frontend locally
+
+
 ---
 
 ## Adding a new distortion

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ Learn how to use, extend, and deploy NightmareNet through our step-by-step tutor
 
 Client developers can also use the committed OpenAPI spec at [`docs/api/openapi.json`](docs/api/openapi.json) (regenerate with `make openapi`).
 
+### Developer Guide
+
+Contributor workflow documentation lives in [`docs/development/`](docs/development/):
+
+*   [Testing](docs/development/testing.md) — pytest markers, coverage, frontend tests, and what CI runs.
+*   [Adding Distortions](docs/development/adding-distortions.md) — the in-tree distortion engine workflow and testing contract.
+*   [Adding Metrics](docs/development/adding-metrics.md) — implement and wire a new evaluation metric.
+*   [Architecture](docs/development/architecture.md) — module dependency and pipeline-flow diagrams.
+*   [Code Style](docs/development/code-style.md) — Ruff, pre-commit hooks, the mypy baseline policy, and commit conventions.
+*   [Local Stack](docs/development/local-stack.md) — run the API and frontend locally.
+
 ### GitHub Action (robustness gate)
 
 ```yaml

--- a/docs/development/adding-distortions.md
+++ b/docs/development/adding-distortions.md
@@ -1,0 +1,177 @@
+# Adding a Distortion Engine
+
+This guide walks through adding a **built-in (in-tree) distortion engine** to the NightmareNet core. If you instead want to ship a distortion as a separately-installed package or a single-file/decorator plugin, see the [Plugin Development Guide](../plugin_development.md) — this document intentionally focuses on the in-repo workflow and links out to avoid duplication.
+
+## The contract
+
+Every distortion — built-in or plugin — implements the same signature, defined in [`nightmarenet/distortions/registry.py`](../../nightmarenet/distortions/registry.py):
+
+```python
+from typing import Callable, Optional
+
+DistortionFn = Callable[[str, float, Optional[int]], str]
+```
+
+That is: take `text`, a `strength` in `[0.0, 1.0]`, and an optional `seed`; return the distorted string. The behavioral contract (from [`nightmarenet/distortions/base.py`](../../nightmarenet/distortions/base.py)) is:
+
+- `strength=0.0` should be approximately a no-op (return the text unchanged).
+- `strength=1.0` should produce maximum distortion.
+- The same `(text, strength, seed)` must produce identical output (determinism).
+- Empty input must return an empty string without raising.
+- The return type must be `str`.
+
+## Two ways to implement an engine
+
+### Option A — a plain function
+
+The registry accepts any callable matching `DistortionFn`. This is the simplest form for a built-in engine.
+
+```python
+# nightmarenet/distortions/your_engine.py
+import random
+from typing import Optional
+
+
+def distort(text: str, strength: float, seed: Optional[int] = None) -> str:
+    """Swap adjacent characters with probability proportional to strength."""
+    if not text:
+        return ""
+    rng = random.Random(seed)
+    chars = list(text)
+    for i in range(len(chars) - 1):
+        if rng.random() < strength:
+            chars[i], chars[i + 1] = chars[i + 1], chars[i]
+    return "".join(chars)
+```
+
+### Option B — a `BaseDistortion` subclass
+
+For engines that carry metadata (`name`, `phase`, `description`), subclass `BaseDistortion` from [`nightmarenet/distortions/base.py`](../../nightmarenet/distortions/base.py):
+
+```python
+from typing import Optional
+
+from nightmarenet.distortions.base import BaseDistortion
+
+
+class CharSwap(BaseDistortion):
+    name = "char_swap"
+    phase = "nightmare"          # "dream", "nightmare", or "custom"
+    description = "Swap adjacent characters"
+
+    def distort(self, text: str, strength: float, seed: Optional[int] = None) -> str:
+        ...
+```
+
+`BaseDistortion.validate()` returns `True` when `name` is set, and the abstract `distort` method enforces the signature.
+
+## Registering the engine
+
+Built-in engines are registered in `DistortionRegistry._register_builtins()` inside [`nightmarenet/distortions/registry.py`](../../nightmarenet/distortions/registry.py), alongside the existing `dream`, `nightmare`, and `keyboard_typo` engines:
+
+```python
+def _register_builtins(self) -> None:
+    from nightmarenet.distortions import your_engine
+
+    self.register(
+        "char_swap",
+        your_engine.distort,
+        metadata={
+            "phase": "nightmare",
+            "description": "Swap adjacent characters",
+            "source": "builtin",
+        },
+    )
+```
+
+The registry is a lazy singleton — retrieve it with `get_registry()` and apply an engine by name:
+
+```python
+from nightmarenet.distortions.registry import get_registry
+
+registry = get_registry()
+result = registry.apply("char_swap", "hello world", strength=0.5, seed=42)
+print(registry.engine_names)          # sorted list of registered engines
+print(registry.list_engines_by_source())  # grouped into builtin / plugin / custom
+```
+
+Relevant `DistortionRegistry` methods:
+
+| Method | Description |
+|---|---|
+| `register(name, fn, metadata=None)` | Register an engine (raises `TypeError` if `fn` is not callable). |
+| `register_decorator(name, phase="custom", description="")` | Decorator form of `register`. |
+| `apply(name, text, strength=0.3, seed=None, **kwargs)` | Apply an engine; extra kwargs are forwarded only if the function accepts them. |
+| `list_engines()` / `list_engines_by_source()` | Enumerate engines with metadata. |
+| `unregister(name)` | Remove an engine. |
+| `engine_names` | Property — sorted engine names. |
+
+> [!NOTE]
+> Vision distortions use a parallel `VisionDistortionRegistry` (retrieved via `get_vision_registry()`) with the signature `(image: torch.Tensor, strength, seed) -> torch.Tensor` and the entry-point group `nightmarenet.distortions.vision`.
+
+## Validating your engine
+
+Use the helpers in [`nightmarenet/distortions/testing.py`](../../nightmarenet/distortions/testing.py) to check the contract before writing full tests:
+
+```python
+from nightmarenet.distortions.testing import (
+    validate_distortion_function,
+    validate_distortion_plugin,
+)
+
+# For a plain function
+failures = validate_distortion_function(distort)
+
+# For a BaseDistortion subclass
+failures = validate_distortion_plugin(CharSwap)
+
+assert not failures, failures
+```
+
+These delegate to `validate_distortion_contract` and `validate_base_distortion` in [`nightmarenet/distortions/validators.py`](../../nightmarenet/distortions/validators.py), which check determinism, the strength-0 no-op, empty input, and type correctness.
+
+## Testing
+
+Add tests under `tests/` (mirroring the package layout). At minimum cover:
+
+1. **Determinism** — same `(text, strength, seed)` produces the same output.
+2. **Strength 0** — approximately a no-op.
+3. **Strength 1** — produces a measurable change.
+4. **Empty input** — returns `""` without raising.
+5. **Registry round-trip** — `get_registry().apply("char_swap", ...)` matches calling the function directly.
+
+```python
+from nightmarenet.distortions.registry import get_registry
+from nightmarenet.distortions.your_engine import distort
+
+
+def test_determinism():
+    assert distort("hello", 0.5, seed=42) == distort("hello", 0.5, seed=42)
+
+
+def test_strength_zero_is_noop():
+    assert distort("hello", 0.0, seed=42) == "hello"
+
+
+def test_empty_input():
+    assert distort("", 0.5, seed=42) == ""
+
+
+def test_registry_round_trip():
+    registry = get_registry()
+    assert registry.apply("char_swap", "hello", strength=0.5, seed=42) == distort(
+        "hello", 0.5, seed=42
+    )
+```
+
+Run them with `pytest tests/test_your_engine.py` (see the [Testing Guide](testing.md)).
+
+## Documentation
+
+Per `CONTRIBUTING.md`, update the README distortion table when adding an engine, and if your distortion implements a published adversarial attack, cite the paper in the module docstring and in `docs/research/paper-draft.md`.
+
+## Related Documentation
+
+- [Plugin Development Guide](../plugin_development.md) — entry-point, decorator, and file-based plugins.
+- [Testing Guide](testing.md) — running and writing tests.
+- [Architecture](architecture.md) — where distortions sit in the pipeline.

--- a/docs/development/adding-metrics.md
+++ b/docs/development/adding-metrics.md
@@ -1,0 +1,124 @@
+# Adding an Evaluation Metric
+
+NightmareNet's evaluation metrics are plain functions in [`nightmarenet/evaluation/metrics.py`](../../nightmarenet/evaluation/metrics.py), dispatched by name from the `Evaluator`. Adding a metric is a four-step change: implement the function, export it, wire a dispatch branch, and enable it in config.
+
+## How metrics are selected
+
+The `Evaluator` in [`nightmarenet/evaluation/evaluator/core.py`](../../nightmarenet/evaluation/evaluator/core.py) reads the list of enabled metrics from config and dispatches on the string name:
+
+```python
+default_metrics = (
+    ["classification", "robustness"]
+    if config.get("model", {}).get("type") == "image_classification"
+    else ["recall", "generalization", "robustness", "hallucination"]
+)
+self.enabled_metrics = list(self.eval_config.get("metrics", default_metrics))
+```
+
+`Evaluator.evaluate(...)` then runs each enabled metric inside a `try/except`, storing the result (or an `{"error": ...}` dict) under the metric name.
+
+## Existing metric functions
+
+All metric functions live in `metrics.py` and are re-exported from [`nightmarenet/evaluation/__init__.py`](../../nightmarenet/evaluation/__init__.py):
+
+| Function | Signature (abridged) | Purpose |
+|---|---|---|
+| `recall_score` | `(model, dataloader, tokenizer, device)` | Token accuracy + perplexity on clean data. |
+| `generalization_score` | `(model, ood_dataloader, clean_dataloader, device)` | OOD-vs-clean perplexity ratio. |
+| `robustness_score` | `(model, base_dataset, tokenizer, distortion_fn, strengths=None, ...)` | AUC over a distortion-strength sweep. |
+| `hallucination_rate` | `(model, factual_dataloader, tokenizer, device, confidence_threshold=0.5)` | High-confidence wrong-prediction rate. |
+| `classification_metrics` | `(model, dataloader, device, return_per_sample=False)` | Accuracy + weighted/per-class F1. |
+
+Each returns a `dict` that includes a `"metric"` key. NaN/Inf values are guarded with the `_safe_float` helper — reuse it in new metrics.
+
+## Step-by-step: add a metric
+
+Suppose you want to add a `calibration` metric.
+
+### 1. Implement the function in `metrics.py`
+
+```python
+def calibration_score(
+    model,
+    dataloader: DataLoader,
+    device="cpu",
+) -> dict:
+    """Expected Calibration Error (ECE) on a labelled dataset.
+
+    Returns:
+        Dict with the metric name and the ECE value.
+    """
+    model.eval()
+    # ... compute ece ...
+    ece = 0.0
+    return {
+        "metric": "calibration",
+        "ece": _safe_float(ece),
+    }
+```
+
+Follow the conventions from `CONTRIBUTING.md`: module logger (no `print`), Google-style docstring on the public function, and wrap suspicious arithmetic with `_safe_float`.
+
+### 2. Export it from `evaluation/__init__.py`
+
+```python
+from nightmarenet.evaluation.metrics import (
+    calibration_score as calibration_score,
+    ...
+)
+```
+
+### 3. Add a dispatch branch in `evaluator/core.py`
+
+Inside `Evaluator.evaluate(...)`, add a branch mirroring the existing ones:
+
+```python
+if "calibration" in self.enabled_metrics:
+    logger.info("Evaluating: calibration")
+    try:
+        results["calibration"] = calibration_score(
+            self.model, clean_dataloader, self.device
+        )
+        if self.tracker:
+            self._log_eval("calibration", results["calibration"])
+    except Exception as e:
+        logger.error("Failed to compute calibration: %s", e)
+        results["calibration"] = {"error": str(e)}
+```
+
+### 4. Enable it in config
+
+Add the metric name to the `evaluation.metrics` list in your YAML config (the default list lives in `nightmarenet/utils/config.py`):
+
+```yaml
+evaluation:
+  metrics:
+    - recall
+    - generalization
+    - robustness
+    - hallucination
+    - calibration
+```
+
+## Testing
+
+Add tests under `tests/` (e.g. `tests/test_metrics.py`) covering:
+
+- The happy path returns a dict with the expected `"metric"` key and value range.
+- Edge cases (empty dataloader, single class) do not raise and return safe defaults.
+- NaN/Inf inputs are neutralized (values pass through `_safe_float`).
+
+```python
+def test_calibration_score_returns_metric_key():
+    result = calibration_score(model, dataloader, device="cpu")
+    assert result["metric"] == "calibration"
+    assert 0.0 <= result["ece"] <= 1.0
+```
+
+Run with `pytest tests/test_metrics.py` — see the [Testing Guide](testing.md).
+
+## Related Documentation
+
+- [Architecture](architecture.md) — where evaluation sits in the pipeline.
+- [Testing Guide](testing.md) — running and writing tests.
+- [Code Style](code-style.md) — the `_safe_float` / no-`print` conventions.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,124 @@
+# Architecture Overview
+
+This document maps the NightmareNet codebase for new contributors: how the modules depend on each other, how the training pipeline flows, and where the OSS core ends and the hosted server begins.
+
+## Module relationships
+
+The OSS core (`nightmarenet/`) is self-contained. The hosted server (`nightmarenet_server/`) and the Next.js `frontend/` build on top of it, but the core never imports from them.
+
+```mermaid
+graph TD
+    CLI["nightmarenet.cli"]
+    Pipeline["nightmarenet.pipeline.Pipeline"]
+    Phases["nightmarenet.phases<br/>(ingest, optimize, prepare, train, evaluate, export)"]
+    Training["nightmarenet.training<br/>(trainer, Wake/Dream/Nightmare/Compress)"]
+    Distortions["nightmarenet.distortions<br/>(registry, base, engines)"]
+    Compression["nightmarenet.compression"]
+    Evaluation["nightmarenet.evaluation<br/>(Evaluator, metrics)"]
+    API["nightmarenet.api.app<br/>(FastAPI)"]
+
+    Server["nightmarenet_server<br/>(auth, DB, workers, search)"]
+    Frontend["frontend<br/>(Next.js dashboard)"]
+
+    CLI --> Pipeline
+    CLI --> Distortions
+    CLI --> Evaluation
+    Pipeline --> Phases
+    Phases --> Training
+    Phases --> Evaluation
+    Training --> Distortions
+    Training --> Compression
+    Evaluation --> Distortions
+    API --> Pipeline
+    API --> Distortions
+    API --> Evaluation
+
+    Server --> API
+    Frontend --> API
+    Frontend --> Server
+
+    classDef core fill:#06B6D4,stroke:#0891B2,color:#020617
+    classDef hosted fill:#818CF8,stroke:#6366F1,color:#020617
+    class CLI,Pipeline,Phases,Training,Distortions,Compression,Evaluation,API core
+    class Server,Frontend hosted
+```
+
+> [!IMPORTANT]
+> The OSS core (`nightmarenet/`) must **not** import from `nightmarenet_server/`, and must not depend on PostgreSQL, Redis, Celery, or OAuth libraries. See the OSS/hosted boundary table in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#architecture-pointers).
+
+## Pipeline phase flow
+
+`Pipeline.run()` (in [`nightmarenet/pipeline.py`](../../nightmarenet/pipeline.py)) executes a fixed sequence of orchestration phases, each implemented as a `Phase` subclass. `EvaluatePhase` internally invokes `ExportPhase`.
+
+```mermaid
+flowchart LR
+    Ingest["IngestPhase<br/>load dataset"]
+    Optimize["OptimizePhase<br/>adaption / data prep"]
+    Prepare["PreparePhase<br/>dataloaders, trainer, distortion_fn"]
+    Train["TrainPhase<br/>Wake -> Dream -> Nightmare -> Compress"]
+    Evaluate["EvaluatePhase<br/>metrics + comparison"]
+    Export["ExportPhase<br/>artifacts + report"]
+
+    Ingest --> Optimize --> Prepare --> Train --> Evaluate --> Export
+```
+
+Each orchestration phase implements the abstract base in [`nightmarenet/phases/base.py`](../../nightmarenet/phases/base.py):
+
+```python
+class Phase(abc.ABC):
+    name: str = "phase"
+
+    @abc.abstractmethod
+    def execute(self, context: PipelineContext) -> PhaseResult:
+        ...
+```
+
+- **`PipelineContext`** is a dataclass holding all mutable run state (`run_id`, `config`, `dataset`, `train_dl`, `trainer`, `history`, `trained_results`, `comparison`, `report_md`, …). Each phase reads and mutates it in place.
+- **`PhaseResult`** reports `success`, `phase_name`, an optional `error`, and a `data` dict.
+
+The four *training* sub-phases (Wake → Dream → Nightmare → Compress) run **inside** `TrainPhase`; their implementations live in `nightmarenet/training/` (trainer and phase logic), not in `nightmarenet/phases/`.
+
+## Evaluation flow
+
+`EvaluatePhase` uses the `Evaluator` (in [`nightmarenet/evaluation/evaluator/core.py`](../../nightmarenet/evaluation/evaluator/core.py)), which dispatches string metric names to functions in [`nightmarenet/evaluation/metrics.py`](../../nightmarenet/evaluation/metrics.py):
+
+```mermaid
+flowchart TD
+    Config["config.evaluation.metrics<br/>(list of names)"]
+    Evaluator["Evaluator.evaluate()"]
+    Recall["recall_score"]
+    Gen["generalization_score"]
+    Rob["robustness_score"]
+    Hall["hallucination_rate"]
+    Cls["classification_metrics"]
+
+    Config --> Evaluator
+    Evaluator --> Recall
+    Evaluator --> Gen
+    Evaluator --> Rob
+    Evaluator --> Hall
+    Evaluator --> Cls
+```
+
+See [Adding Metrics](adding-metrics.md) for how to extend this dispatch.
+
+## Key entry points
+
+| Entry point | Location | Role |
+|---|---|---|
+| `Pipeline` | `nightmarenet.pipeline` | Orchestrates the 4-phase cycle. |
+| `main` | `nightmarenet.cli` | The `nightmarenet` console command. |
+| `get_registry` | `nightmarenet.distortions.registry` | Lazy-singleton distortion registry. |
+| `Evaluator` | `nightmarenet.evaluation.evaluator` | Multi-strength robustness scoring. |
+| `app` | `nightmarenet.api.app` | FastAPI app for the OSS HTTP surface. |
+
+## Server architecture
+
+The hosted server (`nightmarenet_server/`) adds authentication, a multi-tenant database, Celery workers, and semantic experiment search on top of the OSS API. It is documented separately in [`docs/development/local-stack.md`](local-stack.md); the deployment topology and OSS/hosted split are described in [`docs/architecture/`](../architecture/).
+
+## Related Documentation
+
+- [Adding Distortions](adding-distortions.md) — extend the distortion registry.
+- [Adding Metrics](adding-metrics.md) — extend the evaluator.
+- [Local Stack](local-stack.md) — run the API + frontend locally.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — the OSS/hosted boundary and entry points.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,137 @@
+# Testing Guide
+
+This guide covers how to run and write tests for NightmareNet. The suite mirrors what CI runs on every pull request, so a green local run is the best predictor of a green PR.
+
+## Running the Python test suite
+
+Install the dev dependencies once, then run pytest from the repo root:
+
+```bash
+pip install -e ".[dev,api]"
+pytest
+```
+
+The default options are defined in `pyproject.toml` under `[tool.pytest.ini_options]`:
+
+```toml
+testpaths = ["tests"]
+addopts = "-v --tb=short -m 'not slow' --ignore=tests/test_distortion_vision.py"
+markers = [
+    "slow: marks slow tests (deselect with '-m not slow')",
+]
+```
+
+So a bare `pytest` already runs verbosely, uses short tracebacks, **skips slow tests**, and ignores the vision distortion test module.
+
+### Preferred commands
+
+Use the cross-platform developer CLI or the Makefile — both mirror CI:
+
+| Task | Command |
+|------|---------|
+| Run tests (`not slow`, with coverage) | `nightmarenet dev test` or `make test` |
+| Run the full local check (lint + typecheck + test) | `nightmarenet dev check` or `make check` |
+| Frontend tests | `nightmarenet dev test --frontend` or `make frontend-test` |
+
+`make test` runs exactly what CI runs:
+
+```bash
+PYTHONPATH=. pytest -m "not slow" --cov=nightmarenet --cov-report=xml --cov-report=term-missing
+```
+
+## Markers
+
+The `slow` marker separates fast unit tests from long-running ones (training loops, large fuzz suites).
+
+```bash
+# Default: skip slow tests
+pytest -m "not slow"
+
+# Run ONLY slow tests
+pytest -m "slow"
+
+# Run everything
+pytest -m ""
+```
+
+Mark a slow test in code:
+
+```python
+import pytest
+
+
+@pytest.mark.slow
+def test_full_training_cycle():
+    ...
+```
+
+## Coverage
+
+Coverage is collected with `pytest-cov` against the `nightmarenet` package:
+
+```bash
+# Terminal report showing missing lines
+pytest --cov=nightmarenet --cov-report=term-missing
+
+# XML report (what CI uploads to Codecov)
+pytest --cov=nightmarenet --cov-report=xml
+```
+
+CI uploads `coverage.xml` to Codecov on the Python 3.12 job.
+
+## Selecting tests
+
+```bash
+# A single file
+pytest tests/test_pipeline.py
+
+# A single test function
+pytest tests/test_pipeline.py::test_pipeline_runs
+
+# By keyword
+pytest -k "distortion and not vision"
+```
+
+## Frontend tests
+
+The Next.js dashboard lives in `frontend/`. From that directory:
+
+```bash
+cd frontend
+npm ci
+npm run lint        # ESLint
+npx tsc --noEmit    # TypeScript type-check
+npm test            # unit tests
+npm run build       # production build
+npm run test:a11y   # Playwright accessibility tests
+```
+
+## What CI runs
+
+The workflow in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs on every push and pull request to `main`, across a Python `3.9`–`3.12` matrix:
+
+1. `pip install -e ".[dev,api]"`
+2. **mypy** (Python 3.12 only) — strict, baseline-enforced (see [Code Style](code-style.md)).
+3. **pytest** — `pytest -m "not slow" --cov=nightmarenet --cov-report=xml --cov-report=term-missing`.
+4. **Codecov** upload (3.12 only).
+5. **OpenAPI drift check** (3.12 only) — `python scripts/export_openapi.py --check`.
+6. **Frontend** (3.12 only) — `npm ci`, lint, `tsc --noEmit`, unit tests, build, and Playwright accessibility tests.
+
+Ruff lint/format runs in a separate workflow (`.github/workflows/pre-commit.yml`) to avoid duplicate checks.
+
+## Writing tests
+
+Tests live in `tests/` and mirror the package structure (e.g. `tests/test_distortions.py`, `tests/test_pipeline.py`, `tests/test_metrics.py`). A few conventions from `CONTRIBUTING.md`:
+
+- Use `monkeypatch` for environment variables; never mutate `os.environ` directly.
+- Keep the non-slow suite fast; mark anything heavy with `@pytest.mark.slow`.
+- Never reduce the test count without explaining why in the PR description.
+- New distortions, metrics, and phases must be tested for determinism, edge inputs, and registry round-trip.
+
+See [Adding Distortions](adding-distortions.md) and [Adding Metrics](adding-metrics.md) for the specific test patterns those subsystems expect.
+
+## Related Documentation
+
+- [Code Style](code-style.md) — lint, formatting, and the mypy baseline policy.
+- [Local Stack](local-stack.md) — running the API and frontend locally.
+- [Architecture](architecture.md) — how the pieces fit together.


### PR DESCRIPTION
Closes #668

## Summary
Adds contributor workflow documentation under `docs/development/`, consistent with the existing `local-stack.md` format. Each guide has step-by-step instructions and references real file paths and function signatures from source.

| Doc | Covers |
|---|---|
| `docs/development/testing.md` | pytest markers (`-m "not slow"`), coverage, test selection, frontend tests, and the exact CI steps from `.github/workflows/ci.yml` |
| `docs/development/adding-distortions.md` | in-tree distortion workflow — `BaseDistortion`, `DistortionRegistry`, `validate_distortion_function`/`validate_distortion_plugin`, and the testing contract (cross-linked to `docs/plugin_development.md` to avoid overlap) |
| `docs/development/adding-metrics.md` | implement a metric in `evaluation/metrics.py`, export it, wire the `Evaluator` dispatch branch, and enable it in config |
| `docs/development/architecture.md` | **Mermaid** diagrams for module dependencies, the pipeline phase flow (Ingest → Optimize → Prepare → Train → Evaluate → Export), and evaluation dispatch; plus the OSS/hosted boundary |

Cross-links added: a new **Developer Guide** section in `README.md` and a **Developer guides** list in `CONTRIBUTING.md`.

> **Note on `code-style.md`:** The fifth item from the issue, `docs/development/code-style.md`, **already exists** on `main` with a detailed type-checking policy. I left it unchanged rather than overwrite it — all five files now exist in `docs/development/`.

## Acceptance criteria
- [x] 5 markdown files in `docs/development/` (4 new + the pre-existing `code-style.md`)
- [x] Architecture doc includes a Mermaid diagram of module relationships (pipeline phases, evaluation, training, distortions)
- [x] Each guide has step-by-step instructions a newcomer can follow
- [x] References real file paths and function signatures from source
- [x] Consistent with existing `docs/development/local-stack.md` format

## Verification
- All referenced symbols confirmed in source via symbol lookup (`BaseDistortion`, `DistortionRegistry`, `get_registry`, `validate_distortion_function`, `validate_distortion_plugin`, `recall_score`, `robustness_score`, `hallucination_rate`, `Phase`, `PipelineContext`).
- All internal relative links resolve.
- All 3 Mermaid diagrams render with the official `@mermaid-js/mermaid-cli` v11 (same engine GitHub uses).
- No overlap with `docs/plugin_development.md` — the distortion guide focuses on the in-tree path and links out for plugin authoring.
- No markdown linter is configured in the repo, so that lint sub-item is N/A.

## Notes
Documentation only — no code or behavior changes. This PR includes AI-assisted authoring; all file paths and API references were verified against the source.