### PR TITLE
docs: add config guide, notebook table, and 4 example configs (#669)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Learn how to use, extend, and deploy NightmareNet through our step-by-step tutor
 
 Client developers can also use the committed OpenAPI spec at [`docs/api/openapi.json`](docs/api/openapi.json) (regenerate with `make openapi`).
 
+### Configuration & Notebooks
+
+*   [Configuration Guide](configs/README.md) — config schema (all top-level keys), the defaults inheritance/override model, validation rules, and annotated example configs.
+*   [Notebooks Guide](notebooks/README.md) — the Colab-ready walkthrough notebooks with prerequisites, runtime, and expected output.
+
 ### GitHub Action (robustness gate)
 
 ```yaml

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,242 @@
+# Configuration Guide
+
+NightmareNet is driven by YAML configuration files. This directory holds the
+base config, ready-to-run benchmark configs, and a set of annotated
+[`examples/`](examples/). This guide explains the schema, the
+inheritance/override model, and the validation rules.
+
+## How configs are loaded
+
+Configs are loaded by `load_config()` in
+[`../nightmarenet/utils/config.py`](../nightmarenet/utils/config.py):
+
+```python
+from nightmarenet.utils.config import load_config
+
+config = load_config("configs/examples/custom-distortion-chain.yaml")
+```
+
+`load_config()`:
+
+1. Reads your YAML file into a dict.
+2. **Deep-merges it over the built-in `DEFAULT_CONFIG`** (see below).
+3. Validates the merged result and raises `ValueError` on any schema violation.
+
+## Inheritance / override model
+
+There is no `extends:` key. Instead, every config **inherits from the built-in
+defaults** (`DEFAULT_CONFIG` in `utils/config.py`, mirrored by
+[`default.yaml`](default.yaml)). Your file only needs to specify the keys you
+want to change.
+
+- The merge is **recursive (deep)**: setting `distortion.dream_strength` leaves
+  the rest of the `distortion` block at its default values.
+- Nested dictionaries are merged key-by-key; scalars and lists are replaced
+  wholesale.
+- Because of the merge, a minimal config is valid — any key you omit is filled
+  from the defaults.
+
+```yaml
+# A complete, valid config — everything else comes from the defaults.
+model:
+  name: distilbert-base-uncased
+  type: seq_classification
+dataset:
+  name: glue
+  text_column: sentence
+```
+
+> **Unknown top-level keys** (anything not listed in [Top-level keys](#top-level-keys))
+> produce a **warning** with a "did you mean …?" suggestion, but do **not** fail
+> loading. Unknown *nested* keys (e.g. `dataset.config`, `compression.distillation`)
+> are merged through and left for the relevant subsystem to consume.
+
+## Top-level keys
+
+These are the top-level sections defined in [`default.yaml`](default.yaml):
+
+| Key | Purpose |
+|-----|---------|
+| `model` | Backbone model, task type, sequence length, device. |
+| `dataset` | Dataset name/subset, text and label columns, sampling. |
+| `training` | Cycle counts, epochs, batch size, optimizer, checkpointing, distributed. |
+| `distortion` | Dream/Nightmare strengths, schedule, and per-type engine weights. |
+| `compression` | Pruning and (optional) distillation settings. |
+| `evaluation` | Which metrics to run and the robustness strength sweep. |
+| `tracking` | Experiment tracking backend and compliance reporting. |
+| `notifications` | Webhook notifications (see [webhooks guide](../docs/features/webhooks.md)). |
+| `hpo` | Optuna hyperparameter search (consumed by `nightmarenet optimize`; see [`examples/hpo-config.yaml`](examples/hpo-config.yaml)). |
+| `seed` | Global random seed. |
+| `compliance` | Compliance signing-key path. |
+| `observability` | Structured logging and OpenTelemetry export. |
+| `adaption` | Optional Adaption Labs dataset optimization. |
+
+### `model`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `name` | str (required) | `gpt2` | HF model id or local path. |
+| `type` | str (required) | `causal_lm` | `causal_lm` \| `masked_lm` \| `seq_classification` \| `image_classification`. |
+| `num_labels` | int | `2` | Used for `seq_classification`. |
+| `max_length` | int | `128` | Required unless `type: image_classification`. |
+| `device` | str (required) | `auto` | `auto` \| `cuda` \| `cpu`. |
+
+### `dataset`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `name` | str (required) | `wikitext` | HF dataset name. |
+| `subset` | str | `wikitext-2-raw-v1` | Dataset subset/config. |
+| `text_column` | str | `text` | Required unless `type: image_classification`. |
+| `max_samples` | int \| null | `null` | Cap samples for fast iteration; `null` = full. |
+| `streaming` | bool | `false` | Stream instead of loading into memory. |
+
+### `training`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `wake_epochs` | int (required) | `3` | Wake-phase epochs. |
+| `dream_epochs` | int (required) | `2` | Dream-phase epochs. |
+| `nightmare_epochs` | int (required) | `1` | Nightmare-phase epochs. |
+| `num_cycles` | int (required, ≥ 1) | `3` | Number of full cycles. |
+| `compression_rounds` | int (required) | `1` | Compress-phase rounds. |
+| `batch_size` | int (required, ≥ 1) | `8` | Batch size. |
+| `learning_rate` | float (required) | `5e-5` | Range `1e-10`–`1.0`. |
+| `nightmare_lr_multiplier` | float (required) | `2.0` | Range `0.1`–`100`. |
+| `weight_decay` | float | `0.01` | Optimizer weight decay. |
+| `warmup_steps` | int | `100` | LR warmup steps. |
+| `gradient_accumulation_steps` | int (required, ≥ 1) | `4` | Gradient accumulation. |
+| `max_grad_norm` | float (required) | `1.0` | Gradient clipping norm. |
+| `use_amp` | bool | `false` | Mixed-precision training (CUDA). |
+| `gradient_checkpointing` | bool | `false` | Trade compute for memory. |
+| `early_stopping` | bool | `false` | Stop when loss plateaus. |
+| `distributed` | bool | `false` | Enable native DDP (see [`distributed-training.yaml`](examples/distributed-training.yaml)). |
+| `save_every_phase` | bool | `true` | Checkpoint after each phase. |
+| `checkpoint_dir` | str | `checkpoints` | Checkpoint directory. |
+| `log_dir` | str | `logs` | Log directory. |
+
+### `distortion`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `dream_strength` | float (required) | `0.25` | Range `0.0`–`1.0`. |
+| `nightmare_strength` | float (required) | `0.8` | Range `0.0`–`1.0`. |
+| `dream_dp_epsilon` | float \| null | `null` | `null` = off; range `1e-6`–`1e6` when set. |
+| `dream_dp_delta` | float | `1e-5` | DP delta. |
+| `dream_dp_sensitivity` | float | `1.0` | DP sensitivity. |
+| `language` | str | `english` | `keyboard_typo` language. |
+| `keyboard_layout` | str \| null | `null` | Override layout; `null` = language default. |
+| `strength_schedule` | str | `uniform` | `uniform` \| `linear` \| `cosine` \| `step`. |
+| `schedule_across_cycles` | bool | `false` | Per-cycle strength scheduling. |
+| `strength_min` | float | `0.2` | Range `0.0`–`1.0`. |
+| `strength_max` | float | `0.9` | Range `0.0`–`1.0`. |
+| `text` | map | see `default.yaml` | Per-engine weights: `char_swap`, `char_insert`, `char_delete`, `keyboard_typo`, `word_shuffle`, `token_mask`. |
+| `semantic` | map | see `default.yaml` | `synonym_replace`, `negation_inject`, `topic_splice`. |
+| `adversarial` | map | see `default.yaml` | `contradiction`, `ambiguity`, `cross_domain`, `misleading_context`, `learned`, `learned_model`. |
+
+### `compression`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `pruning_ratio` | float (required) | `0.2` | Range `0.0`–`0.9999`. |
+| `pruning_method` | str | `magnitude` | `magnitude` \| `bottleneck`. |
+| `bottleneck_rank_ratio` | float (required) | `0.5` | Range `0.01`–`1.0`. |
+| `finetune_after_prune` | bool | `true` | Fine-tune after pruning. |
+| `finetune_epochs` | int | `1` | Fine-tuning epochs. |
+
+The optional `distillation` keys (`distillation`, `distillation_temperature`,
+`distillation_alpha`, `distillation_epochs`) are documented inline in
+[`default.yaml`](default.yaml).
+
+### `evaluation`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `metrics` | list[str] | `[recall, generalization, robustness, hallucination]` | Enabled metrics. |
+| `robustness_strengths` | list[float] | `[0.1 … 0.9]` | Strength sweep for the robustness AUC. |
+| `output_dir` | str | `results` | Where results are written. |
+| `output_format` | str | `json` | `json` \| `markdown`. |
+
+### `tracking`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `backend` | str | `none` | `none` \| `wandb` \| `tensorboard`. |
+| `project` | str | `nightmarenet` | Project name. |
+| `log_dir` | str | `logs/runs` | Run log directory. |
+
+### `notifications`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `webhooks` | list[map] | `[]` | Each entry needs `url` (str) and optional `events`. |
+
+`events` values must be one of `run_complete`, `regression_detected`, `alert`,
+`deploy`. See the [webhooks guide](../docs/features/webhooks.md).
+
+### `hpo`
+
+An optional map consumed by `nightmarenet optimize`. See
+[`examples/hpo-config.yaml`](examples/hpo-config.yaml).
+
+### `seed`
+
+Global integer random seed (default `42`).
+
+### `compliance`, `observability`, `adaption`
+
+Optional sections documented inline in [`default.yaml`](default.yaml). They are
+not part of the validated schema (unknown-key warnings are expected if used at
+the top level), but are merged through for the relevant subsystems.
+
+## Validation rules
+
+Validation happens in `validate_config()`
+([`../nightmarenet/utils/config.py`](../nightmarenet/utils/config.py)) after the
+merge:
+
+- **Required keys** must be present after merging with defaults. The `required`
+  fields above (`model.name`, `model.type`, `model.device`, the core `training.*`
+  fields, `distortion.dream_strength`/`nightmare_strength`,
+  `compression.pruning_ratio`/`bottleneck_rank_ratio`, `seed`) are supplied by
+  the defaults, so you only hit these errors if you override them with `null`.
+- **`model.max_length` and `dataset.text_column`** are required unless
+  `model.type: image_classification`.
+- **Types** are checked per field (an `int` is accepted where a `float` is
+  expected).
+- **Numeric ranges** are enforced for the fields marked with a range above.
+- **Webhooks** must be a list of mappings with a string `url` and, if present,
+  an `events` list of the allowed event strings.
+
+Any violation raises `ValueError` with a bulleted list of every problem.
+
+## Validate your config
+
+```bash
+python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/custom-distortion-chain.yaml')"
+```
+
+No output (beyond an informational log line) means the config is valid.
+
+## Examples
+
+Annotated, ready-to-run configs live in [`examples/`](examples/):
+
+| File | Demonstrates |
+|------|--------------|
+| [`custom-distortion-chain.yaml`](examples/custom-distortion-chain.yaml) | Chaining/weighting multiple distortion engines and scheduling nightmare strength. |
+| [`multi-dataset-training.yaml`](examples/multi-dataset-training.yaml) | Hardening a model across several datasets (one run per dataset). |
+| [`distributed-training.yaml`](examples/distributed-training.yaml) | Native DDP / multi-GPU setup. |
+| [`transfer-learning.yaml`](examples/transfer-learning.yaml) | Hardening a foundation backbone for robustness transfer. |
+| [`convergence-study.yaml`](examples/convergence-study.yaml) | Adaptive cycle termination / convergence. |
+| [`cross-arch-eval.yaml`](examples/cross-arch-eval.yaml) | Cross-architecture evaluation. |
+| [`dp-training.yaml`](examples/dp-training.yaml) | Differential-privacy Dream noise. |
+| [`gpt2-robustness.yaml`](examples/gpt2-robustness.yaml) | Causal-LM (GPT-2) robustness cycle. |
+| [`hpo-config.yaml`](examples/hpo-config.yaml) | Optuna hyperparameter search. |
+| [`mlflow-tracking.yaml`](examples/mlflow-tracking.yaml) | Experiment tracking. |
+
+## Related Documentation
+
+- [Getting Started](../docs/tutorials/getting-started.md) — install and run your first cycle.
+- [`default.yaml`](default.yaml) — the fully-commented base config.
+- [Webhook notifications guide](../docs/features/webhooks.md) — configuring the `notifications` section.

--- a/configs/examples/custom-distortion-chain.yaml
+++ b/configs/examples/custom-distortion-chain.yaml
@@ -1,0 +1,80 @@
+# Custom distortion chain
+# Tune the per-type distortion weights that make up the Dream and Nightmare
+# phases, and control how nightmare strength is scheduled within each epoch.
+#
+# Validate config:
+#   python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/custom-distortion-chain.yaml')"
+#
+# Preview a single distortion on ad-hoc text:
+#   nightmarenet distort --type nightmare --strength 0.7 --text "I love this movie"
+#
+# Run the full cycle with this config:
+#   nightmarenet train --config configs/examples/custom-distortion-chain.yaml
+
+model:
+  name: distilbert-base-uncased
+  type: seq_classification
+  num_labels: 2
+  max_length: 128
+  device: auto
+
+dataset:
+  name: glue
+  config: sst2            # extra dataset selector; passed through to the loader
+  text_column: sentence
+  label_column: label
+  max_samples: 500
+  streaming: false
+
+training:
+  wake_epochs: 1
+  dream_epochs: 1
+  nightmare_epochs: 1
+  compression_rounds: 1
+  num_cycles: 2
+  batch_size: 8
+  learning_rate: 2.0e-5
+
+distortion:
+  dream_strength: 0.25       # global intensity for the (mild) Dream phase
+  nightmare_strength: 0.8    # global intensity for the (aggressive) Nightmare phase
+
+  # Ramp nightmare strength within each epoch instead of holding it constant.
+  # uniform | linear | cosine | step
+  strength_schedule: cosine
+  strength_min: 0.3          # schedule floor (used by non-uniform schedules)
+  strength_max: 0.9          # schedule ceiling
+
+  language: english          # keyboard_typo language
+  keyboard_layout: null      # null = derive from language (english -> qwerty)
+
+  # Per-type weights = probability of applying each engine when it is sampled.
+  # This is the "chain": every enabled engine can stack on the same example.
+  text:
+    char_swap: 0.4
+    char_insert: 0.2
+    char_delete: 0.2
+    keyboard_typo: 0.3
+    word_shuffle: 0.1
+    token_mask: 0.2
+  semantic:
+    synonym_replace: 0.5
+    negation_inject: 0.2
+    topic_splice: 0.2
+  adversarial:
+    contradiction: 0.3
+    ambiguity: 0.2
+    cross_domain: 0.2
+    misleading_context: 0.2
+    learned: 0.0                              # 0 = disabled (no learned attack)
+    learned_model: distilbert-base-uncased    # fallback MLM if learned is enabled
+
+compression:
+  pruning_ratio: 0.2
+  pruning_method: magnitude
+
+evaluation:
+  metrics: [recall, robustness]
+  robustness_strengths: [0.1, 0.3, 0.5, 0.7, 0.9]
+
+seed: 42

--- a/configs/examples/distributed-training.yaml
+++ b/configs/examples/distributed-training.yaml
@@ -1,0 +1,58 @@
+# Distributed (multi-GPU) training
+# Enables NightmareNet's native DDP path. Each phase picks the right strategy:
+# Wake/Nightmare use DDP, Dream uses DataParallel, and Compress runs on a
+# single GPU. See docs/features/distributed-training.md for the full details.
+#
+# Validate config:
+#   python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/distributed-training.yaml')"
+#
+# Launch on all visible GPUs (DDP requires torchrun so RANK/WORLD_SIZE are set):
+#   torchrun --nproc_per_node=2 -m nightmarenet.cli train \
+#       --config configs/examples/distributed-training.yaml --distributed auto
+#
+# Or pin specific GPU IDs:
+#   torchrun --nproc_per_node=2 -m nightmarenet.cli train \
+#       --config configs/examples/distributed-training.yaml --distributed 0,1
+
+model:
+  name: distilbert-base-uncased
+  type: seq_classification
+  num_labels: 2
+  max_length: 128
+  device: auto             # "auto" lets each rank bind to its local GPU
+
+dataset:
+  name: glue
+  config: sst2
+  text_column: sentence
+  label_column: label
+  max_samples: 2000
+  streaming: false
+
+training:
+  wake_epochs: 1
+  dream_epochs: 1
+  nightmare_epochs: 1
+  compression_rounds: 1
+  num_cycles: 2
+  batch_size: 16                    # per-GPU batch size under DDP
+  learning_rate: 2.0e-5
+  distributed: true                 # turn on the distributed code path
+  use_amp: true                     # mixed precision — recommended on multi-GPU
+  gradient_checkpointing: false     # enable to trade compute for memory on large models
+  gradient_accumulation_steps: 2    # effective batch = batch_size * num_gpus * this
+  checkpoint_dir: checkpoints/distributed
+  log_dir: logs/distributed
+
+distortion:
+  dream_strength: 0.25
+  nightmare_strength: 0.8
+
+compression:
+  pruning_ratio: 0.2
+
+evaluation:
+  metrics: [recall, robustness]
+  robustness_strengths: [0.1, 0.3, 0.5, 0.7, 0.9]
+
+seed: 42

--- a/configs/examples/multi-dataset-training.yaml
+++ b/configs/examples/multi-dataset-training.yaml
@@ -1,0 +1,71 @@
+# Multi-dataset training
+# A training config takes ONE dataset block per run. To harden a model across
+# several datasets, run this config once per dataset (swapping the `dataset`
+# block), reusing the resulting checkpoint as the starting point for the next.
+# This file documents that workflow and is a valid, runnable single-dataset run.
+#
+# Validate config:
+#   python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/multi-dataset-training.yaml')"
+#
+# Run across datasets (each is a separate run; carry the checkpoint forward):
+#   nightmarenet train --config configs/examples/multi-dataset-training.yaml \
+#       --output ./runs/sst2
+#   # then point the next run's model.name at ./runs/sst2 and switch the
+#   # dataset block to ag_news / imdb, etc.
+
+model:
+  # For run 2+, set this to the previous run's output directory to continue
+  # hardening the same weights across datasets.
+  name: distilbert-base-uncased
+  type: seq_classification
+  num_labels: 2            # match the current dataset's label count
+  max_length: 128
+  device: auto
+
+# --- Active dataset for THIS run -------------------------------------------
+# Swap this block per run. Examples of other datasets are in the comments below.
+dataset:
+  name: glue
+  config: sst2             # GLUE task selector (extra key, passed to the loader)
+  text_column: sentence
+  label_column: label
+  max_samples: 500
+  streaming: false
+
+# --- Other datasets to cycle through (uncomment one per run) ---------------
+# dataset:
+#   name: ag_news
+#   text_column: text
+#   label_column: label
+#   max_samples: 500
+#
+# dataset:
+#   name: imdb
+#   text_column: text
+#   label_column: label
+#   max_samples: 500
+
+training:
+  wake_epochs: 1
+  dream_epochs: 1
+  nightmare_epochs: 1
+  compression_rounds: 1
+  num_cycles: 2
+  batch_size: 8
+  learning_rate: 2.0e-5
+  # Keep per-dataset runs in separate directories so checkpoints don't collide.
+  checkpoint_dir: checkpoints/multi_dataset
+  log_dir: logs/multi_dataset
+
+distortion:
+  dream_strength: 0.25
+  nightmare_strength: 0.8
+
+compression:
+  pruning_ratio: 0.2
+
+evaluation:
+  metrics: [recall, robustness]
+  robustness_strengths: [0.1, 0.3, 0.5, 0.7, 0.9]
+
+seed: 42

--- a/configs/examples/transfer-learning.yaml
+++ b/configs/examples/transfer-learning.yaml
@@ -1,0 +1,66 @@
+# Transfer learning
+# Robustness transfer reuses a hardened backbone instead of re-running the full
+# cycle for every task. This file is a valid *pipeline* config that first
+# hardens a foundation on SST-2; the header shows how to register it and then
+# fine-tune onto a downstream task via the transfer CLI.
+#
+# NOTE: the `nightmarenet transfer` step uses a separate, flat transfer schema
+# (see configs/transfer_ag_news.yaml), which is NOT validated by this pipeline
+# loader. This example intentionally stays a valid pipeline config.
+#
+# Validate config:
+#   python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/transfer-learning.yaml')"
+#
+# 1. Harden a foundation backbone with the full cycle:
+#   nightmarenet train --config configs/examples/transfer-learning.yaml \
+#       --output ./output/sst2-hardened
+#
+# 2. Register the hardened model as a reusable foundation backbone:
+#   nightmarenet foundation register --model ./output/sst2-hardened --name sst2-robust
+#
+# 3. Fine-tune the foundation onto a downstream task (freezing bottom layers
+#    to preserve transferred robustness). Uses the flat transfer config:
+#   nightmarenet transfer --foundation sst2-robust --config configs/transfer_ag_news.yaml
+
+model:
+  name: distilbert-base-uncased
+  type: seq_classification
+  num_labels: 2
+  max_length: 128
+  device: auto
+
+dataset:
+  name: glue
+  config: sst2
+  text_column: sentence
+  label_column: label
+  max_samples: 500
+  streaming: false
+
+training:
+  wake_epochs: 1
+  dream_epochs: 1
+  nightmare_epochs: 1
+  compression_rounds: 1
+  num_cycles: 3            # a few cycles so the backbone accumulates robustness
+  batch_size: 8
+  learning_rate: 2.0e-5
+  checkpoint_dir: checkpoints/transfer_foundation
+  log_dir: logs/transfer_foundation
+
+distortion:
+  dream_strength: 0.25
+  nightmare_strength: 0.8
+
+compression:
+  pruning_ratio: 0.2
+
+evaluation:
+  metrics: [recall, robustness]
+  robustness_strengths: [0.1, 0.3, 0.5, 0.7, 0.9]
+
+# The downstream fine-tune (step 3) is configured separately. For reference,
+# configs/transfer_ag_news.yaml sets: task_type, dataset, num_labels,
+# freeze_bottom_n (layers to freeze), unfreeze_after_epoch, and learning_rate.
+
+seed: 42

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -57,6 +57,8 @@ Key config blocks include:
 *   **dataset**: Controls dataset source (e.g., Hugging Face `wikitext` or custom files).
 *   **evaluation**: Dictates which metrics (`recall`, `generalization`, `robustness`, `hallucination`) are calculated.
 
+For the full schema (every top-level key), the defaults inheritance model, validation rules, and annotated example configs, see the [Configuration Guide](../../configs/README.md).
+
 ---
 
 ## 4. Running Your First Evaluation

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,12 +1,13 @@
 # Notebooks
 
-Three Colab-ready walkthroughs covering the full NightmareNet workflow. Each notebook is self-contained, installs `nightmarenet` from the local checkout (or PyPI as a fallback), detects CUDA automatically, and ends with a "Next steps" pointer to the following notebook.
+Colab-ready walkthroughs covering the full NightmareNet workflow. The three numbered notebooks are self-contained, install `nightmarenet` from the local checkout (or PyPI as a fallback), detect CUDA automatically, and end with a "Next steps" pointer to the following notebook; `demo.ipynb` is the original end-to-end demo kept for reference.
 
 | File | Purpose | Runtime | GPU |
 |------|---------|---------|-----|
 | [`01_quickstart.ipynb`](01_quickstart.ipynb) | Install + first distortion + 1-epoch Wake-only run on 100-row SST-2 + loss plot | ~3-5 min CPU, ~60 s T4 | Optional |
 | [`02_benchmark_reproduction.ipynb`](02_benchmark_reproduction.ipynb) | Reproduce the SST-2 README table: baseline vs full 4-phase cycle, side-by-side comparison + bar chart | ~15-25 min CPU, ~3-5 min T4 | Strongly recommended |
 | [`03_custom_distortions.ipynb`](03_custom_distortions.ipynb) | Plugin authoring: write a homoglyph `DistortionFn`, register it via decorator, run a robustness sweep + characteristic curve | ~1-2 min | Not required |
+| [`demo.ipynb`](demo.ipynb) | Original end-to-end demonstration, kept for backward compatibility (see Legacy below) | ~10-20 min CPU | Optional |
 
 ## Local run
 


### PR DESCRIPTION
Closes #669

## Summary
Documents the configuration system and adds four new example configs.

- **`configs/README.md`** — the config schema (every top-level key from `configs/default.yaml`), the defaults inheritance/override model (no `extends:` — every config deep-merges over `DEFAULT_CONFIG`), and the validation rules enforced by `nightmarenet/utils/config.py` (required keys, type checks, numeric ranges, webhook validation).
- **`notebooks/README.md`** — updated so the table lists all four notebooks (added the `demo.ipynb` row).
- **Four new `configs/examples/`** configs, each with a validate one-liner header, CLI usage, and inline comments:

| File | Demonstrates |
|------|--------------|
| `custom-distortion-chain.yaml` | Chaining/weighting distortion engines + nightmare strength schedule |
| `multi-dataset-training.yaml` | Hardening across datasets (one run per dataset) |
| `distributed-training.yaml` | Native DDP / multi-GPU setup |
| `transfer-learning.yaml` | Hardening a foundation backbone for robustness transfer |

Cross-links added from `README.md` (new "Configuration & Notebooks" section) and `docs/tutorials/getting-started.md`.

## Acceptance criteria
- [x] `notebooks/README.md` with a table of all 4 notebooks
- [x] `configs/README.md` with config schema documentation (all fields from `configs/default.yaml`)
- [x] 4 new example configs in `configs/examples/`
- [x] Each new config has inline comments explaining non-obvious fields
- [x] All example configs pass validation: `python -c "from nightmarenet.utils.config import load_config; load_config('configs/examples/X.yaml')"`

## Verification
- Ran `load_config()` on all four new configs — each **passes with no warnings**.
- Confirmed every top-level key in `configs/default.yaml` is documented in `configs/README.md`.
- All internal links resolve. (The distributed/compression/transfer/HPO feature guides are not on `main` yet, so the config guide links to the example configs and `default.yaml` instead; only the existing `webhooks.md` guide is linked.)
- YAML parse check passes on all four configs.

## Notes
Documentation/config only — no code changes. Includes AI-assisted authoring; all schema fields and validation rules were verified against `nightmarenet/utils/config.py` and every example was validated with the real loader.